### PR TITLE
Phase 3: suppress consumed backing files from presented output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      
+
       - name: Install sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
         with:
@@ -33,15 +33,12 @@ jobs:
         with:
           shared-key: "retromount-lint"
 
-      - name: Install FUSE dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfuse-dev
-
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Lint with Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-      
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats
@@ -64,7 +61,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
           toolchain: stable
-      
+
       - name: Install sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
         with:
@@ -74,19 +71,15 @@ jobs:
         with:
           shared-key: "retromount-test-${{ matrix.os }}"
 
-      - name: Install FUSE dependencies
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libfuse-dev
-
       - name: Build (debug)
-        run: cargo build --all-targets --all-features --verbose
+        run: cargo build --locked --all-targets --all-features --verbose
 
       - name: Run tests
-        run: cargo test --all-targets --all-features --verbose
+        run: cargo test --locked --all-targets --all-features --verbose
 
       - name: Build (release)
-        run: cargo build --release --all-targets --all-features --verbose
-      
+        run: cargo build --locked --release --all-targets --all-features --verbose
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats
@@ -116,13 +109,10 @@ jobs:
           shared-key: "retromount-release"
 
       - name: Install packaging dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libfuse-dev
-          cargo install cargo-deb --locked
+        run: cargo install cargo-deb --locked
 
       - name: Build release binary
-        run: cargo build --release --all-features --verbose
+        run: cargo build --locked --release --all-features --verbose
 
       - name: Build Debian package
         run: cargo deb --no-build
