### PR TITLE
Feature/phase3 zip input

### DIFF
--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -54,4 +54,40 @@ mod tests {
         let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["blob.dat.bin", "mario.sfc", "readme.txt"]);
     }
+
+    #[test]
+    fn runs_end_to_end_zip_pipeline() {
+        use std::fs::File;
+        use std::io::Write;
+
+        use crate::input::zip_source::ZipInputSource;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("library.zip");
+
+        let file = File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+
+        zip.start_file("roms/sonic.bin", options).unwrap();
+        zip.write_all(b"rom").unwrap();
+
+        zip.start_file("docs/readme.txt", options).unwrap();
+        zip.write_all(b"hello").unwrap();
+
+        zip.start_file("misc/blob.dat", options).unwrap();
+        zip.write_all(b"xyz").unwrap();
+
+        zip.finish().unwrap();
+
+        let source = ZipInputSource::new(&zip_path);
+        let identifier = BasicInputIdentifier::new();
+        let decoder = BasicInputDecoder::new();
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let root = run_pipeline(&source, &identifier, &decoder, &presenter).unwrap();
+
+        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["blob.dat.bin", "readme.txt", "sonic.bin"]);
+    }
 }

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -34,42 +34,41 @@ impl InputDecoder for BasicInputDecoder {
         object: &SourceObject,
         identity: &InputIdentity,
     ) -> Result<Vec<Content>, io::Error> {
-        let path = Path::new(object.source.0.as_ref());
-        let metadata = fs::metadata(path)?;
         let id = ContentId::new(object.name.clone());
+        let size = content_size_for(object)?;
 
         let content = match identity {
             InputIdentity::Text => Content::Text(TextContent {
-                id: ContentId::new(file_stem_or_name(path, &object.name)),
+                id: ContentId::new(file_stem_or_name_from_object(object)),
                 source: object.source.clone(),
-                size: metadata.len(),
+                size,
             }),
             InputIdentity::DiscImage => Content::Disc(DiscContent {
                 id,
                 source: object.source.clone(),
-                title: file_stem_or_name(path, &object.name),
+                title: file_stem_or_name_from_object(object),
                 disc_number: 1,
             }),
             InputIdentity::File => {
-                if looks_like_rom(path) {
+                if looks_like_rom_name(&object.name) {
                     Content::Rom(RomContent {
                         id,
                         source: object.source.clone(),
                         file_name: object.name.clone(),
-                        size: metadata.len(),
+                        size,
                     })
                 } else {
                     Content::Bytes(BytesContent {
                         id,
                         source: object.source.clone(),
-                        size: metadata.len(),
+                        size,
                     })
                 }
             }
             InputIdentity::Unknown => Content::Bytes(BytesContent {
                 id,
                 source: object.source.clone(),
-                size: metadata.len(),
+                size,
             }),
             InputIdentity::Directory | InputIdentity::Archive => {
                 return Ok(Vec::new());
@@ -80,9 +79,22 @@ impl InputDecoder for BasicInputDecoder {
     }
 }
 
-fn looks_like_rom(path: &Path) -> bool {
+fn content_size_for(object: &SourceObject) -> Result<u64, io::Error> {
+    if is_zip_source(object) {
+        return Ok(0);
+    }
+
+    let path = Path::new(object.source.0.as_ref());
+    Ok(fs::metadata(path)?.len())
+}
+
+fn is_zip_source(object: &SourceObject) -> bool {
+    object.source.0.starts_with("zip:")
+}
+
+fn looks_like_rom_name(name: &str) -> bool {
     matches!(
-        path.extension().and_then(|ext| ext.to_str()),
+        Path::new(name).extension().and_then(|ext| ext.to_str()),
         Some(ext)
             if ext.eq_ignore_ascii_case("rom")
                 || ext.eq_ignore_ascii_case("bin")
@@ -96,10 +108,11 @@ fn looks_like_rom(path: &Path) -> bool {
     )
 }
 
-fn file_stem_or_name(path: &Path, fallback: &str) -> String {
-    path.file_stem()
+fn file_stem_or_name_from_object(object: &SourceObject) -> String {
+    Path::new(&object.name)
+        .file_stem()
         .and_then(|stem| stem.to_str())
-        .unwrap_or(fallback)
+        .unwrap_or(&object.name)
         .to_string()
 }
 
@@ -137,6 +150,19 @@ mod tests {
         let object = SourceObject {
             source: SourceRef::new(path.to_string_lossy().into_owned()),
             name: "game.sfc".to_string(),
+        };
+
+        let content = decoder.decode(&object, &InputIdentity::File).unwrap();
+        assert_eq!(content.len(), 1);
+        assert!(matches!(content[0], Content::Rom(_)));
+    }
+
+    #[test]
+    fn decodes_zip_source_without_filesystem_metadata() {
+        let decoder = BasicInputDecoder::new();
+        let object = SourceObject {
+            source: SourceRef::new("zip:/tmp/test.zip#roms/sonic.bin"),
+            name: "sonic.bin".to_string(),
         };
 
         let content = decoder.decode(&object, &InputIdentity::File).unwrap();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,3 +4,4 @@ pub mod decode;
 pub mod directory_source;
 pub mod identify;
 pub mod source;
+pub mod zip_source;

--- a/src/input/zip_source.rs
+++ b/src/input/zip_source.rs
@@ -1,0 +1,104 @@
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::core::source::{SourceObject, SourceRef};
+use crate::input::source::InputSource;
+
+#[derive(Debug, Clone)]
+pub struct ZipInputSource {
+    archive_path: PathBuf,
+}
+
+impl ZipInputSource {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            archive_path: path.into(),
+        }
+    }
+
+    pub fn archive_path(&self) -> &Path {
+        &self.archive_path
+    }
+}
+
+impl InputSource for ZipInputSource {
+    fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
+        let file = File::open(&self.archive_path)?;
+        let mut archive =
+            zip::ZipArchive::new(file).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+        let mut objects = Vec::new();
+
+        for i in 0..archive.len() {
+            let entry = archive
+                .by_index(i)
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+
+            if entry.is_dir() {
+                continue;
+            }
+
+            let entry_name = entry.name().to_string();
+            let display_name = Path::new(&entry_name)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(&entry_name)
+                .to_string();
+
+            let source = SourceRef::new(format!(
+                "zip:{}#{}",
+                self.archive_path.to_string_lossy(),
+                entry_name
+            ));
+
+            objects.push(SourceObject {
+                source,
+                name: display_name,
+            });
+        }
+
+        objects.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(objects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    fn create_test_zip(path: &Path) {
+        let file = File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+
+        let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+
+        zip.start_file("roms/sonic.bin", options).unwrap();
+        zip.write_all(b"romdata").unwrap();
+
+        zip.start_file("docs/readme.txt", options).unwrap();
+        zip.write_all(b"hello").unwrap();
+
+        zip.add_directory("empty_dir/", options).unwrap();
+
+        zip.finish().unwrap();
+    }
+
+    #[test]
+    fn enumerates_regular_files_in_zip_archive() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("test.zip");
+        create_test_zip(&zip_path);
+
+        let source = ZipInputSource::new(&zip_path);
+        let objects = source.enumerate().unwrap();
+
+        let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
+        assert_eq!(names, vec!["readme.txt", "sonic.bin"]);
+
+        assert!(objects[0].source.0.starts_with("zip:"));
+        assert!(objects[1].source.0.starts_with("zip:"));
+    }
+}

--- a/src/input/zip_source.rs
+++ b/src/input/zip_source.rs
@@ -25,8 +25,8 @@ impl ZipInputSource {
 impl InputSource for ZipInputSource {
     fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
         let file = File::open(&self.archive_path)?;
-        let mut archive =
-            zip::ZipArchive::new(file).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let mut archive = zip::ZipArchive::new(file)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
         let mut objects = Vec::new();
 


### PR DESCRIPTION
## 📦 Phase 3D — ZIP input vertical slice

This PR extends the Phase 3 pipeline to support **ZIP-backed input sources**, proving that the new architecture can operate on both filesystem and archive inputs using the same abstractions.

With this change, the Phase 3 flow now supports:

InputSource → InputIdentifier → InputDecoder → Content  
→ OutputEncoder → OutputPresenter → VFS

for both:

- real directories
- ZIP archives

---

## 🎯 Goals of this PR

- Introduce a ZIP-backed `InputSource`
- Validate that archive contents can flow through the existing Phase 3 pipeline
- Keep ZIP support parallel to the existing Phase 2 ZIP implementation
- Avoid premature complexity such as streaming or archive-specific decoding

---

## 📦 What’s included

### ZIP input source

- `input/zip_source.rs`
  - Implements `InputSource`
  - Opens a ZIP archive and enumerates file entries
  - Skips directory entries
  - Produces `SourceObject`s with ZIP-specific `SourceRef`s in the form:

    `zip:/path/to/archive.zip#entry/path/file.ext`

  - Preserves enough identity for future lazy reading / caching work

---

### Decoder compatibility for non-filesystem sources

- `input/basic_decoder.rs`
  - Updated so non-filesystem sources (currently `zip:`) do not rely on `fs::metadata(...)`
  - ZIP-backed content currently uses placeholder size metadata (`0`) to keep the pipeline moving
  - Existing directory-backed decoding behaviour remains unchanged

---

### End-to-end ZIP pipeline coverage

- `engine/pipeline.rs`
  - Adds an end-to-end test that:
    - creates a temporary ZIP archive
    - enumerates its contents through `ZipInputSource`
    - runs the full Phase 3 pipeline
    - asserts the resulting VFS structure

---

## ✅ Behavioural impact

- No changes to existing Phase 2 ZIP handling
- No changes to loader, CLI, or FUSE behaviour
- New ZIP support exists **in parallel** to the current implementation

---

## 🧪 Tests

- Unit test for ZIP enumeration
- Decoder test for ZIP-backed source handling
- End-to-end pipeline test for ZIP archives

This validates that the same pipeline now works for both directory and archive inputs.

---

## 🚫 Explicitly out of scope

- Real byte streaming from ZIP entries
- Replacing existing ZIP runtime behaviour
- Nested archive handling
- Archive metadata enrichment
- FUSE integration
- Performance optimisation / caching

---

## 🔜 Follow-up work

Potential next steps in Phase 3:

- introduce archive-aware lazy content reading
- connect more existing input types to the new pipeline
- enrich content modelling for disc/image formats
- expose the Phase 3 VFS through FUSE

---

## 💭 Notes

This PR is an important architectural milestone because it demonstrates that Phase 3 input abstractions are general enough to support multiple backing source types without changing the rest of the pipeline.

The implementation is intentionally minimal:
- enumerate archive members
- classify them
- normalize them
- present them through the same VFS path as directory-backed content

That gives us confidence to continue migrating input types incrementally.