### PR TITLE
feat(phase3): add readable backing for vfs files

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,4 +12,5 @@ pub mod reader_registry;
 pub mod source;
 pub mod track;
 pub mod vfs;
+pub mod vfs_reader;
 pub mod virtual_file;

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use crate::core::source::SourceRef;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum VfsNode {
     Directory(VfsDirectory),
@@ -35,29 +37,65 @@ impl VfsDirectory {
             children,
         }
     }
+
+    pub fn find_file(&self, path: &str) -> Option<&VfsFile> {
+        let path = path.trim_matches('/');
+
+        if path.is_empty() {
+            return None;
+        }
+
+        for child in &self.children {
+            match child {
+                VfsNode::File(file) if file.name == path => return Some(file),
+                VfsNode::Directory(dir) => {
+                    if let Some(remainder) = path.strip_prefix(&dir.name) {
+                        if let Some(remainder) = remainder.strip_prefix('/') {
+                            if let Some(file) = dir.find_file(remainder) {
+                                return Some(file);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum FileBacking {
+    Source(SourceRef),
+    Inline(Vec<u8>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct VfsFile {
     pub name: String,
     pub size: u64,
-    pub contents: Option<Vec<u8>>,
+    pub backing: FileBacking,
 }
 
 impl VfsFile {
-    pub fn new(name: impl Into<String>, size: u64) -> Self {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self::inline(name, Vec::new())
+    }
+
+    pub fn source_backed(name: impl Into<String>, size: u64, source: SourceRef) -> Self {
         Self {
             name: name.into(),
             size,
-            contents: None,
+            backing: FileBacking::Source(source),
         }
     }
 
-    pub fn with_contents(name: impl Into<String>, contents: Vec<u8>) -> Self {
+    pub fn inline(name: impl Into<String>, contents: Vec<u8>) -> Self {
         Self {
             name: name.into(),
             size: contents.len() as u64,
-            contents: Some(contents),
+            backing: FileBacking::Inline(contents),
         }
     }
 }
@@ -72,7 +110,7 @@ mod tests {
             "",
             vec![VfsNode::Directory(VfsDirectory::with_children(
                 "snes",
-                vec![VfsNode::File(VfsFile::new("game.sfc", 1024))],
+                vec![VfsNode::File(VfsFile::new("game.sfc"))],
             ))],
         );
 
@@ -88,11 +126,45 @@ mod tests {
     }
 
     #[test]
-    fn builds_virtual_file_with_inline_contents() {
-        let file = VfsFile::with_contents("game.m3u", b"game (Disc 1).cue\n".to_vec());
+    fn builds_inline_file() {
+        let file = VfsFile::inline("game.m3u", b"game (Disc 1).cue\n".to_vec());
 
         assert_eq!(file.name, "game.m3u");
         assert_eq!(file.size, 18);
-        assert_eq!(file.contents, Some(b"game (Disc 1).cue\n".to_vec()));
+
+        match &file.backing {
+            FileBacking::Inline(contents) => {
+                assert_eq!(contents, b"game (Disc 1).cue\n");
+            }
+            _ => panic!("expected inline backing"),
+        }
+    }
+
+    #[test]
+    fn finds_root_file_with_slash_in_name() {
+        let root =
+            VfsDirectory::with_children("", vec![VfsNode::File(VfsFile::new("mixed/notes.txt"))]);
+
+        let file = root
+            .find_file("mixed/notes.txt")
+            .expect("file should exist");
+        assert_eq!(file.name, "mixed/notes.txt");
+    }
+
+    #[test]
+    fn finds_nested_file_in_directory() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "game",
+                vec![VfsNode::File(VfsFile::inline(
+                    "game.m3u",
+                    b"game (Disc 1).cue\ngame (Disc 2).cue\n".to_vec(),
+                ))],
+            ))],
+        );
+
+        let file = root.find_file("game/game.m3u").expect("file should exist");
+        assert_eq!(file.name, "game.m3u");
     }
 }

--- a/src/core/vfs_reader.rs
+++ b/src/core/vfs_reader.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::path::Path;
 
+use crate::core::reader::Reader;
 use crate::core::source::SourceRef;
 use crate::core::vfs::{FileBacking, VfsFile};
 use crate::readers::dir_reader::DirReader;
@@ -45,11 +46,9 @@ fn open_source_ref(source: &SourceRef) -> Result<Box<dyn Reader>, io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::vfs::VfsFile;
     use std::fs;
     use std::io::Write;
-
-    use crate::core::reader::Reader;
-    use crate::core::vfs::VfsFile;
 
     #[test]
     fn opens_inline_backed_vfs_file() {

--- a/src/core/vfs_reader.rs
+++ b/src/core/vfs_reader.rs
@@ -1,0 +1,120 @@
+use std::io;
+use std::path::Path;
+
+use crate::core::reader::Reader;
+use crate::core::source::SourceRef;
+use crate::core::vfs::{FileBacking, VfsFile};
+use crate::readers::dir_reader::DirReader;
+use crate::readers::inline_reader::InlineReader;
+use crate::readers::zip_reader::ZipReader;
+
+pub fn open_vfs_file(file: &VfsFile) -> Result<Box<dyn Reader>, io::Error> {
+    match &file.backing {
+        FileBacking::Inline(contents) => Ok(Box::new(InlineReader::new(contents.clone()))),
+        FileBacking::Source(source) => open_source_ref(source),
+    }
+}
+
+fn open_source_ref(source: &SourceRef) -> Result<Box<dyn Reader>, io::Error> {
+    let source = source.0.as_ref();
+
+    if let Some(remainder) = source.strip_prefix("zip:") {
+        let (archive_path, entry_name) = remainder.split_once('#').ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid ZIP source ref: {source}"),
+            )
+        })?;
+
+        return Ok(Box::new(ZipReader::open(
+            Path::new(archive_path),
+            entry_name,
+        )?));
+    }
+
+    let path = if let Some(path) = source.strip_prefix("file:") {
+        path
+    } else if let Some(path) = source.strip_prefix("cue:") {
+        path
+    } else {
+        source
+    };
+
+    Ok(Box::new(DirReader::open(Path::new(path))?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    use crate::core::reader::Reader;
+    use crate::core::vfs::VfsFile;
+
+    #[test]
+    fn opens_inline_backed_vfs_file() {
+        let file = VfsFile::inline("game.m3u", b"disc1.cue\ndisc2.cue\n".to_vec());
+
+        let mut reader = open_vfs_file(&file).unwrap();
+        let mut buf = vec![0; file.size as usize];
+        let bytes = reader.read_at(0, &mut buf).unwrap();
+
+        assert_eq!(bytes, file.size as usize);
+        assert_eq!(&buf, b"disc1.cue\ndisc2.cue\n");
+    }
+
+    #[test]
+    fn opens_filesystem_backed_vfs_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("readme.txt");
+        fs::write(&path, b"hello world").unwrap();
+
+        let file = VfsFile::source_backed(
+            "readme.txt",
+            11,
+            SourceRef::new(path.to_string_lossy().into_owned()),
+        );
+
+        let mut reader = open_vfs_file(&file).unwrap();
+        let mut buf = vec![0; 11];
+        let bytes = reader.read_at(0, &mut buf).unwrap();
+
+        assert_eq!(bytes, 11);
+        assert_eq!(&buf, b"hello world");
+    }
+
+    #[test]
+    fn opens_zip_backed_vfs_file() {
+        use std::fs::File;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("library.zip");
+
+        {
+            let file = File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+
+            zip.start_file("docs/readme.txt", options).unwrap();
+            zip.write_all(b"zip hello").unwrap();
+            zip.finish().unwrap();
+        }
+
+        let file = VfsFile::source_backed(
+            "docs/readme.txt",
+            9,
+            SourceRef::new(format!(
+                "zip:{}#docs/readme.txt",
+                zip_path.to_string_lossy()
+            )),
+        );
+
+        let mut reader = open_vfs_file(&file).unwrap();
+        let mut buf = vec![0; 9];
+        let bytes = reader.read_at(0, &mut buf).unwrap();
+
+        assert_eq!(bytes, 9);
+        assert_eq!(&buf, b"zip hello");
+    }
+}

--- a/src/core/vfs_reader.rs
+++ b/src/core/vfs_reader.rs
@@ -1,7 +1,6 @@
 use std::io;
 use std::path::Path;
 
-use crate::core::reader::Reader;
 use crate::core::source::SourceRef;
 use crate::core::vfs::{FileBacking, VfsFile};
 use crate::readers::dir_reader::DirReader;

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -143,7 +143,7 @@ mod tests {
             }],
             presented: VfsDirectory::with_children(
                 "",
-                vec![VfsNode::File(VfsFile::new("blob.dat.bin", 0))],
+                vec![VfsNode::File(VfsFile::new("blob.dat.bin"))],
             ),
         };
 

--- a/src/engine/preview.rs
+++ b/src/engine/preview.rs
@@ -85,9 +85,9 @@ mod tests {
         let root = VfsDirectory::with_children(
             "",
             vec![
-                VfsNode::File(VfsFile::new("mario.sfc", 1024)),
-                VfsNode::File(VfsFile::new("readme.txt", 64)),
-                VfsNode::File(VfsFile::new("blob.dat.bin", 12)),
+                VfsNode::File(VfsFile::new("mario.sfc")),
+                VfsNode::File(VfsFile::new("readme.txt")),
+                VfsNode::File(VfsFile::new("blob.dat.bin")),
             ],
         );
 
@@ -104,7 +104,7 @@ mod tests {
             "",
             vec![VfsNode::Directory(VfsDirectory::with_children(
                 "snes",
-                vec![VfsNode::File(VfsFile::new("zelda.sfc", 2048))],
+                vec![VfsNode::File(VfsFile::new("zelda.sfc"))],
             ))],
         );
 

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core::content::Content;
-use crate::core::vfs::{FileBacking, VfsDirectory, VfsFile, VfsNode};
+use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
 
@@ -184,6 +184,7 @@ mod tests {
         BytesContent, Content, ContentId, DiscContent, RomContent, TextContent,
     };
     use crate::core::source::SourceRef;
+    use crate::core::vfs::FileBacking;
     use crate::output::basic_encoder::BasicEncoder;
 
     #[test]

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,8 +1,7 @@
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
 
 use crate::core::content::Content;
-use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
+use crate::core::vfs::{FileBacking, VfsDirectory, VfsFile, VfsNode};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
 
@@ -50,14 +49,18 @@ where
     }
 
     fn disc_group_key(content: &crate::core::content::DiscContent) -> DiscGroupKey {
-        let parent = Path::new(content.id.0.as_ref())
-            .parent()
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default();
-
         DiscGroupKey {
-            parent,
+            parent: Self::logical_parent_path(content.id.0.as_ref()),
             title: content.title.clone(),
+        }
+    }
+
+    fn logical_parent_path(path: &str) -> String {
+        let normalized = path.replace('\\', "/");
+
+        match normalized.rsplit_once('/') {
+            Some((parent, _)) => parent.to_string(),
+            None => String::new(),
         }
     }
 
@@ -78,15 +81,17 @@ where
                             ));
                         }
                     } else {
-                        children.push(VfsNode::File(VfsFile::new(
+                        children.push(VfsNode::File(VfsFile::source_backed(
                             entry.encoded.name.clone(),
                             entry.encoded.size,
+                            entry.content.source().clone(),
                         )));
                     }
                 }
-                _ => children.push(VfsNode::File(VfsFile::new(
+                _ => children.push(VfsNode::File(VfsFile::source_backed(
                     entry.encoded.name.clone(),
                     entry.encoded.size,
+                    entry.content.source().clone(),
                 ))),
             }
         }
@@ -139,7 +144,11 @@ where
         let mut children: Vec<VfsNode> = disc_entries
             .into_iter()
             .map(|(_, entry)| {
-                VfsNode::File(VfsFile::new(entry.encoded.name.clone(), entry.encoded.size))
+                VfsNode::File(VfsFile::source_backed(
+                    entry.encoded.name.clone(),
+                    entry.encoded.size,
+                    entry.content.source().clone(),
+                ))
             })
             .collect();
 
@@ -152,7 +161,7 @@ where
 
     fn build_m3u_file(&self, title: &str, disc_file_names: &[String]) -> VfsFile {
         let playlist = disc_file_names.join("\n") + "\n";
-        VfsFile::with_contents(format!("{title}.m3u"), playlist.into_bytes())
+        VfsFile::inline(format!("{title}.m3u"), playlist.into_bytes())
     }
 }
 
@@ -222,6 +231,16 @@ mod tests {
                 "manifest.txt",
             ]
         );
+
+        match &root.children[0] {
+            VfsNode::File(file) => match &file.backing {
+                FileBacking::Source(source) => {
+                    assert_eq!(source.to_string(), "file:/roms/bios");
+                }
+                other => panic!("expected source backing, got {other:?}"),
+            },
+            other => panic!("expected file, got {other:?}"),
+        }
     }
 
     #[test]
