### PR TITLE
Feature/phase3 preview

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,2 +1,3 @@
 pub mod loader;
 pub mod pipeline;
+pub mod preview;

--- a/src/engine/preview.rs
+++ b/src/engine/preview.rs
@@ -1,0 +1,120 @@
+use std::io::{self, Write};
+use std::path::Path;
+
+use crate::core::vfs::{VfsDirectory, VfsNode};
+use crate::error::RetromountError;
+use crate::input::basic_decoder::BasicInputDecoder;
+use crate::input::basic_identifier::BasicInputIdentifier;
+use crate::input::directory_source::DirectoryInputSource;
+use crate::input::source::InputSource;
+use crate::input::zip_source::ZipInputSource;
+use crate::output::basic_encoder::BasicEncoder;
+use crate::output::generic_presenter::GenericPresenter;
+
+use super::pipeline::run_pipeline;
+
+pub fn run_phase3_preview(path: &Path) -> Result<(), RetromountError> {
+    let source = build_input_source(path)?;
+
+    let identifier = BasicInputIdentifier::new();
+    let decoder = BasicInputDecoder::new();
+    let presenter = GenericPresenter::new(BasicEncoder::new());
+
+    let root = run_pipeline(source.as_ref(), &identifier, &decoder, &presenter)?;
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    write_vfs_tree(&mut handle, &root)?;
+
+    Ok(())
+}
+
+fn build_input_source(path: &Path) -> Result<Box<dyn InputSource>, RetromountError> {
+    if path.is_dir() {
+        return Ok(Box::new(DirectoryInputSource::new(path)));
+    }
+
+    if path.is_file()
+        && path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"))
+    {
+        return Ok(Box::new(ZipInputSource::new(path)));
+    }
+
+    Err(RetromountError::UnsupportedFormat)
+}
+
+pub fn write_vfs_tree<W: Write>(writer: &mut W, root: &VfsDirectory) -> io::Result<()> {
+    writeln!(writer, "/")?;
+
+    for child in &root.children {
+        write_vfs_node(writer, child, 1)?;
+    }
+
+    Ok(())
+}
+
+fn write_vfs_node<W: Write>(writer: &mut W, node: &VfsNode, depth: usize) -> io::Result<()> {
+    let indent = "  ".repeat(depth);
+
+    match node {
+        VfsNode::File(file) => {
+            writeln!(writer, "{indent}{}", file.name)?;
+        }
+        VfsNode::Directory(dir) => {
+            writeln!(writer, "{indent}{}/", dir.name)?;
+
+            for child in &dir.children {
+                write_vfs_node(writer, child, depth + 1)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
+
+    #[test]
+    fn writes_simple_vfs_tree() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![
+                VfsNode::File(VfsFile::new("mario.sfc", 1024)),
+                VfsNode::File(VfsFile::new("readme.txt", 64)),
+                VfsNode::File(VfsFile::new("blob.dat.bin", 12)),
+            ],
+        );
+
+        let mut output = Vec::new();
+        write_vfs_tree(&mut output, &root).unwrap();
+
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(
+            rendered,
+            "/\n  mario.sfc\n  readme.txt\n  blob.dat.bin\n"
+        );
+    }
+
+    #[test]
+    fn writes_nested_vfs_tree() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "snes",
+                vec![VfsNode::File(VfsFile::new("zelda.sfc", 2048))],
+            ))],
+        );
+
+        let mut output = Vec::new();
+        write_vfs_tree(&mut output, &root).unwrap();
+
+        let rendered = String::from_utf8(output).unwrap();
+        assert_eq!(rendered, "/\n  snes/\n    zelda.sfc\n");
+    }
+}

--- a/src/engine/preview.rs
+++ b/src/engine/preview.rs
@@ -95,10 +95,7 @@ mod tests {
         write_vfs_tree(&mut output, &root).unwrap();
 
         let rendered = String::from_utf8(output).unwrap();
-        assert_eq!(
-            rendered,
-            "/\n  mario.sfc\n  readme.txt\n  blob.dat.bin\n"
-        );
+        assert_eq!(rendered, "/\n  mario.sfc\n  readme.txt\n  blob.dat.bin\n");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), RetromountError> {
             run_phase3_preview(&path)
         }
         _ => Err(RetromountError::LoadError(
-            "usage: retromount [phase3-preview <path>]".to_string(),
+            "usage:\n  retromount\n  retromount phase3-preview <path>".to_string(),
         )),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,27 @@ use log::{debug, info};
 use std::path::PathBuf;
 
 use retromount::engine::loader::Loader;
