### PR TITLE
ci: remove Node 20 action dependency and optimise Rust workflow performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
           RUSTC_WRAPPER: sccache
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
+      - name: Upload Linux debug target artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: target-debug-linux
+          path: target
+          if-no-files-found: error
+          retention-days: 1
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats
@@ -95,6 +103,13 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
+
+      - name: Download Linux debug target artifacts
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/download-artifact@v7
+        with:
+          name: target-debug-linux
+          path: target
 
       - name: Run tests
         env:
@@ -142,6 +157,14 @@ jobs:
           RUSTC_WRAPPER: sccache
         run: cargo build --locked --release --all-features --verbose
 
+      - name: Upload Linux release target artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: target-release-linux
+          path: target
+          if-no-files-found: error
+          retention-days: 1
+
       - name: sccache stats
         if: always()
         run: sccache --show-stats
@@ -186,10 +209,11 @@ jobs:
           version: "^2"
           locked: true
 
-      - name: Build release binary
-        env:
-          RUSTC_WRAPPER: sccache
-        run: cargo build --locked --release --all-features --verbose
+      - name: Download Linux release target artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: target-release-linux
+          path: target
 
       - name: Build Debian package
         env:
@@ -206,4 +230,3 @@ jobs:
       - name: sccache stats
         if: always()
         run: sccache --show-stats
-        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: v0.10.0
 
@@ -63,7 +66,7 @@ jobs:
           toolchain: stable
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: v0.10.0
 
@@ -100,7 +103,7 @@ jobs:
           toolchain: stable
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: v0.10.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: sccache
-          version: "^0.10"
+          version: "0.14.0"
           locked: true
 
       - name: Configure sccache
@@ -86,7 +86,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: sccache
-          version: "^0.10"
+          version: "0.14.0"
           locked: true
 
       - name: Configure sccache
@@ -127,7 +127,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: sccache
-          version: "^0.10"
+          version: "0.14.0"
           locked: true
 
       - name: Configure sccache
@@ -169,7 +169,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: sccache
-          version: "^0.10"
+          version: "0.14.0"
           locked: true
 
       - name: Configure sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,12 @@ jobs:
         with:
           shared-key: "retromount-lint"
 
-      - name: Ensure sccache is installed
-        run: |
-          if ! command -v sccache >/dev/null 2>&1; then
-            cargo install sccache --locked
-          fi
+      - name: Install sccache
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: sccache
+          version: "^0.10"
+          locked: true
 
       - name: Configure sccache
         uses: actions/github-script@v8
@@ -81,12 +82,12 @@ jobs:
         with:
           shared-key: "retromount-test-${{ matrix.os }}"
 
-      - name: Ensure sccache is installed
-        shell: bash
-        run: |
-          if ! command -v sccache >/dev/null 2>&1; then
-            cargo install sccache --locked
-          fi
+      - name: Install sccache
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: sccache
+          version: "^0.10"
+          locked: true
 
       - name: Configure sccache
         uses: actions/github-script@v8
@@ -122,11 +123,12 @@ jobs:
         with:
           shared-key: "retromount-release-linux"
 
-      - name: Ensure sccache is installed
-        run: |
-          if ! command -v sccache >/dev/null 2>&1; then
-            cargo install sccache --locked
-          fi
+      - name: Install sccache
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: sccache
+          version: "^0.10"
+          locked: true
 
       - name: Configure sccache
         uses: actions/github-script@v8
@@ -163,11 +165,12 @@ jobs:
         with:
           shared-key: "retromount-package-deb"
 
-      - name: Ensure sccache is installed
-        run: |
-          if ! command -v sccache >/dev/null 2>&1; then
-            cargo install sccache --locked
-          fi
+      - name: Install sccache
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: sccache
+          version: "^0.10"
+          locked: true
 
       - name: Configure sccache
         uses: actions/github-script@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,6 @@ jobs:
           RUSTC_WRAPPER: sccache
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
-      - name: Upload Linux debug target artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: target-debug-linux
-          path: target
-          if-no-files-found: error
-          retention-days: 1
-
       - name: sccache stats
         if: always()
         run: sccache --show-stats
@@ -103,13 +95,6 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
-
-      - name: Download Linux debug target artifacts
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/download-artifact@v7
-        with:
-          name: target-debug-linux
-          path: target
 
       - name: Run tests
         env:
