### PR TITLE
feat(phase3): generate m3u playlists for multi-disc sets

### DIFF
--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -41,6 +41,7 @@ impl VfsDirectory {
 pub struct VfsFile {
     pub name: String,
     pub size: u64,
+    pub contents: Option<Vec<u8>>,
 }
 
 impl VfsFile {
@@ -48,6 +49,15 @@ impl VfsFile {
         Self {
             name: name.into(),
             size,
+            contents: None,
+        }
+    }
+
+    pub fn with_contents(name: impl Into<String>, contents: Vec<u8>) -> Self {
+        Self {
+            name: name.into(),
+            size: contents.len() as u64,
+            contents: Some(contents),
         }
     }
 }
@@ -75,5 +85,14 @@ mod tests {
             }
             _ => panic!("expected directory"),
         }
+    }
+
+    #[test]
+    fn builds_virtual_file_with_inline_contents() {
+        let file = VfsFile::with_contents("game.m3u", b"game (Disc 1).cue\n".to_vec());
+
+        assert_eq!(file.name, "game.m3u");
+        assert_eq!(file.size, 18);
+        assert_eq!(file.contents, Some(b"game (Disc 1).cue\n".to_vec()));
     }
 }

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,8 +1,8 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 use crate::core::content::Content;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
-use crate::output::encode::OutputEncoder;
+use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
 
 pub struct GenericPresenter<E>
@@ -10,6 +10,12 @@ where
     E: OutputEncoder,
 {
     encoder: E,
+}
+
+#[derive(Debug, Clone)]
+struct PresentedEntry {
+    content: Content,
+    encoded: EncodedFile,
 }
 
 impl<E> GenericPresenter<E>
@@ -20,15 +26,96 @@ where
         Self { encoder }
     }
 
