### PR TITLE
Phase 3: group multi-disc sets in presented VFS

### DIFF
--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeMap, HashSet};
+
 use crate::core::content::Content;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::encode::OutputEncoder;
@@ -17,6 +19,17 @@ where
     pub fn new(encoder: E) -> Self {
         Self { encoder }
     }
+
+    fn present_file(&self, content: &Content) -> Option<VfsNode> {
+        if !self.encoder.can_encode(content) {
+            return None;
+        }
+
+        self.encoder
+            .encode(content)
+            .ok()
+            .map(|encoded| VfsNode::File(VfsFile::new(encoded.name, encoded.size)))
+    }
 }
 
 impl<E> OutputPresenter for GenericPresenter<E>
@@ -24,16 +37,59 @@ where
     E: OutputEncoder + Send + Sync,
 {
     fn present(&self, content: &[Content]) -> VfsDirectory {
-        let children = content
-            .iter()
-            .filter(|item| self.encoder.can_encode(item))
-            .filter_map(|item| {
-                self.encoder
-                    .encode(item)
-                    .ok()
-                    .map(|encoded| VfsNode::File(VfsFile::new(encoded.name, encoded.size)))
-            })
-            .collect();
+        let mut multi_disc_titles = HashSet::new();
+        let mut discs_by_title: BTreeMap<String, Vec<&Content>> = BTreeMap::new();
+
+        for item in content {
+            if let Content::Disc(disc) = item {
+                discs_by_title
+                    .entry(disc.title.clone())
+                    .or_default()
+                    .push(item);
+            }
+        }
+
+        for (title, discs) in &discs_by_title {
+            if discs.len() > 1 {
+                multi_disc_titles.insert(title.clone());
+            }
+        }
+
+        let mut emitted_groups = HashSet::new();
+        let mut children = Vec::new();
+
+        for item in content {
+            match item {
+                Content::Disc(disc) if multi_disc_titles.contains(&disc.title) => {
+                    if !emitted_groups.insert(disc.title.clone()) {
+                        continue;
+                    }
+
+                    let mut grouped_discs =
+                        discs_by_title.get(&disc.title).cloned().unwrap_or_default();
+
+                    grouped_discs.sort_by_key(|candidate| match candidate {
+                        Content::Disc(grouped_disc) => grouped_disc.disc_number,
+                        _ => 0,
+                    });
+
+                    let grouped_children = grouped_discs
+                        .into_iter()
+                        .filter_map(|candidate| self.present_file(candidate))
+                        .collect();
+
+                    children.push(VfsNode::Directory(VfsDirectory::with_children(
+                        &disc.title,
+                        grouped_children,
+                    )));
+                }
+                _ => {
+                    if let Some(node) = self.present_file(item) {
+                        children.push(node);
+                    }
+                }
+            }
+        }
 
         VfsDirectory::with_children("", children)
     }
@@ -93,5 +149,91 @@ mod tests {
                 "manifest.txt",
             ]
         );
+    }
+
+    #[test]
+    fn groups_multi_disc_content_into_directory() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![
+            Content::Disc(DiscContent {
+                id: ContentId::new("game-disc2"),
+                source: SourceRef::new("cue:/roms/game_disc2.cue"),
+                title: "game".to_string(),
+                disc_number: 2,
+                consumed_sources: vec![SourceRef::new("cue:/roms/game_disc2.bin")],
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("game-disc1"),
+                source: SourceRef::new("cue:/roms/game_disc1.cue"),
+                title: "game".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("cue:/roms/game_disc1.bin")],
+            }),
+        ];
+
+        let root = presenter.present(&content);
+
+        assert_eq!(root.children.len(), 1);
+
+        match &root.children[0] {
+            VfsNode::Directory(dir) => {
+                assert_eq!(dir.name, "game");
+                assert_eq!(dir.children.len(), 2);
+
+                let names: Vec<&str> = dir.children.iter().map(|node| node.name()).collect();
+                assert_eq!(names, vec!["game (Disc 1).cue", "game (Disc 2).cue"]);
+            }
+            other => panic!("expected grouped directory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preserves_mixed_root_content_around_grouped_multi_disc_set() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![
+            Content::Rom(RomContent {
+                id: ContentId::new("sonic"),
+                source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
+                file_name: "Sonic the Hedgehog.bin".to_string(),
+                size: 1024,
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("game-disc1"),
+                source: SourceRef::new("cue:/roms/game_disc1.cue"),
+                title: "game".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("cue:/roms/game_disc1.bin")],
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("game-disc2"),
+                source: SourceRef::new("cue:/roms/game_disc2.cue"),
+                title: "game".to_string(),
+                disc_number: 2,
+                consumed_sources: vec![SourceRef::new("cue:/roms/game_disc2.bin")],
+            }),
+            Content::Text(TextContent {
+                id: ContentId::new("manifest"),
+                source: SourceRef::new("file:/roms/manifest"),
+                size: 64,
+            }),
+        ];
+
+        let root = presenter.present(&content);
+
+        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
+        assert_eq!(
+            names,
+            vec!["Sonic the Hedgehog.bin", "game", "manifest.txt"]
+        );
+
+        match &root.children[1] {
+            VfsNode::Directory(dir) => {
+                let child_names: Vec<&str> = dir.children.iter().map(|node| node.name()).collect();
+                assert_eq!(child_names, vec!["game (Disc 1).cue", "game (Disc 2).cue"]);
+            }
+            other => panic!("expected grouped directory, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR updates the generic presenter to group multi-disc sets into directories in the presented VFS.

Previously, discs with the same title were still presented as separate root-level files:

```text
/
  game (Disc 1).cue
  game (Disc 2).cue
```

After this change, multi-disc sets are grouped into a directory named after the shared title:

```text
/
  game/
    game (Disc 1).cue
    game (Disc 2).cue
```

Single-disc titles remain unchanged and continue to appear at the root.

## What’s changed

### Multi-disc grouping in the presenter

- Disc content is grouped by decoded disc title
- When more than one disc shares the same title, the presenter creates a directory for that title
- The grouped discs are emitted as child files within that directory

### Stable disc ordering

- Grouped discs are sorted by `disc_number`
- Ensures predictable ordering such as:
  - `Disc 1`
  - `Disc 2`

### Existing root content preserved

- Non-disc content continues to appear at the root
- Single-disc content also remains at the root
- Mixed content is preserved around grouped multi-disc sets

## Why this matters

This is the first step toward treating multi-disc titles as a logical set rather than as unrelated standalone files.

It improves:

- readability of presented output
- consistency for multi-disc titles
- the foundation for later playlist or output-specific handling

## Example

Before:

```text
Presented VFS:
/
  game (Disc 1).cue
  game (Disc 2).cue
```

After:

```text
Presented VFS:
/
  game/
    game (Disc 1).cue
    game (Disc 2).cue
```

## Tests

Added presenter coverage for:

- leaving mixed single-disc content at the root
- grouping multi-disc sets into a directory
- preserving mixed root content around grouped multi-disc sets

Validated with:

```bash
cargo test
cargo run -- inspect ./retromount-testdata/discs/ps1_multi
```

## Notes

This PR changes presentation only. It does not yet generate playlists such as `.m3u`, and it does not introduce output-specific multi-disc rules.