@@ -133,7 +123,7 @@ jobs:
           name: retromount-deb
           path: target/debian/*.deb
           if-no-files-found: error
-      
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
           toolchain: stable
-      
+
       - name: Install sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
         with:
@@ -36,13 +36,10 @@ jobs:
           shared-key: "retromount-release"
 
       - name: Build release
-        run: cargo build --release --all-features --verbose
+        run: cargo build --locked --release --all-features --verbose
 
       - name: Install packaging dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libfuse-dev
-          cargo install cargo-deb --locked
+        run: cargo install cargo-deb --locked
 
       - name: Build Debian package
         run: cargo deb --no-build
@@ -53,7 +50,7 @@ jobs:
           files: target/debian/*.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
- "log 0.4.29",
+ "log",
  "regex",
 ]
 
@@ -228,7 +228,7 @@ dependencies = [
  "anstyle",
  "env_filter",
  "jiff",
- "log 0.4.29",
+ "log",
 ]
 
 [[package]]
@@ -274,19 +274,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "fuse"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
-dependencies = [
- "libc",
- "log 0.3.9",
- "pkg-config",
- "thread-scoped",
- "time 0.1.45",
-]
 
 [[package]]
 name = "generic-array"
@@ -401,7 +388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
- "log 0.4.29",
+ "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
@@ -461,15 +448,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.29",
-]
 
 [[package]]
 name = "log"
@@ -637,9 +615,9 @@ name = "retromount"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "fuse",
- "log 0.4.29",
+ "log",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror",
@@ -818,23 +796,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-scoped"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,12 +856,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasip2"
@@ -1000,28 +955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +1029,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "indexmap",
- "log 0.4.29",
+ "log",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1115,7 +1048,7 @@ dependencies = [
  "anyhow",
  "id-arena",
  "indexmap",
- "log 0.4.29",
+ "log",
  "semver",
  "serde",
  "serde_derive",
@@ -1164,7 +1097,7 @@ dependencies = [
  "pbkdf2",
  "ppmd-rust",
  "sha1",
- "time 0.3.47",
+ "time",
  "typed-path",
  "zeroize",
  "zopfli",
@@ -1191,7 +1124,7 @@ checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",
- "log 0.4.29",
+ "log",
  "simd-adler32",
 ]
 

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -53,6 +53,22 @@ impl Content {
             Self::Text(v) => &v.id,
         }
     }
+
+    pub fn source(&self) -> &SourceRef {
+        match self {
+            Self::Bytes(v) => &v.source,
+            Self::Rom(v) => &v.source,
+            Self::Disc(v) => &v.source,
+            Self::Text(v) => &v.source,
+        }
+    }
+
+    pub fn consumed_sources(&self) -> &[SourceRef] {
+        match self {
+            Self::Disc(v) => &v.consumed_sources,
+            _ => &[],
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -76,6 +92,7 @@ pub struct DiscContent {
     pub source: SourceRef,
     pub title: String,
     pub disc_number: u32,
+    pub consumed_sources: Vec<SourceRef>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -101,5 +118,23 @@ mod tests {
 
         assert_eq!(content.kind(), ContentKind::Rom);
         assert_eq!(content.id().to_string(), "game");
+    }
+
+    #[test]
+    fn returns_source_and_consumed_sources() {
+        let content = Content::Disc(DiscContent {
+            id: ContentId::new("game"),
+            source: SourceRef::new("cue:/roms/game.cue"),
+            title: "game".to_string(),
+            disc_number: 1,
+            consumed_sources: vec![SourceRef::new("cue:/roms/game.bin")],
+        });
+
+        assert_eq!(content.source().to_string(), "cue:/roms/game.cue");
+        assert_eq!(content.consumed_sources().len(), 1);
+        assert_eq!(
+            content.consumed_sources()[0].to_string(),
+            "cue:/roms/game.bin"
+        );
     }
 }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::io;
 
 use crate::core::content::Content;
@@ -62,12 +63,26 @@ pub fn run_pipeline_with_trace(
         });
     }
 
-    let presented = presenter.present(&all_content);
+    let presented_content = suppress_consumed_content(&all_content);
+    let presented = presenter.present(&presented_content);
 
     Ok(PipelineTrace {
         objects: traced_objects,
         presented,
     })
+}
+
+fn suppress_consumed_content(all_content: &[Content]) -> Vec<Content> {
+    let consumed_sources: HashSet<_> = all_content
+        .iter()
+        .flat_map(|content| content.consumed_sources().iter().cloned())
+        .collect();
+
+    all_content
+        .iter()
+        .filter(|content| !consumed_sources.contains(content.source()))
+        .cloned()
+        .collect()
 }
 
 #[cfg(test)]
@@ -238,5 +253,30 @@ mod tests {
         assert!(trace.objects[2].supported);
         assert_eq!(trace.objects[2].decoded.len(), 1);
         assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Rom);
+    }
+
+    #[test]
+    fn suppresses_disc_backing_files_from_presented_output() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(temp_dir.path().join("game.bin"), b"discdata").unwrap();
+        fs::write(
+            temp_dir.path().join("game.cue"),
+            r#"
+    FILE "game.bin" BINARY
+    TRACK 01 MODE2/2352
+        INDEX 01 00:00:00
+    "#,
+        )
+        .unwrap();
+
+        let source = DirectoryInputSource::new(temp_dir.path());
+        let identifier = BasicInputIdentifier::new();
+        let decoder = BasicInputDecoder::new();
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let root = run_pipeline(&source, &identifier, &decoder, &presenter).unwrap();
+
+        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["game (Disc 1).cue"]);
     }
 }

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::io;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use crate::core::content::{

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -1,14 +1,17 @@
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use crate::core::content::{
     BytesContent, Content, ContentId, DiscContent, RomContent, TextContent,
 };
+use crate::core::cue::parse_cue;
 use crate::core::reader::Reader;
-use crate::core::source::SourceObject;
+use crate::core::source::{SourceObject, SourceRef};
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
+use crate::readers::dir_reader::DirReader;
 use crate::readers::zip_reader::ZipReader;
 
 #[derive(Debug, Default)]
@@ -50,6 +53,7 @@ impl InputDecoder for BasicInputDecoder {
                 source: object.source.clone(),
                 title: file_stem_or_name_from_object(object),
                 disc_number: 1,
+                consumed_sources: consumed_sources_for_disc_image(object)?,
             }),
             InputIdentity::File => {
                 if looks_like_rom_name(&object.name) {
@@ -97,6 +101,63 @@ fn parse_zip_source(object: &SourceObject) -> Option<(String, String)> {
     let (archive_path, entry_name) = remainder.split_once('#')?;
 
     Some((archive_path.to_string(), entry_name.to_string()))
+}
+
+fn consumed_sources_for_disc_image(object: &SourceObject) -> Result<Vec<SourceRef>, io::Error> {
+    let cue_text = read_text_from_source(object)?;
+    let parsed = parse_cue(&cue_text);
+
+    let mut consumed = Vec::new();
+
+    for file_entry in parsed {
+        let source = resolve_relative_source(object, &file_entry.path);
+        consumed.push(source);
+    }
+
+    Ok(consumed)
+}
+
+fn read_text_from_source(object: &SourceObject) -> Result<String, io::Error> {
+    if let Some((archive_path, entry_name)) = parse_zip_source(object) {
+        let mut reader = ZipReader::open(Path::new(&archive_path), &entry_name)?;
+        let mut bytes = vec![0; reader.len() as usize];
+        let bytes_read = reader.read_at(0, &mut bytes)?;
+        bytes.truncate(bytes_read);
+
+        return String::from_utf8(bytes)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err));
+    }
+
+    let path = Path::new(object.source.0.as_ref());
+    let mut reader = DirReader::open(path)?;
+    let mut bytes = vec![0; reader.len() as usize];
+    let bytes_read = reader.read_at(0, &mut bytes)?;
+    bytes.truncate(bytes_read);
+
+    String::from_utf8(bytes).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+}
+
+fn resolve_relative_source(object: &SourceObject, referenced_path: &Path) -> SourceRef {
+    if let Some((archive_path, entry_name)) = parse_zip_source(object) {
+        let entry_path = Path::new(&entry_name);
+        let base_dir = entry_path.parent().unwrap_or_else(|| Path::new(""));
+        let resolved = normalize_virtual_path(base_dir.join(referenced_path));
+
+        return SourceRef::new(format!("zip:{archive_path}#{resolved}"));
+    }
+
+    let cue_path = Path::new(object.source.0.as_ref());
+    let base_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
+    let resolved = base_dir.join(referenced_path);
+
+    SourceRef::new(resolved.to_string_lossy().into_owned())
+}
+
+fn normalize_virtual_path(path: PathBuf) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 fn looks_like_rom_name(name: &str) -> bool {
@@ -194,6 +255,94 @@ mod tests {
         match &content[0] {
             Content::Rom(rom) => assert_eq!(rom.size, 7),
             other => panic!("expected Rom content, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disc_content_tracks_consumed_sources_for_filesystem_cue() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cue_path = temp_dir.path().join("game.cue");
+        let bin_path = temp_dir.path().join("game.bin");
+
+        fs::write(&bin_path, b"discdata").unwrap();
+        fs::write(
+            &cue_path,
+            r#"
+    FILE "game.bin" BINARY
+    TRACK 01 MODE2/2352
+        INDEX 01 00:00:00
+    "#,
+        )
+        .unwrap();
+
+        let decoder = BasicInputDecoder::new();
+        let object = SourceObject {
+            source: SourceRef::new(cue_path.to_string_lossy().into_owned()),
+            name: "game.cue".to_string(),
+        };
+
+        let content = decoder.decode(&object, &InputIdentity::DiscImage).unwrap();
+        assert_eq!(content.len(), 1);
+
+        match &content[0] {
+            Content::Disc(disc) => {
+                assert_eq!(disc.consumed_sources.len(), 1);
+                assert_eq!(
+                    disc.consumed_sources[0].to_string(),
+                    bin_path.to_string_lossy()
+                );
+            }
+            other => panic!("expected Disc content, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disc_content_tracks_consumed_sources_for_zip_cue() {
+        use std::fs::File;
+        use std::io::Write;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("test.zip");
+
+        {
+            let file = File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+
+            zip.start_file("ps1/game.bin", options).unwrap();
+            zip.write_all(b"discdata").unwrap();
+
+            zip.start_file("ps1/game.cue", options).unwrap();
+            zip.write_all(
+                br#"
+    FILE "game.bin" BINARY
+    TRACK 01 MODE2/2352
+        INDEX 01 00:00:00
+    "#,
+            )
+            .unwrap();
+
+            zip.finish().unwrap();
+        }
+
+        let decoder = BasicInputDecoder::new();
+        let object = SourceObject {
+            source: SourceRef::new(format!("zip:{}#ps1/game.cue", zip_path.to_string_lossy())),
+            name: "ps1/game.cue".to_string(),
+        };
+
+        let content = decoder.decode(&object, &InputIdentity::DiscImage).unwrap();
+        assert_eq!(content.len(), 1);
+
+        match &content[0] {
+            Content::Disc(disc) => {
+                assert_eq!(disc.consumed_sources.len(), 1);
+                assert_eq!(
+                    disc.consumed_sources[0].to_string(),
+                    format!("zip:{}#ps1/game.bin", zip_path.to_string_lossy())
+                );
+            }
+            other => panic!("expected Disc content, got {other:?}"),
         }
     }
 }

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -86,6 +86,7 @@ mod tests {
             source: SourceRef::new("cue:/roms/ff7.cue"),
             title: "Final Fantasy VII".to_string(),
             disc_number: 1,
+            consumed_sources: vec![SourceRef::new("cue:/roms/ff7.bin")],
         });
 
         let encoded = encoder.encode(&content).unwrap();

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -65,11 +65,12 @@ mod tests {
                 size: 1024,
             }),
             Content::Disc(DiscContent {
-                id: ContentId::new("mgs-disc1"),
-                source: SourceRef::new("cue:/roms/mgs.cue"),
-                title: "Metal Gear Solid".to_string(),
+                id: ContentId::new("ff7-disc1"),
+                source: SourceRef::new("cue:/roms/ff7.cue"),
+                title: "Final Fantasy VII".to_string(),
                 disc_number: 1,
-            }),
+                consumed_sources: vec![SourceRef::new("cue:/roms/ff7.bin")],
+            })
             Content::Text(TextContent {
                 id: ContentId::new("manifest"),
                 source: SourceRef::new("file:/roms/manifest"),

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -70,7 +70,7 @@ mod tests {
                 title: "Final Fantasy VII".to_string(),
                 disc_number: 1,
                 consumed_sources: vec![SourceRef::new("cue:/roms/ff7.bin")],
-            })
+            }),
             Content::Text(TextContent {
                 id: ContentId::new("manifest"),
                 source: SourceRef::new("file:/roms/manifest"),

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -89,7 +89,7 @@ mod tests {
             vec![
                 "bios.bin",
                 "Sonic the Hedgehog.bin",
-                "Metal Gear Solid (Disc 1).cue",
+                "Final Fantasy VII (Disc 1).cue",
                 "manifest.txt",
             ]
         );


### PR DESCRIPTION
## Summary

This PR introduces consumed-source tracking for decoded content and uses it to suppress backing files from standalone presented output.

The immediate goal is to handle CUE/BIN disc images more cleanly: a `.cue` file should present as the logical disc image, while its referenced `.bin` track files should remain available as backing data rather than surfacing as separate top-level ROM entries.

## What’s changed

### Consumed-source tracking on decoded content

- Adds `consumed_sources` support to decoded content
- `DiscContent` now records the backing sources it depends on
- `Content` exposes a generic `consumed_sources()` helper for pipeline use

### CUE decoding now records referenced track files

- When decoding a `.cue`, the decoder now parses the CUE contents
- Referenced files are resolved to concrete `SourceRef` values
- Works for both filesystem-backed CUE files and ZIP-backed CUE files

### Pipeline suppresses consumed sources from presentation

- Before presentation, the pipeline now builds a set of consumed sources
- Any decoded content whose primary source is consumed by another decoded object is suppressed from standalone presentation
- This currently affects CUE/BIN sets by hiding the `.bin` files from presented output

## Why this matters

This introduces an important modelling concept for Retromount:

- some decoded content is composite
- composite content can consume additional sources
- consumed sources should not appear as peer user-facing items
- but they must remain available to the content object and future encoder logic

This is a better fit for disc images than treating `.cue` and `.bin` as unrelated standalone objects.

## Example

Before:

```text
Presented VFS:
/
  discs/ps1_multi/game_disc1.bin
  game_disc1 (Disc 1).cue
  discs/ps1_multi/game_disc2.bin
  game_disc2 (Disc 1).cue
  discs/ps1_single/game.bin
  game (Disc 1).cue
```

After:

```text
Presented VFS:
/
  game_disc1 (Disc 1).cue
  game_disc2 (Disc 1).cue
  game (Disc 1).cue
```

## Scope

This PR changes presentation behaviour only.

It does **not** remove backing files from discovery or decoding. They still exist in the decoded model and remain available as dependencies of the disc content that consumes them.

## Tests

Added coverage for:

- consumed-source access on `Content`
- tracking consumed sources for filesystem-backed CUE files
- tracking consumed sources for ZIP-backed CUE files
- suppressing disc backing files from presented output

Validated with real test data using:

```bash
cargo run -- inspect ./retromount-testdata
cargo run -- inspect ./retromount-testdata/discs/ps1_single
cargo run -- inspect ./retromount-testdata/discs/ps1_multi
cargo run -- inspect ./retromount-testdata/zips_ps1/ps1_game.zip
```

## Next steps

Planned follow-up work:

- Improve disc title parsing
- Improve disc number detection
- Group multi-disc sets more intelligently
- Consider extending consumed-source modelling to other composite formats