### PR TITLE
Feature/retromount inspect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["filesystem", "emulators"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 serde_yaml = "0.9"
 log = "0.4"
 env_logger = "0.11.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ env_logger = "0.11.9"
 thiserror = "2.0"  # For custom error types
 zip = "8"
 
-[target.'cfg(unix)'.dependencies]
-fuse = "0.3.1"
-
 [dev-dependencies]
 tempfile = "3.27"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["fuse", "retro", "filesystem", "emulation"]
 categories = ["filesystem", "emulators"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 log = "0.4"

--- a/generate-testdata.sh
+++ b/generate-testdata.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE="${1:-./retromount-testdata}"
+
+echo "Creating test dataset at: $BASE"
+rm -rf "$BASE"
+mkdir -p "$BASE"
+
+# ----------------------------
+# 1. Simple ROM directory
+# ----------------------------
+mkdir -p "$BASE/roms/snes"
+
+echo "fake rom data" > "$BASE/roms/snes/Super Mario World.sfc"
+echo "fake rom data" > "$BASE/roms/snes/Zelda.sfc"
+
+# junk files
+echo "Some release notes" > "$BASE/roms/snes/game.nfo"
+echo "cover image" > "$BASE/roms/snes/cover.jpg"
+
+# ----------------------------
+# 2. ZIP archive with ROMs
+# ----------------------------
+mkdir -p "$BASE/zips/tmp"
+
+echo "rom1" > "$BASE/zips/tmp/game1.gb"
+echo "rom2" > "$BASE/zips/tmp/game2.gb"
+echo "readme" > "$BASE/zips/tmp/readme.txt"
+
+(
+  cd "$BASE/zips/tmp"
+  zip -q ../gameboy_collection.zip *
+)
+
+rm -rf "$BASE/zips/tmp"
+
+# ----------------------------
+# 3. Single-disc CUE/BIN
+# ----------------------------
+mkdir -p "$BASE/discs/ps1_single"
+
+echo "binarydata" > "$BASE/discs/ps1_single/game.bin"
+
+cat > "$BASE/discs/ps1_single/game.cue" <<EOF
+FILE "game.bin" BINARY
+  TRACK 01 MODE2/2352
+    INDEX 01 00:00:00
+EOF
+
+# ----------------------------
+# 4. Multi-disc set
+# ----------------------------
+mkdir -p "$BASE/discs/ps1_multi"
+
+for i in 1 2; do
+  echo "disc$i" > "$BASE/discs/ps1_multi/game_disc${i}.bin"
+
+  cat > "$BASE/discs/ps1_multi/game_disc${i}.cue" <<EOF
+FILE "game_disc${i}.bin" BINARY
+  TRACK 01 MODE2/2352
+    INDEX 01 00:00:00
+EOF
+done
+
+# ----------------------------
+# 5. ZIP containing CUE/BIN
+# ----------------------------
+mkdir -p "$BASE/zips_ps1/tmp"
+
+echo "discdata" > "$BASE/zips_ps1/tmp/game.bin"
+
+cat > "$BASE/zips_ps1/tmp/game.cue" <<EOF
+FILE "game.bin" BINARY
+  TRACK 01 MODE2/2352
+    INDEX 01 00:00:00
+EOF
+
+(
+  cd "$BASE/zips_ps1/tmp"
+  zip -q ../ps1_game.zip *
+)
+
+rm -rf "$BASE/zips_ps1/tmp"
+
+# ----------------------------
+# 6. Mixed messy directory
+# ----------------------------
+mkdir -p "$BASE/mixed"
+
+echo "rom" > "$BASE/mixed/game1.nes"
+echo "random text" > "$BASE/mixed/notes.txt"
+echo "image" > "$BASE/mixed/screenshot.png"
+
+# nested zip
+mkdir -p "$BASE/mixed/tmp"
+echo "nested rom" > "$BASE/mixed/tmp/nested.gb"
+(
+  cd "$BASE/mixed/tmp"
+  zip -q ../nested.zip *
+)
+rm -rf "$BASE/mixed/tmp"
+
+# ----------------------------
+# Done
+# ----------------------------
+echo "✅ Test dataset created."
+echo ""
+echo "Try:"
+echo "  cargo run -- inspect $BASE"

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -1,9 +1,10 @@
+use serde::Serialize;
 use std::fmt;
 use std::sync::Arc;
 
 use crate::core::source::SourceRef;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum ContentKind {
     Bytes,
     Rom,
@@ -11,7 +12,7 @@ pub enum ContentKind {
     Text,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ContentId(pub Arc<str>);
 
 impl ContentId {
@@ -26,7 +27,7 @@ impl fmt::Display for ContentId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum Content {
     Bytes(BytesContent),
     Rom(RomContent),
@@ -54,14 +55,14 @@ impl Content {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BytesContent {
     pub id: ContentId,
     pub source: SourceRef,
     pub size: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RomContent {
     pub id: ContentId,
     pub source: SourceRef,
@@ -69,7 +70,7 @@ pub struct RomContent {
     pub size: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DiscContent {
     pub id: ContentId,
     pub source: SourceRef,
@@ -77,7 +78,7 @@ pub struct DiscContent {
     pub disc_number: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TextContent {
     pub id: ContentId,
     pub source: SourceRef,

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -1,7 +1,8 @@
+use serde::Serialize;
 use std::fmt;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct SourceRef(pub Arc<str>);
 
 impl SourceRef {
@@ -16,7 +17,7 @@ impl fmt::Display for SourceRef {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SourceObject {
     pub source: SourceRef,
     pub name: String,

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum VfsNode {
     Directory(VfsDirectory),
     File(VfsFile),
@@ -13,7 +15,7 @@ impl VfsNode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct VfsDirectory {
     pub name: String,
     pub children: Vec<VfsNode>,
@@ -35,7 +37,7 @@ impl VfsDirectory {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct VfsFile {
     pub name: String,
     pub size: u64,

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -1,0 +1,155 @@
+use std::io::{self, Write};
+use std::path::Path;
+
+use crate::core::content::Content;
+use crate::error::RetromountError;
+use crate::input::basic_decoder::BasicInputDecoder;
+use crate::input::basic_identifier::BasicInputIdentifier;
+use crate::output::basic_encoder::BasicEncoder;
+use crate::output::generic_presenter::GenericPresenter;
+
+use super::pipeline::{run_pipeline_with_trace, PipelineTrace};
+use super::preview::{build_input_source, write_vfs_tree};
+
+pub fn run_phase3_inspect(path: &Path) -> Result<(), RetromountError> {
+    let source = build_input_source(path)?;
+
+    let identifier = BasicInputIdentifier::new();
+    let decoder = BasicInputDecoder::new();
+    let presenter = GenericPresenter::new(BasicEncoder::new());
+
+    let trace = run_pipeline_with_trace(source.as_ref(), &identifier, &decoder, &presenter)?;
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+
+    write_inspect_report(&mut handle, path, &trace)?;
+
+    Ok(())
+}
+
+pub fn write_inspect_report<W: Write>(
+    writer: &mut W,
+    path: &Path,
+    trace: &PipelineTrace,
+) -> io::Result<()> {
+    writeln!(writer, "Input:")?;
+    writeln!(writer, "  Path: {}", path.display())?;
+    writeln!(writer, "  Objects: {}", trace.objects.len())?;
+    writeln!(writer)?;
+
+    writeln!(writer, "Decoded:")?;
+    if trace.objects.is_empty() {
+        writeln!(writer, "  (none)")?;
+    } else {
+        for object in &trace.objects {
+            writeln!(writer, "  - {}", object.object.name)?;
+            writeln!(writer, "    Source: {}", object.object.source)?;
+            writeln!(writer, "    Identity: {:?}", object.identity)?;
+            writeln!(writer, "    Supported: {}", yes_no(object.supported))?;
+
+            if object.decoded.is_empty() {
+                writeln!(writer, "    Decoded: (none)")?;
+            } else {
+                for content in &object.decoded {
+                    write_content_summary(writer, content)?;
+                }
+            }
+        }
+    }
+
+    writeln!(writer)?;
+    writeln!(writer, "Presented VFS:")?;
+    write_vfs_tree(writer, &trace.presented)?;
+
+    Ok(())
+}
+
+fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Result<()> {
+    match content {
+        Content::Bytes(bytes) => {
+            writeln!(writer, "    Decoded: Bytes")?;
+            writeln!(writer, "      ID: {}", bytes.id)?;
+            writeln!(writer, "      Source: {}", bytes.source)?;
+            writeln!(writer, "      Size: {}", bytes.size)?;
+        }
+        Content::Rom(rom) => {
+            writeln!(writer, "    Decoded: Rom")?;
+            writeln!(writer, "      ID: {}", rom.id)?;
+            writeln!(writer, "      Source: {}", rom.source)?;
+            writeln!(writer, "      File name: {}", rom.file_name)?;
+            writeln!(writer, "      Size: {}", rom.size)?;
+        }
+        Content::Disc(disc) => {
+            writeln!(writer, "    Decoded: Disc")?;
+            writeln!(writer, "      ID: {}", disc.id)?;
+            writeln!(writer, "      Source: {}", disc.source)?;
+            writeln!(writer, "      Title: {}", disc.title)?;
+            writeln!(writer, "      Disc number: {}", disc.disc_number)?;
+        }
+        Content::Text(text) => {
+            writeln!(writer, "    Decoded: Text")?;
+            writeln!(writer, "      ID: {}", text.id)?;
+            writeln!(writer, "      Source: {}", text.source)?;
+            writeln!(writer, "      Size: {}", text.size)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::content::{BytesContent, ContentId};
+    use crate::core::source::{SourceObject, SourceRef};
+    use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
+    use crate::engine::pipeline::TracedObject;
+    use crate::input::identify::InputIdentity;
+
+    #[test]
+    fn writes_inspect_report() {
+        let trace = PipelineTrace {
+            objects: vec![TracedObject {
+                object: SourceObject {
+                    source: SourceRef::new("zip:/tmp/library.zip#misc/blob.dat"),
+                    name: "blob.dat".to_string(),
+                },
+                identity: InputIdentity::File,
+                supported: true,
+                decoded: vec![Content::Bytes(BytesContent {
+                    id: ContentId::new("blob.dat"),
+                    source: SourceRef::new("zip:/tmp/library.zip#misc/blob.dat"),
+                    size: 0,
+                })],
+            }],
+            presented: VfsDirectory::with_children(
+                "",
+                vec![VfsNode::File(VfsFile::new("blob.dat.bin", 0))],
+            ),
+        };
+
+        let mut output = Vec::new();
+        write_inspect_report(&mut output, Path::new("/tmp/library.zip"), &trace).unwrap();
+
+        let rendered = String::from_utf8(output).unwrap();
+
+        assert!(rendered.contains("Input:"));
+        assert!(rendered.contains("Path: /tmp/library.zip"));
+        assert!(rendered.contains("Objects: 1"));
+        assert!(rendered.contains("Decoded:"));
+        assert!(rendered.contains("Identity: File"));
+        assert!(rendered.contains("Supported: yes"));
+        assert!(rendered.contains("Decoded: Bytes"));
+        assert!(rendered.contains("Presented VFS:"));
+        assert!(rendered.contains("blob.dat.bin"));
+    }
+}

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -13,6 +13,7 @@ use super::preview::{build_input_source, write_vfs_tree};
 
 pub fn run_phase3_inspect(path: &Path) -> Result<(), RetromountError> {
     let source = build_input_source(path)?;
+    let kind = source.kind();
 
     let identifier = BasicInputIdentifier::new();
     let decoder = BasicInputDecoder::new();
@@ -23,7 +24,7 @@ pub fn run_phase3_inspect(path: &Path) -> Result<(), RetromountError> {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    write_inspect_report(&mut handle, path, &trace)?;
+    write_inspect_report(&mut handle, path, kind.as_str(), &trace)?;
 
     Ok(())
 }
@@ -31,10 +32,12 @@ pub fn run_phase3_inspect(path: &Path) -> Result<(), RetromountError> {
 pub fn write_inspect_report<W: Write>(
     writer: &mut W,
     path: &Path,
+    input_kind: &str,
     trace: &PipelineTrace,
 ) -> io::Result<()> {
     writeln!(writer, "Input:")?;
     writeln!(writer, "  Path: {}", path.display())?;
+    writeln!(writer, "  Type: {}", input_kind)?;
     writeln!(writer, "  Objects: {}", trace.objects.len())?;
     writeln!(writer)?;
 
@@ -138,12 +141,13 @@ mod tests {
         };
 
         let mut output = Vec::new();
-        write_inspect_report(&mut output, Path::new("/tmp/library.zip"), &trace).unwrap();
+        write_inspect_report(&mut output, Path::new("/tmp/library.zip"), "Zip", &trace).unwrap();
 
         let rendered = String::from_utf8(output).unwrap();
 
         assert!(rendered.contains("Input:"));
         assert!(rendered.contains("Path: /tmp/library.zip"));
+        assert!(rendered.contains("Type: Zip"));
         assert!(rendered.contains("Objects: 1"));
         assert!(rendered.contains("Decoded:"));
         assert!(rendered.contains("Identity: File"));

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -11,15 +11,22 @@ use crate::output::generic_presenter::GenericPresenter;
 use super::pipeline::{run_pipeline_with_trace, PipelineTrace};
 use super::preview::{build_input_source, write_vfs_tree};
 
-pub fn run_phase3_inspect(path: &Path) -> Result<(), RetromountError> {
+pub fn run_phase3_inspect(path: &Path, json: bool) -> Result<(), RetromountError> {
     let source = build_input_source(path)?;
     let kind = source.kind();
 
     let identifier = BasicInputIdentifier::new();
     let decoder = BasicInputDecoder::new();
     let presenter = GenericPresenter::new(BasicEncoder::new());
-
+    
     let trace = run_pipeline_with_trace(source.as_ref(), &identifier, &decoder, &presenter)?;
+
+    if json {
+        let output = serde_json::to_string_pretty(&trace)
+            .map_err(|err| RetromountError::LoadError(err.to_string()))?;
+        println!("{output}");
+        return Ok(());
+    }
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -18,7 +18,7 @@ pub fn run_phase3_inspect(path: &Path, json: bool) -> Result<(), RetromountError
     let identifier = BasicInputIdentifier::new();
     let decoder = BasicInputDecoder::new();
     let presenter = GenericPresenter::new(BasicEncoder::new());
-    
+
     let trace = run_pipeline_with_trace(source.as_ref(), &identifier, &decoder, &presenter)?;
 
     if json {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod inspect;
 pub mod loader;
 pub mod pipeline;
 pub mod preview;

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -7,14 +7,15 @@ use crate::input::decode::InputDecoder;
 use crate::input::identify::{InputIdentifier, InputIdentity};
 use crate::input::source::InputSource;
 use crate::output::present::OutputPresenter;
+use serde::Serialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PipelineTrace {
     pub objects: Vec<TracedObject>,
     pub presented: VfsDirectory,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct TracedObject {
     pub object: SourceObject,
     pub identity: InputIdentity,

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,10 +1,26 @@
 use std::io;
 
+use crate::core::content::Content;
+use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;
 use crate::input::decode::InputDecoder;
-use crate::input::identify::InputIdentifier;
+use crate::input::identify::{InputIdentifier, InputIdentity};
 use crate::input::source::InputSource;
 use crate::output::present::OutputPresenter;
+
+#[derive(Debug, Clone)]
+pub struct PipelineTrace {
+    pub objects: Vec<TracedObject>,
+    pub presented: VfsDirectory,
+}
+
+#[derive(Debug, Clone)]
+pub struct TracedObject {
+    pub object: SourceObject,
+    pub identity: InputIdentity,
+    pub supported: bool,
+    pub decoded: Vec<Content>,
+}
 
 pub fn run_pipeline(
     source: &dyn InputSource,
@@ -12,18 +28,45 @@ pub fn run_pipeline(
     decoder: &dyn InputDecoder,
     presenter: &dyn OutputPresenter,
 ) -> Result<VfsDirectory, io::Error> {
+    Ok(run_pipeline_with_trace(source, identifier, decoder, presenter)?.presented)
+}
+
+pub fn run_pipeline_with_trace(
+    source: &dyn InputSource,
+    identifier: &dyn InputIdentifier,
+    decoder: &dyn InputDecoder,
+    presenter: &dyn OutputPresenter,
+) -> Result<PipelineTrace, io::Error> {
     let objects = source.enumerate()?;
-    let mut content = Vec::new();
+    let mut traced_objects = Vec::new();
+    let mut all_content = Vec::new();
 
     for object in objects {
         let identity = identifier.identify(&object)?;
+        let supported = decoder.supports(&identity);
 
-        if decoder.supports(&identity) {
-            content.extend(decoder.decode(&object, &identity)?);
-        }
+        let decoded = if supported {
+            decoder.decode(&object, &identity)?
+        } else {
+            Vec::new()
+        };
+
+        all_content.extend(decoded.iter().cloned());
+
+        traced_objects.push(TracedObject {
+            object,
+            identity,
+            supported,
+            decoded,
+        });
     }
 
-    Ok(presenter.present(&content))
+    let presented = presenter.present(&all_content);
+
+    Ok(PipelineTrace {
+        objects: traced_objects,
+        presented,
+    })
 }
 
 #[cfg(test)]
@@ -31,6 +74,7 @@ mod tests {
     use super::*;
     use std::fs;
 
+    use crate::core::content::ContentKind;
     use crate::input::basic_decoder::BasicInputDecoder;
     use crate::input::basic_identifier::BasicInputIdentifier;
     use crate::input::directory_source::DirectoryInputSource;
@@ -89,5 +133,109 @@ mod tests {
 
         let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["blob.dat.bin", "readme.txt", "sonic.bin"]);
+    }
+
+    #[test]
+    fn traces_end_to_end_directory_pipeline() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(temp_dir.path().join("mario.sfc"), b"rom").unwrap();
+        fs::write(temp_dir.path().join("readme.txt"), b"hello").unwrap();
+        fs::write(temp_dir.path().join("blob.dat"), b"xyz").unwrap();
+
+        let source = DirectoryInputSource::new(temp_dir.path());
+        let identifier = BasicInputIdentifier::new();
+        let decoder = BasicInputDecoder::new();
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let trace = run_pipeline_with_trace(&source, &identifier, &decoder, &presenter).unwrap();
+
+        assert_eq!(trace.objects.len(), 3);
+
+        let names: Vec<&str> = trace
+            .presented
+            .children
+            .iter()
+            .map(|node| node.name())
+            .collect();
+        assert_eq!(names, vec!["blob.dat.bin", "mario.sfc", "readme.txt"]);
+
+        assert_eq!(trace.objects[0].object.name, "blob.dat");
+        assert_eq!(trace.objects[0].identity, InputIdentity::File);
+        assert!(trace.objects[0].supported);
+        assert_eq!(trace.objects[0].decoded.len(), 1);
+        assert_eq!(trace.objects[0].decoded[0].kind(), ContentKind::Bytes);
+
+        assert_eq!(trace.objects[1].object.name, "mario.sfc");
+        assert_eq!(trace.objects[1].identity, InputIdentity::File);
+        assert!(trace.objects[1].supported);
+        assert_eq!(trace.objects[1].decoded.len(), 1);
+        assert_eq!(trace.objects[1].decoded[0].kind(), ContentKind::Rom);
+
+        assert_eq!(trace.objects[2].object.name, "readme.txt");
+        assert_eq!(trace.objects[2].identity, InputIdentity::Text);
+        assert!(trace.objects[2].supported);
+        assert_eq!(trace.objects[2].decoded.len(), 1);
+        assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Text);
+    }
+
+    #[test]
+    fn traces_end_to_end_zip_pipeline() {
+        use std::fs::File;
+        use std::io::Write;
+
+        use crate::input::zip_source::ZipInputSource;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("library.zip");
+
+        let file = File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+
+        zip.start_file("roms/sonic.bin", options).unwrap();
+        zip.write_all(b"rom").unwrap();
+
+        zip.start_file("docs/readme.txt", options).unwrap();
+        zip.write_all(b"hello").unwrap();
+
+        zip.start_file("misc/blob.dat", options).unwrap();
+        zip.write_all(b"xyz").unwrap();
+
+        zip.finish().unwrap();
+
+        let source = ZipInputSource::new(&zip_path);
+        let identifier = BasicInputIdentifier::new();
+        let decoder = BasicInputDecoder::new();
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let trace = run_pipeline_with_trace(&source, &identifier, &decoder, &presenter).unwrap();
+
+        assert_eq!(trace.objects.len(), 3);
+
+        let names: Vec<&str> = trace
+            .presented
+            .children
+            .iter()
+            .map(|node| node.name())
+            .collect();
+        assert_eq!(names, vec!["blob.dat.bin", "readme.txt", "sonic.bin"]);
+
+        assert_eq!(trace.objects[0].object.name, "blob.dat");
+        assert_eq!(trace.objects[0].identity, InputIdentity::File);
+        assert!(trace.objects[0].supported);
+        assert_eq!(trace.objects[0].decoded.len(), 1);
+        assert_eq!(trace.objects[0].decoded[0].kind(), ContentKind::Bytes);
+
+        assert_eq!(trace.objects[1].object.name, "readme.txt");
+        assert_eq!(trace.objects[1].identity, InputIdentity::Text);
+        assert!(trace.objects[1].supported);
+        assert_eq!(trace.objects[1].decoded.len(), 1);
+        assert_eq!(trace.objects[1].decoded[0].kind(), ContentKind::Text);
+
+        assert_eq!(trace.objects[2].object.name, "sonic.bin");
+        assert_eq!(trace.objects[2].identity, InputIdentity::File);
+        assert!(trace.objects[2].supported);
+        assert_eq!(trace.objects[2].decoded.len(), 1);
+        assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Rom);
     }
 }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crate::core::content::Content;
+use crate::core::content::{Content, ContentKind};
 use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;
 use crate::input::decode::InputDecoder;
@@ -151,12 +151,7 @@ mod tests {
 
         assert_eq!(trace.objects.len(), 3);
 
-        let names: Vec<&str> = trace
-            .presented
-            .children
-            .iter()
-            .map(|node| node.name())
-            .collect();
+        let names: Vec<&str> = trace.presented.children.iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["blob.dat.bin", "mario.sfc", "readme.txt"]);
 
         assert_eq!(trace.objects[0].object.name, "blob.dat");
@@ -212,12 +207,7 @@ mod tests {
 
         assert_eq!(trace.objects.len(), 3);
 
-        let names: Vec<&str> = trace
-            .presented
-            .children
-            .iter()
-            .map(|node| node.name())
-            .collect();
+        let names: Vec<&str> = trace.presented.children.iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["blob.dat.bin", "readme.txt", "sonic.bin"]);
 
         assert_eq!(trace.objects[0].object.name, "blob.dat");

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -151,7 +151,12 @@ mod tests {
 
         assert_eq!(trace.objects.len(), 3);
 
-        let names: Vec<&str> = trace.presented.children.iter().map(|node| node.name()).collect();
+        let names: Vec<&str> = trace
+            .presented
+            .children
+            .iter()
+            .map(|node| node.name())
+            .collect();
         assert_eq!(names, vec!["blob.dat.bin", "mario.sfc", "readme.txt"]);
 
         assert_eq!(trace.objects[0].object.name, "blob.dat");
@@ -207,7 +212,12 @@ mod tests {
 
         assert_eq!(trace.objects.len(), 3);
 
-        let names: Vec<&str> = trace.presented.children.iter().map(|node| node.name()).collect();
+        let names: Vec<&str> = trace
+            .presented
+            .children
+            .iter()
+            .map(|node| node.name())
+            .collect();
         assert_eq!(names, vec!["blob.dat.bin", "readme.txt", "sonic.bin"]);
 
         assert_eq!(trace.objects[0].object.name, "blob.dat");

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -74,7 +74,6 @@ mod tests {
     use super::*;
     use std::fs;
 
-    use crate::core::content::ContentKind;
     use crate::input::basic_decoder::BasicInputDecoder;
     use crate::input::basic_identifier::BasicInputIdentifier;
     use crate::input::directory_source::DirectoryInputSource;

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crate::core::content::{Content, ContentKind};
+use crate::core::content::Content;
 use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;
 use crate::input::decode::InputDecoder;
@@ -75,6 +75,7 @@ mod tests {
     use super::*;
     use std::fs;
 
+    use crate::core::content::ContentKind;
     use crate::input::basic_decoder::BasicInputDecoder;
     use crate::input::basic_identifier::BasicInputIdentifier;
     use crate::input::directory_source::DirectoryInputSource;

--- a/src/engine/preview.rs
+++ b/src/engine/preview.rs
@@ -29,7 +29,7 @@ pub fn run_phase3_preview(path: &Path) -> Result<(), RetromountError> {
     Ok(())
 }
 
-fn build_input_source(path: &Path) -> Result<Box<dyn InputSource>, RetromountError> {
+pub fn build_input_source(path: &Path) -> Result<Box<dyn InputSource>, RetromountError> {
     if path.is_dir() {
         return Ok(Box::new(DirectoryInputSource::new(path)));
     }

--- a/src/input/directory_source.rs
+++ b/src/input/directory_source.rs
@@ -25,6 +25,10 @@ impl InputSource for DirectoryInputSource {
         InputSourceKind::Directory
     }
 
+    fn kind(&self) -> InputSourceKind {
+        InputSourceKind::Directory
+    }
+
     fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
         let mut objects = Vec::new();
 
@@ -70,5 +74,13 @@ mod tests {
 
         let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
         assert_eq!(names, vec!["a.bin", "b.txt"]);
+    }
+
+    #[test]
+    fn reports_directory_kind() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source = DirectoryInputSource::new(temp_dir.path());
+
+        assert_eq!(source.kind(), InputSourceKind::Directory);
     }
 }

--- a/src/input/directory_source.rs
+++ b/src/input/directory_source.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::core::source::{SourceObject, SourceRef};
-use crate::input::source::InputSource;
+use crate::input::source::{InputSource, InputSourceKind};
 
 #[derive(Debug, Clone)]
 pub struct DirectoryInputSource {
@@ -21,6 +21,10 @@ impl DirectoryInputSource {
 }
 
 impl InputSource for DirectoryInputSource {
+    fn kind(&self) -> InputSourceKind {
+        InputSourceKind::Directory
+    }
+
     fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
         let mut objects = Vec::new();
 
@@ -45,6 +49,14 @@ impl InputSource for DirectoryInputSource {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn reports_directory_kind() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source = DirectoryInputSource::new(temp_dir.path());
+
+        assert_eq!(source.kind(), InputSourceKind::Directory);
+    }
 
     #[test]
     fn enumerates_regular_files_in_directory() {

--- a/src/input/directory_source.rs
+++ b/src/input/directory_source.rs
@@ -25,10 +25,6 @@ impl InputSource for DirectoryInputSource {
         InputSourceKind::Directory
     }
 
-    fn kind(&self) -> InputSourceKind {
-        InputSourceKind::Directory
-    }
-
     fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
         let mut objects = Vec::new();
 
@@ -74,13 +70,5 @@ mod tests {
 
         let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
         assert_eq!(names, vec!["a.bin", "b.txt"]);
-    }
-
-    #[test]
-    fn reports_directory_kind() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let source = DirectoryInputSource::new(temp_dir.path());
-
-        assert_eq!(source.kind(), InputSourceKind::Directory);
     }
 }

--- a/src/input/identify.rs
+++ b/src/input/identify.rs
@@ -1,5 +1,5 @@
-use serde::Serialize;
 use crate::core::source::SourceObject;
+use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum InputIdentity {

--- a/src/input/identify.rs
+++ b/src/input/identify.rs
@@ -1,6 +1,7 @@
+use serde::Serialize;
 use crate::core::source::SourceObject;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum InputIdentity {
     File,
     Directory,

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -1,6 +1,7 @@
 use crate::core::source::SourceObject;
+use serde::Serialize;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum InputSourceKind {
     Directory,
     Zip,

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -1,5 +1,21 @@
 use crate::core::source::SourceObject;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputSourceKind {
+    Directory,
+    Zip,
+}
+
+impl InputSourceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Directory => "Directory",
+            Self::Zip => "Zip",
+        }
+    }
+}
+
 pub trait InputSource: Send + Sync {
+    fn kind(&self) -> InputSourceKind;
     fn enumerate(&self) -> Result<Vec<SourceObject>, std::io::Error>;
 }

--- a/src/input/zip_source.rs
+++ b/src/input/zip_source.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::core::source::{SourceObject, SourceRef};
-use crate::input::source::InputSource;
+use crate::input::source::{InputSource, InputSourceKind};
 
 #[derive(Debug, Clone)]
 pub struct ZipInputSource {
@@ -23,6 +23,10 @@ impl ZipInputSource {
 }
 
 impl InputSource for ZipInputSource {
+    fn kind(&self) -> InputSourceKind {
+        InputSourceKind::Zip
+    }
+
     fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
         let file = File::open(&self.archive_path)?;
         let mut archive = zip::ZipArchive::new(file)
@@ -84,6 +88,16 @@ mod tests {
         zip.add_directory("empty_dir/", options).unwrap();
 
         zip.finish().unwrap();
+    }
+
+    #[test]
+    fn reports_zip_kind() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("test.zip");
+        create_test_zip(&zip_path);
+
+        let source = ZipInputSource::new(&zip_path);
+        assert_eq!(source.kind(), InputSourceKind::Zip);
     }
 
     #[test]

--- a/src/input/zip_source.rs
+++ b/src/input/zip_source.rs
@@ -27,6 +27,10 @@ impl InputSource for ZipInputSource {
         InputSourceKind::Zip
     }
 
+    fn kind(&self) -> InputSourceKind {
+        InputSourceKind::Zip
+    }
+
     fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
         let file = File::open(&self.archive_path)?;
         let mut archive = zip::ZipArchive::new(file)
@@ -114,5 +118,15 @@ mod tests {
 
         assert!(objects[0].source.0.starts_with("zip:"));
         assert!(objects[1].source.0.starts_with("zip:"));
+    }
+
+    #[test]
+    fn reports_zip_kind() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("test.zip");
+        create_test_zip(&zip_path);
+
+        let source = ZipInputSource::new(&zip_path);
+        assert_eq!(source.kind(), InputSourceKind::Zip);
     }
 }

--- a/src/input/zip_source.rs
+++ b/src/input/zip_source.rs
@@ -27,10 +27,6 @@ impl InputSource for ZipInputSource {
         InputSourceKind::Zip
     }
 
-    fn kind(&self) -> InputSourceKind {
-        InputSourceKind::Zip
-    }
-
     fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
         let file = File::open(&self.archive_path)?;
         let mut archive = zip::ZipArchive::new(file)
@@ -118,15 +114,5 @@ mod tests {
 
         assert!(objects[0].source.0.starts_with("zip:"));
         assert!(objects[1].source.0.starts_with("zip:"));
-    }
-
-    #[test]
-    fn reports_zip_kind() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let zip_path = temp_dir.path().join("test.zip");
-        create_test_zip(&zip_path);
-
-        let source = ZipInputSource::new(&zip_path);
-        assert_eq!(source.kind(), InputSourceKind::Zip);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,17 @@ fn main() -> Result<(), RetromountError> {
         }
         [command, path] if command.to_string_lossy() == "inspect" => {
             let path = PathBuf::from(path);
-            run_phase3_inspect(&path)
+            run_phase3_inspect(&path, false)
+        }
+        [command, path, flag]
+            if command.to_string_lossy() == "inspect"
+                && flag.to_string_lossy() == "--json" =>
+        {
+            let path = PathBuf::from(path);
+            run_phase3_inspect(&path, true)
         }
         _ => Err(RetromountError::LoadError(
-            "usage:\n  retromount\n  retromount phase3-preview <path>\n  retromount inspect <path>"
+            "usage:\n  retromount\n  retromount phase3-preview <path>\n  retromount inspect <path> [--json]"
                 .to_string(),
         )),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use log::{debug, info};
 use std::path::PathBuf;
 
+use retromount::engine::inspect::run_phase3_inspect;
 use retromount::engine::loader::Loader;
 use retromount::engine::preview::run_phase3_preview;
 use retromount::{RetromountError, ViewConfig};
@@ -16,8 +17,13 @@ fn main() -> Result<(), RetromountError> {
             let path = PathBuf::from(path);
             run_phase3_preview(&path)
         }
+        [command, path] if command.to_string_lossy() == "inspect" => {
+            let path = PathBuf::from(path);
+            run_phase3_inspect(&path)
+        }
         _ => Err(RetromountError::LoadError(
-            "usage:\n  retromount\n  retromount phase3-preview <path>".to_string(),
+            "usage:\n  retromount\n  retromount phase3-preview <path>\n  retromount inspect <path>"
+                .to_string(),
         )),
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces the initial `inspect` command for Phase 3, providing a full end-to-end view of the Retromount pipeline:

InputSource → InputIdentifier → InputDecoder → OutputPresenter → VFS

This allows us to run Retromount against real data and observe how content is discovered, classified, decoded, and presented.

## What’s included

### CLI

- Adds `inspect` command:
  ```bash
  retromount inspect <path>
  ```

- Supports:
  - directories
  - zip archives

### Pipeline integration

- Wires together:
  - input sources
  - identifier layer
  - decoder layer
  - presenter layer
  - VFS model

- Outputs:
  - input summary
  - decoded objects
  - presented VFS structure

### Logging

- Uses `env_logger`
- Supports `RUST_LOG=info|debug` for deeper inspection

### Test data tooling 🧪

- Adds `generate-testdata.sh` script to create a representative local dataset including:
  - ROM directories
  - ZIP archives
  - CUE/BIN disc images
  - multi-disc layouts
  - mixed/junk files

## Example usage

```bash
RUST_LOG=debug cargo run -- inspect ./retromount-testdata
```

## Current limitations (known + expected)

This PR intentionally focuses on visibility rather than completeness. The following are known gaps:

- Directory input is non-recursive
- ZIP entry sizes are reported as 0
- Disc `.bin` files are surfaced alongside `.cue` (no dependency suppression yet)
- Multi-disc grouping and disc number parsing are minimal
- Nested archives are not treated as input sources

These will be addressed in follow-up PRs.

## Why this matters 🚀

This is the first point where Retromount can be exercised against real-world data.

It provides:
- a debugging tool
- a validation surface for Phase 3 architecture
- a foundation for future work (mounting, grouping, filtering, etc.)

## Next steps (follow-up work)

Planned improvements:

- Recursive directory enumeration
- Correct ZIP entry metadata (size, etc.)
- Disc dependency handling (hide backing files)
- Improved disc title / disc number parsing
- Optional nested archive handling

## Notes

- Removed legacy `fuse` dependency for now; mount support will be reintroduced later using a feature-gated modern approach (likely `fuser` + FUSE3).