### PR TITLE
Feature/phase3 generic output

### DIFF
--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -1,0 +1,107 @@
+use crate::core::content::Content;
+use crate::output::encode::{EncodedFile, OutputEncoder};
+
+#[derive(Debug, Default)]
+pub struct BasicEncoder;
+
+impl BasicEncoder {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn file_name_for(&self, content: &Content) -> String {
+        match content {
+            Content::Bytes(bytes) => format!("{}.bin", bytes.id),
+            Content::Rom(rom) => rom.file_name.clone(),
+            Content::Disc(disc) => format!("{} (Disc {}).cue", disc.title, disc.disc_number),
+            Content::Text(text) => format!("{}.txt", text.id),
+        }
+    }
+
+    fn size_for(&self, content: &Content) -> u64 {
+        match content {
+            Content::Bytes(bytes) => bytes.size,
+            Content::Rom(rom) => rom.size,
+            Content::Disc(_) => 0,
+            Content::Text(text) => text.size,
+        }
+    }
+}
+
+impl OutputEncoder for BasicEncoder {
+    fn can_encode(&self, _content: &Content) -> bool {
+        true
+    }
+
+    fn encode(&self, content: &Content) -> Result<EncodedFile, std::io::Error> {
+        Ok(EncodedFile {
+            name: self.file_name_for(content),
+            size: self.size_for(content),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::content::{BytesContent, Content, ContentId, DiscContent, RomContent, TextContent};
+    use crate::core::source::SourceRef;
+
+    #[test]
+    fn encodes_bytes_content() {
+        let encoder = BasicEncoder::new();
+        let content = Content::Bytes(BytesContent {
+            id: ContentId::new("bios"),
+            source: SourceRef::new("file:/roms/bios"),
+            size: 512,
+        });
+
+        let encoded = encoder.encode(&content).unwrap();
+        assert_eq!(encoded.name, "bios.bin");
+        assert_eq!(encoded.size, 512);
+    }
+
+    #[test]
+    fn encodes_rom_content() {
+        let encoder = BasicEncoder::new();
+        let content = Content::Rom(RomContent {
+            id: ContentId::new("mario-world"),
+            source: SourceRef::new("zip:/roms/snes.zip#smw.sfc"),
+            file_name: "Super Mario World.sfc".to_string(),
+            size: 4096,
+        });
+
+        let encoded = encoder.encode(&content).unwrap();
+        assert_eq!(encoded.name, "Super Mario World.sfc");
+        assert_eq!(encoded.size, 4096);
+    }
+
+    #[test]
+    fn encodes_disc_content() {
+        let encoder = BasicEncoder::new();
+        let content = Content::Disc(DiscContent {
+            id: ContentId::new("ff7-disc1"),
+            source: SourceRef::new("cue:/roms/ff7.cue"),
+            title: "Final Fantasy VII".to_string(),
+            disc_number: 1,
+        });
+
+        let encoded = encoder.encode(&content).unwrap();
+        assert_eq!(encoded.name, "Final Fantasy VII (Disc 1).cue");
+        assert_eq!(encoded.size, 0);
+    }
+
+    #[test]
+    fn encodes_text_content() {
+        let encoder = BasicEncoder::new();
+        let content = Content::Text(TextContent {
+            id: ContentId::new("readme"),
+            source: SourceRef::new("file:/roms/readme"),
+            size: 128,
+        });
+
+        let encoded = encoder.encode(&content).unwrap();
+        assert_eq!(encoded.name, "readme.txt");
+        assert_eq!(encoded.size, 128);
+    }
+}

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -44,7 +44,9 @@ impl OutputEncoder for BasicEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::content::{BytesContent, Content, ContentId, DiscContent, RomContent, TextContent};
+    use crate::core::content::{
+        BytesContent, Content, ContentId, DiscContent, RomContent, TextContent,
+    };
     use crate::core::source::SourceRef;
 
     #[test]

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,0 +1,93 @@
+use crate::core::content::Content;
+use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
+use crate::output::encode::OutputEncoder;
+use crate::output::present::OutputPresenter;
+
+pub struct GenericPresenter<E>
+where
+    E: OutputEncoder,
+{
+    encoder: E,
+}
+
+impl<E> GenericPresenter<E>
+where
+    E: OutputEncoder,
+{
+    pub fn new(encoder: E) -> Self {
+        Self { encoder }
+    }
+}
+
+impl<E> OutputPresenter for GenericPresenter<E>
+where
+    E: OutputEncoder + Send + Sync,
+{
+    fn present(&self, content: &[Content]) -> VfsDirectory {
+        let children = content
+            .iter()
+            .filter(|item| self.encoder.can_encode(item))
+            .filter_map(|item| {
+                self.encoder.encode(item).ok().map(|encoded| {
+                    VfsNode::File(VfsFile::new(encoded.name, encoded.size))
+                })
+            })
+            .collect();
+
+        VfsDirectory::with_children("", children)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::content::{BytesContent, Content, ContentId, DiscContent, RomContent, TextContent};
+    use crate::core::source::SourceRef;
+    use crate::output::basic_encoder::BasicEncoder;
+
+    #[test]
+    fn presents_mixed_content_as_root_files() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![
+            Content::Bytes(BytesContent {
+                id: ContentId::new("bios"),
+                source: SourceRef::new("file:/roms/bios"),
+                size: 512,
+            }),
+            Content::Rom(RomContent {
+                id: ContentId::new("sonic"),
+                source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
+                file_name: "Sonic the Hedgehog.bin".to_string(),
+                size: 1024,
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("mgs-disc1"),
+                source: SourceRef::new("cue:/roms/mgs.cue"),
+                title: "Metal Gear Solid".to_string(),
+                disc_number: 1,
+            }),
+            Content::Text(TextContent {
+                id: ContentId::new("manifest"),
+                source: SourceRef::new("file:/roms/manifest"),
+                size: 64,
+            }),
+        ];
+
+        let root = presenter.present(&content);
+
+        assert_eq!(root.name, "");
+        assert_eq!(root.children.len(), 4);
+
+        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "bios.bin",
+                "Sonic the Hedgehog.bin",
+                "Metal Gear Solid (Disc 1).cue",
+                "manifest.txt",
+            ]
+        );
+    }
+}

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -28,9 +28,10 @@ where
             .iter()
             .filter(|item| self.encoder.can_encode(item))
             .filter_map(|item| {
-                self.encoder.encode(item).ok().map(|encoded| {
-                    VfsNode::File(VfsFile::new(encoded.name, encoded.size))
-                })
+                self.encoder
+                    .encode(item)
+                    .ok()
+                    .map(|encoded| VfsNode::File(VfsFile::new(encoded.name, encoded.size)))
             })
             .collect();
 
@@ -41,7 +42,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::content::{BytesContent, Content, ContentId, DiscContent, RomContent, TextContent};
+    use crate::core::content::{
+        BytesContent, Content, ContentId, DiscContent, RomContent, TextContent,
+    };
     use crate::core::source::SourceRef;
     use crate::output::basic_encoder::BasicEncoder;
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,2 +1,4 @@
+pub mod basic_encoder;
 pub mod encode;
+pub mod generic_presenter;
 pub mod present;


### PR DESCRIPTION
## 🧩 Phase 3B — Generic presenter and basic encoder

This PR builds on Phase 3A by introducing the first **functional slice** of the new architecture:

`Content -> OutputEncoder -> OutputPresenter -> VFS`

It proves that normalized content can be transformed into a virtual filesystem structure.

---

## 🎯 Goals of this PR

- Introduce a minimal **OutputEncoder implementation**
- Introduce a minimal **OutputPresenter implementation**
- Validate the Phase 3 pipeline by producing a VFS tree from `Content`
- Keep scope deliberately small and independent from existing Phase 2 logic

---

## 📦 What’s included

### Basic encoder

- `output/basic_encoder.rs`
  - Implements `OutputEncoder`
  - Maps `Content` → `EncodedFile`
  - Provides simple naming rules:
    - `Bytes` → `<id>.bin`
    - `Rom` → original filename
    - `Disc` → `<title> (Disc N).cue`
    - `Text` → `<id>.txt`
  - Derives file size from content metadata (no real data access yet)

---

### Generic presenter

- `output/generic_presenter.rs`
  - Implements `OutputPresenter`
  - Projects content into a flat VFS layout:
    - all files at root (`/`)
    - one file per `Content` item
  - Uses `OutputEncoder` to derive file metadata

---

### Module updates

- `output/mod.rs`
  - Registers new modules:
    - `basic_encoder`
    - `generic_presenter`

---

## ✅ Behavioural impact

- No changes to existing Phase 2 functionality
- No changes to CLI or loader
- No integration with input pipeline yet
- No FUSE integration

This is an **isolated Phase 3 capability addition**

---

## 🧪 Tests

- Unit tests for:
  - encoding each `Content` variant
  - presenting mixed content into a VFS tree
- Validates naming and layout behaviour

---

## 🚫 Explicitly out of scope

- Real byte streaming / file contents
- Integration with `InputSource` / `Loader`
- ZIP, directory, or CUE migration
- Multi-level directory presentation
- FUSE mount implementation

---

## 🔜 Follow-up work

Next steps in Phase 3:

- **Phase 3C**
  - Connect existing inputs (ZIP, directory) to new pipeline
  - Produce `Content` from real sources

- **Phase 3D**
  - Expose VFS via FUSE

- **Phase 3E**
  - Expand content model for richer disc/media handling

---

## 💭 Notes

This PR is the first proof that the new architecture can:

- normalize content
- encode it into a target representation
- project it into a virtual filesystem

It intentionally keeps the presentation model simple (flat root) to validate the pipeline before introducing complexity.