### PR TITLE
fix(phase3): preserve presented paths for decoded text content

### DIFF
--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -191,15 +191,22 @@ fn file_stem_or_name_from_object(object: &SourceObject) -> String {
 fn path_without_extension(name: &str) -> String {
     let path = Path::new(name);
 
-    match (
-        path.parent(),
-        path.file_stem().and_then(|stem| stem.to_str()),
-    ) {
-        (Some(parent), Some(stem)) if !parent.as_os_str().is_empty() => {
-            parent.join(stem).to_string_lossy().into_owned()
+    let stem = match path.file_stem().and_then(|stem| stem.to_str()) {
+        Some(stem) => stem,
+        None => return name.to_string(),
+    };
+
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => {
+            let parent = parent
+                .components()
+                .map(|component| component.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+
+            format!("{parent}/{stem}")
         }
-        (_, Some(stem)) => stem.to_string(),
-        _ => name.to_string(),
+        _ => stem.to_string(),
     }
 }
 

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -43,7 +43,7 @@ impl InputDecoder for BasicInputDecoder {
 
         let content = match identity {
             InputIdentity::Text => Content::Text(TextContent {
-                id: ContentId::new(file_stem_or_name_from_object(object)),
+                id: ContentId::new(path_without_extension(&object.name)),
                 source: object.source.clone(),
                 size,
             }),
@@ -186,6 +186,21 @@ fn file_stem_or_name_from_object(object: &SourceObject) -> String {
         .and_then(|stem| stem.to_str())
         .unwrap_or(&object.name)
         .to_string()
+}
+
+fn path_without_extension(name: &str) -> String {
+    let path = Path::new(name);
+
+    match (
+        path.parent(),
+        path.file_stem().and_then(|stem| stem.to_str()),
+    ) {
+        (Some(parent), Some(stem)) if !parent.as_os_str().is_empty() => {
+            parent.join(stem).to_string_lossy().into_owned()
+        }
+        (_, Some(stem)) => stem.to_string(),
+        _ => name.to_string(),
+    }
 }
 
 fn parse_disc_info_from_name(name: &str) -> (String, u32) {
@@ -417,5 +432,45 @@ FILE "game.bin" BINARY
     #[test]
     fn defaults_to_disc_one_when_no_disc_suffix_exists() {
         assert_eq!(parse_disc_info_from_name("game"), ("game".to_string(), 1));
+    }
+
+    #[test]
+    fn decodes_text_file_with_relative_path_id() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("notes.txt");
+        fs::write(&path, b"hello").unwrap();
+
+        let decoder = BasicInputDecoder::new();
+        let object = SourceObject {
+            source: SourceRef::new(path.to_string_lossy().into_owned()),
+            name: "mixed/notes.txt".to_string(),
+        };
+
+        let content = decoder.decode(&object, &InputIdentity::Text).unwrap();
+
+        match &content[0] {
+            Content::Text(text) => assert_eq!(text.id.to_string(), "mixed/notes"),
+            other => panic!("expected text content, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_text_file_with_normalized_relative_path_id() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("game.nfo");
+        fs::write(&path, b"hello").unwrap();
+
+        let decoder = BasicInputDecoder::new();
+        let object = SourceObject {
+            source: SourceRef::new(path.to_string_lossy().into_owned()),
+            name: "roms/snes/game.nfo".to_string(),
+        };
+
+        let content = decoder.decode(&object, &InputIdentity::Text).unwrap();
+
+        match &content[0] {
+            Content::Text(text) => assert_eq!(text.id.to_string(), "roms/snes/game"),
+            other => panic!("expected text content, got {other:?}"),
+        }
     }
 }

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -21,7 +21,7 @@ impl BasicEncoder {
             Content::Bytes(bytes) => format!("{}.bin", bytes.id),
             Content::Rom(rom) => rom.file_name.clone(),
             Content::Disc(disc) => format!("{} (Disc {}).cue", disc.title, disc.disc_number),
-            Content::Text(text) => Self::normalize_extension(text.source.as_str(), "txt"),
+            Content::Text(text) => Self::normalize_extension(text.source.0.as_ref(), "txt"),
         }
     }
 

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -9,19 +9,12 @@ impl BasicEncoder {
         Self
     }
 
-    fn normalize_extension(path: &str, new_ext: &str) -> String {
-        match path.rsplit_once('.') {
-            Some((base, _)) => format!("{base}.{new_ext}"),
-            None => format!("{path}.{new_ext}"),
-        }
-    }
-
     fn file_name_for(&self, content: &Content) -> String {
         match content {
             Content::Bytes(bytes) => format!("{}.bin", bytes.id),
             Content::Rom(rom) => rom.file_name.clone(),
             Content::Disc(disc) => format!("{} (Disc {}).cue", disc.title, disc.disc_number),
-            Content::Text(text) => Self::normalize_extension(text.source.0.as_ref(), "txt"),
+            Content::Text(text) => format!("{}.txt", text.id),
         }
     }
 
@@ -111,7 +104,7 @@ mod tests {
         });
 
         let encoded = encoder.encode(&content).unwrap();
-        assert_eq!(encoded.name, "file:/roms/readme.txt");
+        assert_eq!(encoded.name, "readme.txt");
         assert_eq!(encoded.size, 128);
     }
 
@@ -119,7 +112,7 @@ mod tests {
     fn preserves_relative_path_for_text_content() {
         let encoder = BasicEncoder::new();
         let content = Content::Text(TextContent {
-            id: ContentId::new("game"),
+            id: ContentId::new("mixed/notes"),
             source: SourceRef::new("mixed/notes.txt"),
             size: 10,
         });
@@ -130,10 +123,10 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_text_extension_from_source_path() {
+    fn normalizes_text_extension_from_id_path() {
         let encoder = BasicEncoder::new();
         let content = Content::Text(TextContent {
-            id: ContentId::new("game"),
+            id: ContentId::new("roms/snes/game"),
             source: SourceRef::new("roms/snes/game.nfo"),
             size: 19,
         });

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -9,12 +9,19 @@ impl BasicEncoder {
         Self
     }
 
+    fn normalize_extension(path: &str, new_ext: &str) -> String {
+        match path.rsplit_once('.') {
+            Some((base, _)) => format!("{base}.{new_ext}"),
+            None => format!("{path}.{new_ext}"),
+        }
+    }
+
     fn file_name_for(&self, content: &Content) -> String {
         match content {
             Content::Bytes(bytes) => format!("{}.bin", bytes.id),
             Content::Rom(rom) => rom.file_name.clone(),
             Content::Disc(disc) => format!("{} (Disc {}).cue", disc.title, disc.disc_number),
-            Content::Text(text) => format!("{}.txt", text.id),
+            Content::Text(text) => Self::normalize_extension(text.source.as_str(), "txt"),
         }
     }
 
@@ -104,7 +111,35 @@ mod tests {
         });
 
         let encoded = encoder.encode(&content).unwrap();
-        assert_eq!(encoded.name, "readme.txt");
+        assert_eq!(encoded.name, "file:/roms/readme.txt");
         assert_eq!(encoded.size, 128);
+    }
+
+    #[test]
+    fn preserves_relative_path_for_text_content() {
+        let encoder = BasicEncoder::new();
+        let content = Content::Text(TextContent {
+            id: ContentId::new("game"),
+            source: SourceRef::new("mixed/notes.txt"),
+            size: 10,
+        });
+
+        let encoded = encoder.encode(&content).unwrap();
+        assert_eq!(encoded.name, "mixed/notes.txt");
+        assert_eq!(encoded.size, 10);
+    }
+
+    #[test]
+    fn normalizes_text_extension_from_source_path() {
+        let encoder = BasicEncoder::new();
+        let content = Content::Text(TextContent {
+            id: ContentId::new("game"),
+            source: SourceRef::new("roms/snes/game.nfo"),
+            size: 19,
+        });
+
+        let encoded = encoder.encode(&content).unwrap();
+        assert_eq!(encoded.name, "roms/snes/game.txt");
+        assert_eq!(encoded.size, 19);
     }
 }


### PR DESCRIPTION
## Summary

Preserve relative paths for decoded text content so presented output remains consistent across content types.

## Changes

- derive `TextContent.id` from the logical source object name without its extension
- keep text encoding based on `text.id`
- add tests covering:
  - relative text paths
  - extension normalization
  - nested text content paths

## Result

Presented VFS output now preserves relative paths for text files, e.g.:

- `mixed/notes.txt`
- `roms/snes/game.txt`

instead of flattening them to the root.