### PR TITLE
Phase 3: recurse directory input sources for library-root inspection

### DIFF
--- a/src/input/directory_source.rs
+++ b/src/input/directory_source.rs
@@ -34,11 +34,13 @@ impl DirectoryInputSource {
             }
 
             if path.is_file() {
-                let name = path
-                    .strip_prefix(root)
-                    .unwrap_or(&path)
-                    .to_string_lossy()
-                    .into_owned();
+                let relative = path.strip_prefix(root).unwrap_or(&path);
+
+                let name = relative
+                    .components()
+                    .map(|component| component.as_os_str().to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join("/");
 
                 let source = SourceRef::new(path.to_string_lossy().into_owned());
 

--- a/src/input/directory_source.rs
+++ b/src/input/directory_source.rs
@@ -18,6 +18,36 @@ impl DirectoryInputSource {
     pub fn root(&self) -> &Path {
         &self.root
     }
+
+    fn collect_files(
+        root: &Path,
+        current: &Path,
+        objects: &mut Vec<SourceObject>,
+    ) -> Result<(), io::Error> {
+        for entry in fs::read_dir(current)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_dir() {
+                Self::collect_files(root, &path, objects)?;
+                continue;
+            }
+
+            if path.is_file() {
+                let name = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .into_owned();
+
+                let source = SourceRef::new(path.to_string_lossy().into_owned());
+
+                objects.push(SourceObject { source, name });
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl InputSource for DirectoryInputSource {
@@ -27,19 +57,7 @@ impl InputSource for DirectoryInputSource {
 
     fn enumerate(&self) -> Result<Vec<SourceObject>, io::Error> {
         let mut objects = Vec::new();
-
-        for entry in fs::read_dir(&self.root)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if path.is_file() {
-                let name = entry.file_name().to_string_lossy().into_owned();
-                let source = SourceRef::new(path.to_string_lossy().into_owned());
-
-                objects.push(SourceObject { source, name });
-            }
-        }
-
+        Self::collect_files(&self.root, &self.root, &mut objects)?;
         objects.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(objects)
     }
@@ -59,16 +77,35 @@ mod tests {
     }
 
     #[test]
-    fn enumerates_regular_files_in_directory() {
+    fn enumerates_regular_files_in_directory_recursively() {
         let temp_dir = tempfile::tempdir().unwrap();
         fs::write(temp_dir.path().join("b.txt"), b"hello").unwrap();
-        fs::write(temp_dir.path().join("a.bin"), b"abc").unwrap();
         fs::create_dir(temp_dir.path().join("subdir")).unwrap();
+        fs::write(temp_dir.path().join("subdir").join("a.bin"), b"abc").unwrap();
 
         let source = DirectoryInputSource::new(temp_dir.path());
         let objects = source.enumerate().unwrap();
 
         let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
-        assert_eq!(names, vec!["a.bin", "b.txt"]);
+        assert_eq!(names, vec!["b.txt", "subdir/a.bin"]);
+    }
+
+    #[test]
+    fn ignores_directories_and_sorts_nested_results() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(temp_dir.path().join("roms/snes")).unwrap();
+        fs::create_dir_all(temp_dir.path().join("roms/megadrive")).unwrap();
+
+        fs::write(temp_dir.path().join("roms/snes/zelda.sfc"), b"1").unwrap();
+        fs::write(temp_dir.path().join("roms/megadrive/sonic.bin"), b"2").unwrap();
+
+        let source = DirectoryInputSource::new(temp_dir.path());
+        let objects = source.enumerate().unwrap();
+
+        let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["roms/megadrive/sonic.bin", "roms/snes/zelda.sfc"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR updates the directory input source to recursively enumerate files, enabling `inspect` to work correctly against real-world library roots.

Previously, only files directly within the specified directory were discovered. This meant running `inspect` against a typical ROM library root (which contains nested folders) would return zero objects.

## What’s changed

### Recursive directory enumeration

- Directory input source now walks subdirectories recursively
- All files under the root path are discovered and emitted as `SourceObject`s

### Stable logical naming

- Object names are now stored as paths relative to the input root
- Paths are normalised to use `/` as a separator across all platforms
- Ensures consistent behaviour between Linux and Windows

### Deterministic ordering

- Results are sorted by name to ensure stable and predictable output

## Example

Before:

```
retromount inspect ./roms
→ Objects: 0
```

After:

```
retromount inspect ./roms
→ Objects: N (all files under subdirectories)
```

## Why this matters

Real-world ROM libraries (e.g. RetroNAS-style layouts) are almost always nested by system or category.

This change allows Retromount to:

- operate on a library root instead of individual subfolders
- provide meaningful output for `inspect`
- better reflect real-world usage patterns

## Tests

- Updated directory source tests to cover recursive traversal
- Added assertions for nested file discovery
- Fixed cross-platform test failures by normalising path separators

All tests pass on:
- Linux
- Windows (CI)

## Current behaviour notes

- Relative paths are currently preserved in object names but are still presented as flat filenames in the VFS layer
- This will be addressed in a future improvement to the presenter/VFS mapping

## Next steps

Follow-up improvements planned:

- Fix ZIP entry metadata (size reporting)
- Suppress disc backing files (e.g. `.bin` for `.cue`)
- Improve disc title and disc number parsing
- Consider nested archive handling

## Notes

This change is intentionally limited to the input layer and does not modify decoder or presenter behaviour.