@@ -230,3 +215,4 @@ jobs:
       - name: sccache stats
         if: always()
         run: sccache --show-stats
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,23 +77,16 @@ jobs:
             cargo install sccache --locked
           fi
 
-      - name: Build (debug)
-        run: cargo build --locked --all-targets --all-features --verbose
-
       - name: Run tests
         run: cargo test --locked --all-targets --all-features --verbose
-
-      - name: Build (release)
-        run: cargo build --locked --release --all-targets --all-features --verbose
 
       - name: sccache stats
         if: always()
         run: sccache --show-stats
 
-  package-deb:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  build-release-linux:
+    needs: lint
     runs-on: ubuntu-latest
-    needs: test
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
@@ -107,7 +100,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: "retromount-release"
+          shared-key: "retromount-release-linux"
 
       - name: Ensure sccache is installed
         run: |
@@ -115,8 +108,44 @@ jobs:
             cargo install sccache --locked
           fi
 
-      - name: Install packaging dependencies
-        run: cargo install cargo-deb --locked
+      - name: Build release binary
+        run: cargo build --locked --release --all-features --verbose
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
+
+  package-deb:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test, build-release-linux]
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: "retromount-package-deb"
+
+      - name: Ensure sccache is installed
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            cargo install sccache --locked
+          fi
+
+      - name: Install cargo-deb
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deb
+          version: "^2"
+          locked: true
 
       - name: Build release binary
         run: cargo build --locked --release --all-features --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,18 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_ENABLED: "on"
+      SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           shared-key: "retromount-lint"
 
@@ -35,6 +36,13 @@ jobs:
           if ! command -v sccache >/dev/null 2>&1; then
             cargo install sccache --locked
           fi
+
+      - name: Configure sccache
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
       - name: Check formatting
         env:
@@ -54,7 +62,8 @@ jobs:
     needs: lint
     runs-on: ${{ matrix.os }}
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_ENABLED: "on"
+      SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
     strategy:
       fail-fast: false
@@ -64,11 +73,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           shared-key: "retromount-test-${{ matrix.os }}"
 
@@ -78,6 +87,13 @@ jobs:
           if ! command -v sccache >/dev/null 2>&1; then
             cargo install sccache --locked
           fi
+
+      - name: Configure sccache
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
       - name: Run tests
         env:
@@ -92,16 +108,17 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_ENABLED: "on"
+      SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           shared-key: "retromount-release-linux"
 
@@ -110,6 +127,13 @@ jobs:
           if ! command -v sccache >/dev/null 2>&1; then
             cargo install sccache --locked
           fi
+
+      - name: Configure sccache
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
       - name: Build release binary
         env:
@@ -125,16 +149,17 @@ jobs:
     needs: [test, build-release-linux]
     runs-on: ubuntu-latest
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_ENABLED: "on"
+      SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           shared-key: "retromount-package-deb"
 
@@ -143,6 +168,13 @@ jobs:
           if ! command -v sccache >/dev/null 2>&1; then
             cargo install sccache --locked
           fi
+
+      - name: Configure sccache
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
       - name: Install cargo-deb
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,15 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: v0.10.0
-
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: "retromount-lint"
+
+      - name: Ensure sccache is installed
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            cargo install sccache --locked
+          fi
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -65,14 +66,16 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: v0.10.0
-
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: "retromount-test-${{ matrix.os }}"
+
+      - name: Ensure sccache is installed
+        shell: bash
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            cargo install sccache --locked
+          fi
 
       - name: Build (debug)
         run: cargo build --locked --all-targets --all-features --verbose
@@ -102,14 +105,15 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: v0.10.0
-
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: "retromount-release"
+
+      - name: Ensure sccache is installed
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            cargo install sccache --locked
+          fi
 
       - name: Install packaging dependencies
         run: cargo install cargo-deb --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
 
     steps:
@@ -38,9 +37,13 @@ jobs:
           fi
 
       - name: Check formatting
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo fmt --all -- --check
 
       - name: Lint with Clippy
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
       - name: sccache stats
@@ -51,7 +54,6 @@ jobs:
     needs: lint
     runs-on: ${{ matrix.os }}
     env:
-      RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
 
     strategy:
@@ -78,6 +80,8 @@ jobs:
           fi
 
       - name: Run tests
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo test --locked --all-targets --all-features --verbose
 
       - name: sccache stats
@@ -88,7 +92,6 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     env:
-      RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
 
     steps:
