### PR TITLE
fix(zip): report real sizes for zip-backed content

### DIFF
--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -5,9 +5,11 @@ use std::path::Path;
 use crate::core::content::{
     BytesContent, Content, ContentId, DiscContent, RomContent, TextContent,
 };
+use crate::core::reader::Reader;
 use crate::core::source::SourceObject;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
+use crate::readers::zip_reader::ZipReader;
 
 #[derive(Debug, Default)]
 pub struct BasicInputDecoder;
@@ -80,16 +82,21 @@ impl InputDecoder for BasicInputDecoder {
 }
 
 fn content_size_for(object: &SourceObject) -> Result<u64, io::Error> {
-    if is_zip_source(object) {
-        return Ok(0);
+    if let Some((archive_path, entry_name)) = parse_zip_source(object) {
+        let reader = ZipReader::open(Path::new(&archive_path), &entry_name)?;
+        return Ok(reader.len());
     }
 
     let path = Path::new(object.source.0.as_ref());
     Ok(fs::metadata(path)?.len())
 }
 
-fn is_zip_source(object: &SourceObject) -> bool {
-    object.source.0.starts_with("zip:")
+fn parse_zip_source(object: &SourceObject) -> Option<(String, String)> {
+    let source = object.source.0.as_ref();
+    let remainder = source.strip_prefix("zip:")?;
+    let (archive_path, entry_name) = remainder.split_once('#')?;
+
+    Some((archive_path.to_string(), entry_name.to_string()))
 }
 
 fn looks_like_rom_name(name: &str) -> bool {
@@ -158,15 +165,35 @@ mod tests {
     }
 
     #[test]
-    fn decodes_zip_source_without_filesystem_metadata() {
+    fn decodes_zip_source_with_entry_size() {
+        use std::fs::File;
+        use std::io::Write;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("test.zip");
+
+        {
+            let file = File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+
+            zip.start_file("roms/sonic.bin", options).unwrap();
+            zip.write_all(b"romdata").unwrap();
+            zip.finish().unwrap();
+        }
+
         let decoder = BasicInputDecoder::new();
         let object = SourceObject {
-            source: SourceRef::new("zip:/tmp/test.zip#roms/sonic.bin"),
+            source: SourceRef::new(format!("zip:{}#roms/sonic.bin", zip_path.to_string_lossy())),
             name: "sonic.bin".to_string(),
         };
 
         let content = decoder.decode(&object, &InputIdentity::File).unwrap();
         assert_eq!(content.len(), 1);
-        assert!(matches!(content[0], Content::Rom(_)));
+
+        match &content[0] {
+            Content::Rom(rom) => assert_eq!(rom.size, 7),
+            other => panic!("expected Rom content, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes ZIP-backed content reporting incorrect sizes during Phase 3 inspection and decoding.

Previously, objects discovered inside a ZIP archive were decoded with a size of `0`, even though equivalent directory-backed files reported correct sizes. This caused inconsistent and misleading `inspect` output for ZIP inputs.

## What’s changed

### ZIP-backed content now reports real sizes

- Replaces the hard-coded `0` size for ZIP-backed objects
- Uses the existing ZIP reader path to resolve the real entry length
- Ensures ZIP-backed ROM and text content report meaningful metadata

### Decoder test coverage improved

- Replaces the old ZIP decoder test that only verified decoding succeeded
- Adds a stronger test that creates a real ZIP archive and asserts the decoded content size matches the entry contents

## Example

Before:

```text
Decoded: Rom
  Size: 0
```

After:

```text
Decoded: Rom
  Size: 5
```

## Why this matters

This brings ZIP-backed content into line with the rest of the content model.

It improves:

- correctness of `inspect` output
- consistency between directory and ZIP inputs
- confidence in content metadata used by later pipeline stages

## Scope

This PR only fixes size reporting for objects when the ZIP itself is the active input source.

It does **not** change current behaviour for ZIP files discovered inside a directory tree. Those are still treated as ordinary files rather than nested input sources, which remains a separate future enhancement.

## Testing

Validated with:

```bash
cargo run -- inspect ./retromount-testdata/zips/gameboy_collection.zip
cargo run -- inspect ./retromount-testdata
```

Confirmed that:

- ZIP entries now report non-zero real sizes
- root-level directory inspection still behaves as expected

## Next steps

Planned follow-up work:

- Suppress disc backing files such as `.bin` when a `.cue` is present
- Improve disc title and disc number parsing
- Consider nested archive handling