### PR TITLE
Add explicit permissions to CI and Release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - 'v*'
+
+permissions:
+  contents: write
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Code scanning flagged workflows that do not explicitly define `GITHUB_TOKEN` permissions, so the workflows should scope token access instead of relying on defaults.

### Description
- Added a workflow-level `permissions` block to `.github/workflows/ci.yml` with `contents: read` to limit token scope for CI runs.
- Added a workflow-level `permissions` block to `.github/workflows/release.yml` with `contents: write` to allow release actions that need write access.
- Updated the two workflow YAML files in the repository to include these explicit permissions.

### Testing
- Ran `git diff --check` to ensure no whitespace or patch issues, which returned cleanly.
- Ran `yamllint` when available against the modified workflow files, which produced no blocking errors.
- Verified the workflow files include the new `permissions` blocks by inspecting the updated files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adeff7c55c832e84b53225210adb91)