@@ -109,6 +112,8 @@ jobs:
           fi
 
       - name: Build release binary
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo build --locked --release --all-features --verbose
 
       - name: sccache stats
@@ -120,7 +125,6 @@ jobs:
     needs: [test, build-release-linux]
     runs-on: ubuntu-latest
     env:
-      RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
 
     steps:
@@ -148,9 +152,13 @@ jobs:
           locked: true
 
       - name: Build release binary
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo build --locked --release --all-features --verbose
 
       - name: Build Debian package
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo deb --no-build
 
       - name: Upload Debian artifact

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,5 +62,5 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:${{ matrix.language }}"
           

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,9 @@ on:
   schedule:
     - cron: '36 0 * * 0'  # Weekly at 00:36 UTC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -60,3 +63,4 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     env:
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_ENABLED: "on"
+      SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           shared-key: "retromount-release"
 
@@ -37,6 +38,13 @@ jobs:
           if ! command -v sccache >/dev/null 2>&1; then
             cargo install sccache --locked
           fi
+
+      - name: Configure sccache
+        uses: actions/github-script@v8
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
 
       - name: Install cargo-deb
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
           toolchain: stable
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: v0.10.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,15 @@ jobs:
             cargo install sccache --locked
           fi
 
+      - name: Install cargo-deb
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deb
+          version: "^2"
+          locked: true
+
       - name: Build release
         run: cargo build --locked --release --all-features --verbose
-
-      - name: Install packaging dependencies
-        run: cargo install cargo-deb --locked
 
       - name: Build Debian package
         run: cargo deb --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,15 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: v0.10.0
-
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: "retromount-release"
+
+      - name: Ensure sccache is installed
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            cargo install sccache --locked
+          fi
 
       - name: Build release
         run: cargo build --locked --release --all-features --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     env:
-      RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
 
     steps:
@@ -47,9 +46,13 @@ jobs:
           locked: true
 
       - name: Build release
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo build --locked --release --all-features --verbose
 
       - name: Build Debian package
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo deb --no-build
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

This PR modernises and streamlines the GitHub Actions setup for Retromount.

The main driver was the GitHub Actions Node.js 20 deprecation warning, which was being triggered by `mozilla-actions/sccache-action`. Rather than waiting on an upstream fix, this PR removes that dependency entirely and replaces it with a native `sccache` setup.

While making that change, the CI workflows were also cleaned up to reduce redundant work and improve overall execution time.

---

## What changed

### Removed Node 20-based action dependency
- removed `mozilla-actions/sccache-action`
- opted workflows into Node 24 execution with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"`
- avoids future breakage from GitHub Actions Node 20 retirement

### Replaced action-managed sccache with native setup
- install `sccache` directly with Cargo when not already present
- fixed bootstrap ordering so `RUSTC_WRAPPER=sccache` is only applied to actual build/test/lint steps, not to the `cargo install sccache` step itself
- configured the GitHub Actions sccache backend explicitly
- added `SCCACHE_IGNORE_SERVER_IO_ERROR=1` so CI falls back to normal compilation if the cache backend has problems

### Kept Rust dependency/build caching
- retained `Swatinem/rust-cache`
- continued using shared cache keys per workflow/job purpose

### Reduced redundant CI work
- simplified the test matrix so it runs tests only
- moved Linux release build validation into a dedicated job
- avoided unnecessary Windows release builds in the main CI path
- updated Debian packaging to depend only on the jobs it actually needs

### Improved packaging workflow efficiency
- switched `cargo-deb` installation to a cached cargo-install action rather than reinstalling it from scratch every run

---

## Why this is better

- removes reliance on an aging JavaScript action that is still tied to Node 20
- makes the Rust build cache path more transparent and under our control
- reduces duplicate build work in CI
- shortens the critical path for Linux packaging jobs
- keeps CI resilient if the sccache backend has a transient issue

---

## Notes

- the first run after this change may take longer because `sccache` is compiled from source during bootstrap
- subsequent runs should be faster once the Cargo/Rust caches are warm
- no functional Rust code changes are included in this PR; this is CI/workflow maintenance only

---

## Validation

This PR was validated by:
- confirming workflows no longer depend on `mozilla-actions/sccache-action`
- confirming the Node 20 warning path is removed from our workflow definitions
- verifying the updated CI configuration runs green with the native `sccache` setup