@@ -277,10 +296,15 @@ mod tests {
             other => panic!("expected file, got {other:?}"),
         };
 
-        assert_eq!(
-            playlist.contents,
-            Some(b"Final Fantasy VII (Disc 1).cue\nFinal Fantasy VII (Disc 2).cue\n".to_vec())
-        );
+        match &playlist.backing {
+            FileBacking::Inline(contents) => {
+                assert_eq!(
+                    contents,
+                    b"Final Fantasy VII (Disc 1).cue\nFinal Fantasy VII (Disc 2).cue\n"
+                );
+            }
+            other => panic!("expected inline backing, got {other:?}"),
+        }
     }
 
     #[test]
@@ -346,5 +370,17 @@ mod tests {
             child_names,
             vec!["game (Disc 1).cue", "game (Disc 2).cue", "game.m3u"]
         );
+    }
+
+    #[test]
+    fn normalizes_disc_group_parent_to_logical_path() {
+        let key = GenericPresenter::<BasicEncoder>::disc_group_key(&DiscContent {
+            id: ContentId::new(r"discs\ps1_multi\game_disc1.cue"),
+            source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.cue"),
+            title: "game".to_string(),
+            disc_number: 1,
+            consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.bin")],
+        });
+        assert_eq!(key.parent, "discs/ps1_multi");
     }
 }