+use retromount::engine::preview::run_phase3_preview;
 use retromount::{RetromountError, ViewConfig};
 
 fn main() -> Result<(), RetromountError> {
     env_logger::init();
 
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+
+    match args.as_slice() {
+        [] => run_configured_views(),
+        [command, path] if command.to_string_lossy() == "phase3-preview" => {
+            let path = PathBuf::from(path);
+            run_phase3_preview(&path)
+        }
+        _ => Err(RetromountError::LoadError(
+            "usage: retromount [phase3-preview <path>]".to_string(),
+        )),
+    }
+}
+
+fn run_configured_views() -> Result<(), RetromountError> {
     let config_path = PathBuf::from("retromount.yaml");
     debug!("Loading config from: {:?}", config_path);
 


### PR DESCRIPTION
# 🚀 PR: Add Phase 3 Preview CLI (Directory + ZIP)

## Summary

This PR introduces a **temporary CLI command** to preview the Phase 3 pipeline output against real data:

```bash
retromount phase3-preview <path>
```

This allows us to exercise the full Phase 3 pipeline:

```text
InputSource → InputIdentifier → InputDecoder → Content
→ OutputEncoder → OutputPresenter → VFS
```

…without needing FUSE or further integration work.

---

## ✨ What’s included

### 1. Preview engine (`engine::preview`)

New module:

```
src/engine/preview.rs
```

Provides:

- `run_phase3_preview(path)`
  - Builds and runs the Phase 3 pipeline
  - Selects input source:
    - `DirectoryInputSource`
    - `ZipInputSource`
- `write_vfs_tree(...)`
  - Recursive VFS tree printer
  - Outputs a simple, readable structure

Example output:

```text
/
  mario.sfc
  readme.txt
  blob.dat.bin
```

---

### 2. CLI integration

Updated:

```
src/main.rs
```

Adds:

```bash
retromount phase3-preview <path>
```

- Does **not** affect existing behaviour
- Default (no args) still runs Phase 2 config loader

---

### 3. Input type detection

Minimal detection logic:

- Directory → `DirectoryInputSource`
- `.zip` file → `ZipInputSource`
- Otherwise → `UnsupportedFormat`

---

### 4. Tests

Added unit tests for:

- Flat VFS rendering
- Nested directory rendering

This ensures the preview output is stable and predictable.

---

## 🎯 Design goals

- ✅ Keep implementation **minimal**
- ✅ Reuse existing Phase 3 components:
  - `BasicInputIdentifier`
  - `BasicInputDecoder`
  - `GenericPresenter`
  - `BasicEncoder`
- ✅ No FUSE / async / streaming
- ✅ No changes to existing loader/config behaviour
- ✅ Clean separation of concerns:
  - `engine::preview` → pipeline + rendering
  - `main.rs` → CLI routing

---

## 🧠 Why this matters

This is the **first time Phase 3 is runnable against real data**, not just tests.

It enables:

- Rapid validation of:
  - ZIP handling
  - content decoding
  - output encoding
- Debugging pipeline behaviour end-to-end
- A foundation for future tooling (inspect, debug, FUSE)

---

## 🔧 Example usage

```bash
cargo run -- phase3-preview ./roms
cargo run -- phase3-preview ./library.zip
```

---

## 📦 Commit breakdown

```text
feat(engine): add phase 3 preview runner and VFS tree printer
feat(cli): add phase3-preview command
chore(cli): improve usage error message
```

---

## 🚧 Future work (out of scope)

- FUSE mount integration
- Streaming / lazy decoding
- Rich metadata display
- Filtering / platform-specific views
- Integration with existing Loader

---

## ✅ Status

- Builds cleanly
- Tests passing
- No impact to existing functionality