-    fn present_file(&self, content: &Content) -> Option<VfsNode> {
-        if !self.encoder.can_encode(content) {
-            return None;
+    fn encode_entries(&self, content: &[Content]) -> Vec<PresentedEntry> {
+        content
+            .iter()
+            .filter(|item| self.encoder.can_encode(item))
+            .filter_map(|item| {
+                self.encoder
+                    .encode(item)
+                    .ok()
+                    .map(|encoded| PresentedEntry {
+                        content: item.clone(),
+                        encoded,
+                    })
+            })
+            .collect()
+    }
+
+    fn build_root_children(&self, entries: &[PresentedEntry]) -> Vec<VfsNode> {
+        let multi_disc_titles = self.multi_disc_titles(entries);
+        let mut emitted_groups = HashSet::new();
+        let mut children = Vec::new();
+
+        for entry in entries {
+            match &entry.content {
+                Content::Disc(disc) if multi_disc_titles.contains(&disc.title) => {
+                    if emitted_groups.insert(disc.title.clone()) {
+                        children.push(VfsNode::Directory(
+                            self.build_multi_disc_directory(&disc.title, entries),
+                        ));
+                    }
+                }
+                _ => children.push(VfsNode::File(VfsFile::new(
+                    entry.encoded.name.clone(),
+                    entry.encoded.size,
+                ))),
+            }
         }
 
-        self.encoder
-            .encode(content)
-            .ok()
-            .map(|encoded| VfsNode::File(VfsFile::new(encoded.name, encoded.size)))
+        children
+    }
+
+    fn multi_disc_titles(&self, entries: &[PresentedEntry]) -> HashSet<String> {
+        let mut disc_counts = HashMap::new();
+
+        for entry in entries {
+            if let Content::Disc(disc) = &entry.content {
+                *disc_counts.entry(disc.title.clone()).or_insert(0usize) += 1;
+            }
+        }
+
+        disc_counts
+            .into_iter()
+            .filter_map(|(title, count)| (count > 1).then_some(title))
+            .collect()
+    }
+
+    fn build_multi_disc_directory(&self, title: &str, entries: &[PresentedEntry]) -> VfsDirectory {
+        let mut disc_entries: Vec<_> = entries
+            .iter()
+            .filter_map(|entry| match &entry.content {
+                Content::Disc(disc) if disc.title == title => Some((disc.disc_number, entry)),
+                _ => None,
+            })
+            .collect();
+
+        disc_entries.sort_by(|(left_disc, left_entry), (right_disc, right_entry)| {
+            left_disc
+                .cmp(right_disc)
+                .then_with(|| left_entry.encoded.name.cmp(&right_entry.encoded.name))
+        });
+
+        let disc_file_names: Vec<String> = disc_entries
+            .iter()
+            .map(|(_, entry)| entry.encoded.name.clone())
+            .collect();
+
+        let mut children: Vec<VfsNode> = disc_entries
+            .into_iter()
+            .map(|(_, entry)| {
+                VfsNode::File(VfsFile::new(entry.encoded.name.clone(), entry.encoded.size))
+            })
+            .collect();
+
+        children.push(VfsNode::File(self.build_m3u_file(title, &disc_file_names)));
+
+        VfsDirectory::with_children(title, children)
+    }
+
+    fn build_m3u_file(&self, title: &str, disc_file_names: &[String]) -> VfsFile {
+        let playlist = disc_file_names.join("\n") + "\n";
+        VfsFile::with_contents(format!("{title}.m3u"), playlist.into_bytes())
     }
 }
 
@@ -37,59 +124,8 @@ where
     E: OutputEncoder + Send + Sync,
 {
     fn present(&self, content: &[Content]) -> VfsDirectory {
-        let mut multi_disc_titles = HashSet::new();
-        let mut discs_by_title: BTreeMap<String, Vec<&Content>> = BTreeMap::new();
-
-        for item in content {
-            if let Content::Disc(disc) = item {
-                discs_by_title
-                    .entry(disc.title.clone())
-                    .or_default()
-                    .push(item);
-            }
-        }
-
-        for (title, discs) in &discs_by_title {
-            if discs.len() > 1 {
-                multi_disc_titles.insert(title.clone());
-            }
-        }
-
-        let mut emitted_groups = HashSet::new();
-        let mut children = Vec::new();
-
-        for item in content {
-            match item {
-                Content::Disc(disc) if multi_disc_titles.contains(&disc.title) => {
-                    if !emitted_groups.insert(disc.title.clone()) {
-                        continue;
-                    }
-
-                    let mut grouped_discs =
-                        discs_by_title.get(&disc.title).cloned().unwrap_or_default();
-
-                    grouped_discs.sort_by_key(|candidate| match candidate {
-                        Content::Disc(grouped_disc) => grouped_disc.disc_number,
-                        _ => 0,
-                    });
-
-                    let grouped_children = grouped_discs
-                        .into_iter()
-                        .filter_map(|candidate| self.present_file(candidate))
-                        .collect();
-
-                    children.push(VfsNode::Directory(VfsDirectory::with_children(
-                        &disc.title,
-                        grouped_children,
-                    )));
-                }
-                _ => {
-                    if let Some(node) = self.present_file(item) {
-                        children.push(node);
-                    }
-                }
-            }
-        }
+        let entries = self.encode_entries(content);
+        let children = self.build_root_children(&entries);
 
         VfsDirectory::with_children("", children)
     }
@@ -152,88 +188,79 @@ mod tests {
     }
 
     #[test]
-    fn groups_multi_disc_content_into_directory() {
-        let presenter = GenericPresenter::new(BasicEncoder::new());
-
-        let content = vec![
-            Content::Disc(DiscContent {
-                id: ContentId::new("game-disc2"),
-                source: SourceRef::new("cue:/roms/game_disc2.cue"),
-                title: "game".to_string(),
-                disc_number: 2,
-                consumed_sources: vec![SourceRef::new("cue:/roms/game_disc2.bin")],
-            }),
-            Content::Disc(DiscContent {
-                id: ContentId::new("game-disc1"),
-                source: SourceRef::new("cue:/roms/game_disc1.cue"),
-                title: "game".to_string(),
-                disc_number: 1,
-                consumed_sources: vec![SourceRef::new("cue:/roms/game_disc1.bin")],
-            }),
-        ];
-
-        let root = presenter.present(&content);
-
-        assert_eq!(root.children.len(), 1);
-
-        match &root.children[0] {
-            VfsNode::Directory(dir) => {
-                assert_eq!(dir.name, "game");
-                assert_eq!(dir.children.len(), 2);
-
-                let names: Vec<&str> = dir.children.iter().map(|node| node.name()).collect();
-                assert_eq!(names, vec!["game (Disc 1).cue", "game (Disc 2).cue"]);
-            }
-            other => panic!("expected grouped directory, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn preserves_mixed_root_content_around_grouped_multi_disc_set() {
+    fn groups_multi_disc_sets_and_generates_playlist() {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![
             Content::Rom(RomContent {
-                id: ContentId::new("sonic"),
-                source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
-                file_name: "Sonic the Hedgehog.bin".to_string(),
+                id: ContentId::new("crash-bandicoot"),
+                source: SourceRef::new("file:/roms/Crash Bandicoot.bin"),
+                file_name: "Crash Bandicoot.bin".to_string(),
                 size: 1024,
             }),
             Content::Disc(DiscContent {
-                id: ContentId::new("game-disc1"),
-                source: SourceRef::new("cue:/roms/game_disc1.cue"),
-                title: "game".to_string(),
-                disc_number: 1,
-                consumed_sources: vec![SourceRef::new("cue:/roms/game_disc1.bin")],
+                id: ContentId::new("ff7-disc2"),
+                source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+                title: "Final Fantasy VII".to_string(),
+                disc_number: 2,
+                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
             }),
             Content::Disc(DiscContent {
-                id: ContentId::new("game-disc2"),
-                source: SourceRef::new("cue:/roms/game_disc2.cue"),
-                title: "game".to_string(),
-                disc_number: 2,
-                consumed_sources: vec![SourceRef::new("cue:/roms/game_disc2.bin")],
-            }),
-            Content::Text(TextContent {
-                id: ContentId::new("manifest"),
-                source: SourceRef::new("file:/roms/manifest"),
-                size: 64,
+                id: ContentId::new("ff7-disc1"),
+                source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+                title: "Final Fantasy VII".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
             }),
         ];
 
         let root = presenter.present(&content);
 
-        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
+        assert_eq!(root.children.len(), 2);
+        assert_eq!(root.children[0].name(), "Crash Bandicoot.bin");
+        assert_eq!(root.children[1].name(), "Final Fantasy VII");
+
+        let directory = match &root.children[1] {
+            VfsNode::Directory(directory) => directory,
+            other => panic!("expected directory, got {other:?}"),
+        };
+
+        let child_names: Vec<&str> = directory.children.iter().map(|node| node.name()).collect();
         assert_eq!(
-            names,
-            vec!["Sonic the Hedgehog.bin", "game", "manifest.txt"]
+            child_names,
+            vec![
+                "Final Fantasy VII (Disc 1).cue",
+                "Final Fantasy VII (Disc 2).cue",
+                "Final Fantasy VII.m3u",
+            ]
         );
 
-        match &root.children[1] {
-            VfsNode::Directory(dir) => {
-                let child_names: Vec<&str> = dir.children.iter().map(|node| node.name()).collect();
-                assert_eq!(child_names, vec!["game (Disc 1).cue", "game (Disc 2).cue"]);
-            }
-            other => panic!("expected grouped directory, got {other:?}"),
-        }
+        let playlist = match &directory.children[2] {
+            VfsNode::File(file) => file,
+            other => panic!("expected file, got {other:?}"),
+        };
+
+        assert_eq!(
+            playlist.contents,
+            Some(b"Final Fantasy VII (Disc 1).cue\nFinal Fantasy VII (Disc 2).cue\n".to_vec())
+        );
+    }
+
+    #[test]
+    fn does_not_generate_playlist_for_single_disc_title() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![Content::Disc(DiscContent {
+            id: ContentId::new("metal-gear-solid"),
+            source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
+            title: "Metal Gear Solid".to_string(),
+            disc_number: 1,
+            consumed_sources: vec![SourceRef::new("cue:/roms/mgs-disc1.bin")],
+        })];
+
+        let root = presenter.present(&content);
+
+        assert_eq!(root.children.len(), 1);
+        assert_eq!(root.children[0].name(), "Metal Gear Solid (Disc 1).cue");
     }
 }

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 use crate::core::content::Content;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
@@ -16,6 +17,12 @@ where
 struct PresentedEntry {
     content: Content,
     encoded: EncodedFile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DiscGroupKey {
+    parent: String,
+    title: String,
 }
 
 impl<E> GenericPresenter<E>
@@ -42,18 +49,39 @@ where
             .collect()
     }
 
+    fn disc_group_key(content: &crate::core::content::DiscContent) -> DiscGroupKey {
+        let parent = Path::new(content.id.0.as_ref())
+            .parent()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        DiscGroupKey {
+            parent,
+            title: content.title.clone(),
+        }
+    }
+
     fn build_root_children(&self, entries: &[PresentedEntry]) -> Vec<VfsNode> {
-        let multi_disc_titles = self.multi_disc_titles(entries);
+        let multi_disc_groups = self.multi_disc_groups(entries);
         let mut emitted_groups = HashSet::new();
         let mut children = Vec::new();
 
         for entry in entries {
             match &entry.content {
-                Content::Disc(disc) if multi_disc_titles.contains(&disc.title) => {
-                    if emitted_groups.insert(disc.title.clone()) {
-                        children.push(VfsNode::Directory(
-                            self.build_multi_disc_directory(&disc.title, entries),
-                        ));
+                Content::Disc(disc) => {
+                    let key = Self::disc_group_key(disc);
+
+                    if multi_disc_groups.contains(&key) {
+                        if emitted_groups.insert(key.clone()) {
+                            children.push(VfsNode::Directory(
+                                self.build_multi_disc_directory(&key, entries),
+                            ));
+                        }
+                    } else {
+                        children.push(VfsNode::File(VfsFile::new(
+                            entry.encoded.name.clone(),
+                            entry.encoded.size,
+                        )));
                     }
                 }
                 _ => children.push(VfsNode::File(VfsFile::new(
@@ -66,26 +94,33 @@ where
         children
     }
 
-    fn multi_disc_titles(&self, entries: &[PresentedEntry]) -> HashSet<String> {
-        let mut disc_counts = HashMap::new();
+    fn multi_disc_groups(&self, entries: &[PresentedEntry]) -> HashSet<DiscGroupKey> {
+        let mut disc_counts: HashMap<DiscGroupKey, usize> = HashMap::new();
 
         for entry in entries {
             if let Content::Disc(disc) = &entry.content {
-                *disc_counts.entry(disc.title.clone()).or_insert(0usize) += 1;
+                let key = Self::disc_group_key(disc);
+                *disc_counts.entry(key).or_insert(0usize) += 1;
             }
         }
 
         disc_counts
             .into_iter()
-            .filter_map(|(title, count)| (count > 1).then_some(title))
+            .filter_map(|(key, count)| (count > 1).then_some(key))
             .collect()
     }
 
-    fn build_multi_disc_directory(&self, title: &str, entries: &[PresentedEntry]) -> VfsDirectory {
+    fn build_multi_disc_directory(
+        &self,
+        key: &DiscGroupKey,
+        entries: &[PresentedEntry],
+    ) -> VfsDirectory {
         let mut disc_entries: Vec<_> = entries
             .iter()
             .filter_map(|entry| match &entry.content {
-                Content::Disc(disc) if disc.title == title => Some((disc.disc_number, entry)),
+                Content::Disc(disc) if Self::disc_group_key(disc) == *key => {
+                    Some((disc.disc_number, entry))
+                }
                 _ => None,
             })
             .collect();
@@ -108,9 +143,11 @@ where
             })
             .collect();
 
-        children.push(VfsNode::File(self.build_m3u_file(title, &disc_file_names)));
+        children.push(VfsNode::File(
+            self.build_m3u_file(&key.title, &disc_file_names),
+        ));
 
-        VfsDirectory::with_children(title, children)
+        VfsDirectory::with_children(&key.title, children)
     }
 
     fn build_m3u_file(&self, title: &str, disc_file_names: &[String]) -> VfsFile {
@@ -199,14 +236,14 @@ mod tests {
                 size: 1024,
             }),
             Content::Disc(DiscContent {
-                id: ContentId::new("ff7-disc2"),
+                id: ContentId::new("ff7/ff7-disc2"),
                 source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
                 title: "Final Fantasy VII".to_string(),
                 disc_number: 2,
                 consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
             }),
             Content::Disc(DiscContent {
-                id: ContentId::new("ff7-disc1"),
+                id: ContentId::new("ff7/ff7-disc1"),
                 source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
                 title: "Final Fantasy VII".to_string(),
                 disc_number: 1,
@@ -251,7 +288,7 @@ mod tests {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![Content::Disc(DiscContent {
-            id: ContentId::new("metal-gear-solid"),
+            id: ContentId::new("mgs/mgs-disc1"),
             source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
             title: "Metal Gear Solid".to_string(),
             disc_number: 1,
@@ -262,5 +299,52 @@ mod tests {
 
         assert_eq!(root.children.len(), 1);
         assert_eq!(root.children[0].name(), "Metal Gear Solid (Disc 1).cue");
+    }
+
+    #[test]
+    fn does_not_merge_same_title_from_different_directories() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![
+            Content::Disc(DiscContent {
+                id: ContentId::new("discs/ps1_multi/game_disc1.cue"),
+                source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.cue"),
+                title: "game".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.bin")],
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("discs/ps1_multi/game_disc2.cue"),
+                source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc2.cue"),
+                title: "game".to_string(),
+                disc_number: 2,
+                consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_multi/game_disc2.bin")],
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("discs/ps1_single/game.cue"),
+                source: SourceRef::new("file:/roms/discs/ps1_single/game.cue"),
+                title: "game".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_single/game.bin")],
+            }),
+        ];
+
+        let root = presenter.present(&content);
+
+        assert_eq!(root.children.len(), 2);
+
+        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["game", "game (Disc 1).cue"]);
+
+        let multi_dir = match &root.children[0] {
+            VfsNode::Directory(directory) => directory,
+            other => panic!("expected directory, got {other:?}"),
+        };
+
+        let child_names: Vec<&str> = multi_dir.children.iter().map(|node| node.name()).collect();
+        assert_eq!(
+            child_names,
+            vec!["game (Disc 1).cue", "game (Disc 2).cue", "game.m3u"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Add automatic M3U playlist generation for multi-disc sets in the presenter layer.

## Behaviour

- Multi-disc titles are grouped into a directory
- An `.m3u` playlist is generated when more than one disc exists
- Playlist entries reference presented filenames (not source paths)
- Single-disc titles are not grouped and do not generate M3U
- Disc grouping is scoped by parent path + title to avoid collisions

## Example Output

/
  game/
    game (Disc 1).cue
    game (Disc 2).cue
    game.m3u
  game (Disc 1).cue

## Implementation Notes

- M3U generation is implemented in `GenericPresenter`
- Introduced inline-content support in `VfsFile` for virtual files
- Added grouping key (parent path + title) to avoid cross-directory merging

## Tests

Added/updated tests to cover:

- Multi-disc grouping + M3U generation
- No M3U for single-disc titles
- No grouping across different directories with same title
- Virtual file contents in VFS

All tests passing locally and in CI.

## Next Steps

- Normalise presented paths across content types (path preservation)
- Introduce richer virtual file model (beyond inline bytes)
- Implement VFS read layer