--- a/src/readers/inline_reader.rs
+++ b/src/readers/inline_reader.rs
@@ -1,0 +1,60 @@
+use std::io::Result;
+
+use crate::core::reader::Reader;
+
+pub struct InlineReader {
+    data: Vec<u8>,
+}
+
+impl InlineReader {
+    pub fn new(data: Vec<u8>) -> Self {
+        Self { data }
+    }
+}
+
+impl Reader for InlineReader {
+    fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<usize> {
+        let offset = offset as usize;
+
+        if offset >= self.data.len() || buf.is_empty() {
+            return Ok(0);
+        }
+
+        let available = &self.data[offset..];
+        let count = available.len().min(buf.len());
+        buf[..count].copy_from_slice(&available[..count]);
+
+        Ok(count)
+    }
+
+    fn len(&self) -> u64 {
+        self.data.len() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::reader::Reader;
+
+    #[test]
+    fn reads_inline_bytes() {
+        let mut reader = InlineReader::new(b"abcdef".to_vec());
+
+        let mut buf = vec![0; 3];
+        let bytes = reader.read_at(2, &mut buf).unwrap();
+
+        assert_eq!(bytes, 3);
+        assert_eq!(&buf, b"cde");
+    }
+
+    #[test]
+    fn returns_zero_when_offset_is_past_end() {
+        let mut reader = InlineReader::new(b"abc".to_vec());
+
+        let mut buf = vec![0; 3];
+        let bytes = reader.read_at(10, &mut buf).unwrap();
+
+        assert_eq!(bytes, 0);
+    }
+}

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -1,2 +1,3 @@
 pub mod dir_reader;
+pub mod inline_reader;
 pub mod zip_reader;


### PR DESCRIPTION
## Summary

Add readable backing for presented VFS files.

## Changes

- introduce `FileBacking` for VFS files:
  - `Source(SourceRef)`
  - `Inline(Vec<u8>)`
- add `InlineReader`
- add `open_vfs_file()` to open both inline and source-backed VFS files through the existing `Reader` trait
- update the presenter so regular files are source-backed and generated `.m3u` playlists are inline-backed
- normalize disc grouping parent paths to logical `/`-style separators across platforms

## Result

Presented VFS files now carry enough information to be opened and read, which prepares the project for the next step: actual mounted VFS reads.