### PR TITLE
Feature/phase3 core abstractions

### DIFF
--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -1,0 +1,104 @@
+use std::fmt;
+use std::sync::Arc;
+
+use crate::core::source::SourceRef;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentKind {
+    Bytes,
+    Rom,
+    Disc,
+    Text,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentId(pub Arc<str>);
+
+impl ContentId {
+    pub fn new(value: impl Into<Arc<str>>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl fmt::Display for ContentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Content {
+    Bytes(BytesContent),
+    Rom(RomContent),
+    Disc(DiscContent),
+    Text(TextContent),
+}
+
+impl Content {
+    pub fn kind(&self) -> ContentKind {
+        match self {
+            Self::Bytes(_) => ContentKind::Bytes,
+            Self::Rom(_) => ContentKind::Rom,
+            Self::Disc(_) => ContentKind::Disc,
+            Self::Text(_) => ContentKind::Text,
+        }
+    }
+
+    pub fn id(&self) -> &ContentId {
+        match self {
+            Self::Bytes(v) => &v.id,
+            Self::Rom(v) => &v.id,
+            Self::Disc(v) => &v.id,
+            Self::Text(v) => &v.id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BytesContent {
+    pub id: ContentId,
+    pub source: SourceRef,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RomContent {
+    pub id: ContentId,
+    pub source: SourceRef,
+    pub file_name: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscContent {
+    pub id: ContentId,
+    pub source: SourceRef,
+    pub title: String,
+    pub disc_number: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextContent {
+    pub id: ContentId,
+    pub source: SourceRef,
+    pub size: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::source::SourceRef;
+
+    #[test]
+    fn returns_content_kind() {
+        let content = Content::Rom(RomContent {
+            id: ContentId::new("game"),
+            source: SourceRef::new("src:game"),
+            file_name: "game.sfc".to_string(),
+            size: 123,
+        });
+
+        assert_eq!(content.kind(), ContentKind::Rom);
+        assert_eq!(content.id().to_string(), "game");
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod content;
 pub mod cue;
 pub mod disc;
 pub mod game_image;
@@ -8,5 +9,7 @@ pub mod platform;
 pub mod reader;
 pub mod reader_factory;
 pub mod reader_registry;
+pub mod source;
 pub mod track;
+pub mod vfs;
 pub mod virtual_file;

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SourceRef(pub Arc<str>);
+
+impl SourceRef {
+    pub fn new(value: impl Into<Arc<str>>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl fmt::Display for SourceRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceObject {
+    pub source: SourceRef,
+    pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_source_ref() {
+        let source = SourceRef::new("zip:/roms/snes.zip#game.sfc");
+        assert_eq!(source.to_string(), "zip:/roms/snes.zip#game.sfc");
+    }
+}

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -1,0 +1,77 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VfsNode {
+    Directory(VfsDirectory),
+    File(VfsFile),
+}
+
+impl VfsNode {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Directory(dir) => &dir.name,
+            Self::File(file) => &file.name,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VfsDirectory {
+    pub name: String,
+    pub children: Vec<VfsNode>,
+}
+
+impl VfsDirectory {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            children: Vec::new(),
+        }
+    }
+
+    pub fn with_children(name: impl Into<String>, children: Vec<VfsNode>) -> Self {
+        Self {
+            name: name.into(),
+            children,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VfsFile {
+    pub name: String,
+    pub size: u64,
+}
+
+impl VfsFile {
+    pub fn new(name: impl Into<String>, size: u64) -> Self {
+        Self {
+            name: name.into(),
+            size,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_simple_tree() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "snes",
+                vec![VfsNode::File(VfsFile::new("game.sfc", 1024))],
+            ))],
+        );
+
+        assert_eq!(root.children.len(), 1);
+
+        match &root.children[0] {
+            VfsNode::Directory(dir) => {
+                assert_eq!(dir.name, "snes");
+                assert_eq!(dir.children.len(), 1);
+            }
+            _ => panic!("expected directory"),
+        }
+    }
+}

--- a/src/input/decode.rs
+++ b/src/input/decode.rs
@@ -1,0 +1,13 @@
+use crate::core::content::Content;
+use crate::core::source::SourceObject;
+use crate::input::identify::InputIdentity;
+
+pub trait InputDecoder: Send + Sync {
+    fn supports(&self, identity: &InputIdentity) -> bool;
+
+    fn decode(
+        &self,
+        object: &SourceObject,
+        identity: &InputIdentity,
+    ) -> Result<Vec<Content>, std::io::Error>;
+}

--- a/src/input/identify.rs
+++ b/src/input/identify.rs
@@ -1,0 +1,15 @@
+use crate::core::source::SourceObject;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputIdentity {
+    File,
+    Directory,
+    Archive,
+    DiscImage,
+    Text,
+    Unknown,
+}
+
+pub trait InputIdentifier: Send + Sync {
+    fn identify(&self, object: &SourceObject) -> Result<InputIdentity, std::io::Error>;
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,0 +1,3 @@
+pub mod decode;
+pub mod identify;
+pub mod source;

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -1,0 +1,5 @@
+use crate::core::source::SourceObject;
+
+pub trait InputSource: Send + Sync {
+    fn enumerate(&self) -> Result<Vec<SourceObject>, std::io::Error>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ use crate::core::platform::Platform;
 pub mod core;
 pub mod engine;
 pub mod error;
+pub mod input;
 pub mod inputs;
+pub mod output;
 pub mod readers;
 
 pub use error::RetromountError;

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -1,0 +1,12 @@
+use crate::core::content::Content;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodedFile {
+    pub name: String,
+    pub size: u64,
+}
+
+pub trait OutputEncoder: Send + Sync {
+    fn can_encode(&self, content: &Content) -> bool;
+    fn encode(&self, content: &Content) -> Result<EncodedFile, std::io::Error>;
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,2 @@
+pub mod encode;
+pub mod present;

--- a/src/output/present.rs
+++ b/src/output/present.rs
@@ -1,0 +1,6 @@
+use crate::core::content::Content;
+use crate::core::vfs::VfsDirectory;
+
+pub trait OutputPresenter: Send + Sync {
+    fn present(&self, content: &[Content]) -> VfsDirectory;
+}


### PR DESCRIPTION
## 🧱 Phase 3A — Core abstractions and architecture skeleton

This PR introduces the foundational building blocks for **Phase 3**, establishing the new modular pipeline architecture for Retromount.

> ⚠️ This is a **non-functional refactor groundwork PR** — it adds new types and traits but does not change existing behaviour.

---

## 🎯 Goals of this PR

- Define a **normalized internal content model**
- Introduce **stable source identity abstractions**
- Establish a **virtual filesystem (VFS) representation**
- Define **input/output boundaries via traits**
- Lay the groundwork for the Phase 3 pipeline without disrupting Phase 2

---

## 🏗️ New architecture (target)

The long-term pipeline being introduced is:

InputSource -> InputIdentifier -> InputDecoder -> Core  
→ OutputPresenter -> OutputEncoder -> VFS/FUSE

This PR introduces the **types and traits only** — no runtime wiring yet.

---

## 📦 What’s included

### Core abstractions

- `core/content.rs`
  - Introduces normalized content model:
    - `Content` enum with:
      - `Bytes`
      - `Rom`
      - `Disc`
      - `Text`
  - Adds `ContentId` and `ContentKind`

- `core/source.rs`
  - Adds `SourceRef` for stable, opaque source identity
  - Adds `SourceObject` as a unit of discovery

- `core/vfs.rs`
  - Introduces minimal virtual filesystem model:
    - `VfsDirectory`
    - `VfsFile`
    - `VfsNode`

---

### Input layer (traits only)

- `input/source.rs`
  - `InputSource` — enumerates candidate objects

- `input/identify.rs`
  - `InputIdentifier` — classifies object structure
  - `InputIdentity` enum (File, Directory, Archive, DiscImage, etc.)

- `input/decode.rs`
  - `InputDecoder` — converts identified inputs into normalized `Content`

---

### Output layer (traits only)

- `output/present.rs`
  - `OutputPresenter` — maps content → virtual tree

- `output/encode.rs`
  - `OutputEncoder` — serializes content into output representations
  - `EncodedFile` abstraction

---

### Module wiring

- New `input` and `output` modules added
- `core` module extended with new abstractions
- All additions are **non-breaking and coexist with Phase 2 code**

---

## ✅ Behavioural impact

- No changes to existing functionality
- No changes to CLI or loader behaviour
- No migration of existing input handlers yet
- All existing tests should continue to pass

---

## 🧪 Tests

- Unit tests added for:
  - content model (`Content`, `ContentKind`)
  - source identity (`SourceRef`)
  - VFS tree construction

---

## 🚫 Explicitly out of scope

This PR intentionally does **not** include:

- FUSE integration
- ZIP / CUE / CHD migration to new abstractions
- Presenter or encoder implementations
- Changes to `Loader` or `VirtualFile`
- End-to-end pipeline wiring

---

## 🔜 Follow-up work

Next steps in Phase 3:

- **Phase 3B**
  - Generic `OutputPresenter`
  - Basic `OutputEncoder`
  - First end-to-end flow using new abstractions

- **Phase 3C**
  - ZIP/native vertical slice using new pipeline

- **Phase 3D**
  - FUSE-backed VFS

- **Phase 3E**
  - Richer disc/media handling

---

## 💭 Notes

This PR is intentionally small and foundational. It creates clear extension points so future work can:

- plug in new input types (ZIP, directories, remote sources)
- support multiple output formats (MiSTer, Batocera, etc.)
- expose content via a virtual filesystem cleanly