### PR TITLE
feat(phase3): add VFS resolver and readable file abstraction

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -13,4 +13,5 @@ pub mod source;
 pub mod track;
 pub mod vfs;
 pub mod vfs_reader;
+pub mod vfs_resolver;
 pub mod virtual_file;

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -38,7 +38,7 @@ impl VfsDirectory {
         }
     }
 
-    pub fn find_file(&self, path: &str) -> Option<&VfsFile> {
+    pub fn find_node(&self, path: &str) -> Option<&VfsNode> {
         let path = path.trim_matches('/');
 
         if path.is_empty() {
@@ -47,12 +47,13 @@ impl VfsDirectory {
 
         for child in &self.children {
             match child {
-                VfsNode::File(file) if file.name == path => return Some(file),
+                VfsNode::File(file) if file.name == path => return Some(child),
+                VfsNode::Directory(dir) if dir.name == path => return Some(child),
                 VfsNode::Directory(dir) => {
                     if let Some(remainder) = path.strip_prefix(&dir.name) {
                         if let Some(remainder) = remainder.strip_prefix('/') {
-                            if let Some(file) = dir.find_file(remainder) {
-                                return Some(file);
+                            if let Some(node) = dir.find_node(remainder) {
+                                return Some(node);
                             }
                         }
                     }
@@ -62,6 +63,20 @@ impl VfsDirectory {
         }
 
         None
+    }
+
+    pub fn find_file(&self, path: &str) -> Option<&VfsFile> {
+        match self.find_node(path) {
+            Some(VfsNode::File(file)) => Some(file),
+            _ => None,
+        }
+    }
+
+    pub fn find_directory(&self, path: &str) -> Option<&VfsDirectory> {
+        match self.find_node(path) {
+            Some(VfsNode::Directory(dir)) => Some(dir),
+            _ => None,
+        }
     }
 }
 
@@ -166,5 +181,58 @@ mod tests {
 
         let file = root.find_file("game/game.m3u").expect("file should exist");
         assert_eq!(file.name, "game.m3u");
+    }
+
+    #[test]
+    fn finds_directory_by_path() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "game",
+                vec![VfsNode::File(VfsFile::inline(
+                    "game.m3u",
+                    b"game (Disc 1).cue\ngame (Disc 2).cue\n".to_vec(),
+                ))],
+            ))],
+        );
+
+        let dir = root.find_directory("game").expect("directory should exist");
+        assert_eq!(dir.name, "game");
+    }
+
+    #[test]
+    fn finds_node_for_root_file() {
+        let root =
+            VfsDirectory::with_children("", vec![VfsNode::File(VfsFile::new("mixed/notes.txt"))]);
+
+        let node = root
+            .find_node("mixed/notes.txt")
+            .expect("node should exist");
+
+        match node {
+            VfsNode::File(file) => assert_eq!(file.name, "mixed/notes.txt"),
+            other => panic!("expected file node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finds_node_for_directory() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "game",
+                vec![VfsNode::File(VfsFile::inline(
+                    "game.m3u",
+                    b"game (Disc 1).cue\ngame (Disc 2).cue\n".to_vec(),
+                ))],
+            ))],
+        );
+
+        let node = root.find_node("game").expect("node should exist");
+
+        match node {
+            VfsNode::Directory(dir) => assert_eq!(dir.name, "game"),
+            other => panic!("expected directory node, got {other:?}"),
+        }
     }
 }

--- a/src/core/vfs_resolver.rs
+++ b/src/core/vfs_resolver.rs
@@ -1,0 +1,158 @@
+use std::io;
+
+use crate::core::reader::Reader;
+use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
+use crate::core::vfs_reader::open_vfs_file;
+
+pub fn find_node<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsNode> {
+    let path = normalize_vfs_path(path);
+
+    if path.is_empty() {
+        return None;
+    }
+
+    root.find_node(&path)
+}
+
+pub fn find_directory<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsDirectory> {
+    let path = normalize_vfs_path(path);
+
+    if path.is_empty() {
+        return Some(root);
+    }
+
+    root.find_directory(&path)
+}
+
+pub fn find_file<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsFile> {
+    let path = normalize_vfs_path(path);
+
+    if path.is_empty() {
+        return None;
+    }
+
+    root.find_file(&path)
+}
+
+pub fn open_file(root: &VfsDirectory, path: &str) -> Result<Box<dyn Reader>, io::Error> {
+    let file = find_file(root, path).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, format!("file not found: {path}"))
+    })?;
+
+    open_vfs_file(file)
+}
+
+fn normalize_vfs_path(path: &str) -> String {
+    path.replace('\\', "/").trim_matches('/').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::source::SourceRef;
+    use crate::core::vfs::{VfsFile, VfsNode};
+
+    #[test]
+    fn finds_root_file_by_path() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::File(VfsFile::inline(
+                "mixed/notes.txt",
+                b"hello".to_vec(),
+            ))],
+        );
+
+        let file = find_file(&root, "mixed/notes.txt").expect("file should exist");
+        assert_eq!(file.name, "mixed/notes.txt");
+    }
+
+    #[test]
+    fn finds_directory_by_path() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "game",
+                vec![VfsNode::File(VfsFile::inline(
+                    "game.m3u",
+                    b"disc1.cue\ndisc2.cue\n".to_vec(),
+                ))],
+            ))],
+        );
+
+        let dir = find_directory(&root, "game").expect("directory should exist");
+        assert_eq!(dir.name, "game");
+    }
+
+    #[test]
+    fn finds_root_directory_for_empty_path() {
+        let root = VfsDirectory::with_children("", vec![]);
+
+        let dir = find_directory(&root, "").expect("root directory should exist");
+        assert_eq!(dir.name, "");
+    }
+
+    #[test]
+    fn opens_inline_file_by_path() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "game",
+                vec![VfsNode::File(VfsFile::inline(
+                    "game.m3u",
+                    b"disc1.cue\ndisc2.cue\n".to_vec(),
+                ))],
+            ))],
+        );
+
+        let mut reader = open_file(&root, "game/game.m3u").unwrap();
+        let mut buf = vec![0; 20];
+        let bytes = reader.read_at(0, &mut buf).unwrap();
+
+        assert_eq!(&buf[..bytes], b"disc1.cue\ndisc2.cue\n");
+    }
+
+    #[test]
+    fn opens_source_backed_file_by_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("readme.txt");
+        std::fs::write(&path, b"hello world").unwrap();
+
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::File(VfsFile::source_backed(
+                "docs/readme.txt",
+                11,
+                SourceRef::new(path.to_string_lossy().into_owned()),
+            ))],
+        );
+
+        let mut reader = open_file(&root, "docs/readme.txt").unwrap();
+        let mut buf = vec![0; 11];
+        let bytes = reader.read_at(0, &mut buf).unwrap();
+
+        assert_eq!(bytes, 11);
+        assert_eq!(&buf, b"hello world");
+    }
+
+    #[test]
+    fn normalizes_backslashes_in_resolved_paths() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::File(VfsFile::inline(
+                "mixed/notes.txt",
+                b"hello".to_vec(),
+            ))],
+        );
+
+        let file = find_file(&root, r"mixed\notes.txt").expect("file should exist");
+        assert_eq!(file.name, "mixed/notes.txt");
+    }
+
+    #[test]
+    fn returns_not_found_when_opening_missing_file() {
+        let root = VfsDirectory::with_children("", vec![]);
+
+        let err = open_file(&root, "missing.txt").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/src/core/vfs_resolver.rs
+++ b/src/core/vfs_resolver.rs
@@ -14,7 +14,7 @@ pub fn find_node(root: &VfsDirectory, path: &str) -> Option<&VfsNode> {
     root.find_node(&path)
 }
 
-pub fn find_directory<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsDirectory> {
+pub fn find_directory(root: &VfsDirectory, path: &str) -> Option<&VfsDirectory> {
     let path = normalize_vfs_path(path);
 
     if path.is_empty() {
@@ -24,7 +24,7 @@ pub fn find_directory<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsD
     root.find_directory(&path)
 }
 
-pub fn find_file<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsFile> {
+pub fn find_file(root: &VfsDirectory, path: &str) -> Option<&VfsFile> {
     let path = normalize_vfs_path(path);
 
     if path.is_empty() {

--- a/src/core/vfs_resolver.rs
+++ b/src/core/vfs_resolver.rs
@@ -4,7 +4,7 @@ use crate::core::reader::Reader;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::core::vfs_reader::open_vfs_file;
 
-pub fn find_node(root: &VfsDirectory, path: &str) -> Option<&VfsNode> {
+pub fn find_node<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsNode> {
     let path = normalize_vfs_path(path);
 
     if path.is_empty() {
@@ -14,7 +14,7 @@ pub fn find_node(root: &VfsDirectory, path: &str) -> Option<&VfsNode> {
     root.find_node(&path)
 }
 
-pub fn find_directory(root: &VfsDirectory, path: &str) -> Option<&VfsDirectory> {
+pub fn find_directory<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsDirectory> {
     let path = normalize_vfs_path(path);
 
     if path.is_empty() {
@@ -24,7 +24,7 @@ pub fn find_directory(root: &VfsDirectory, path: &str) -> Option<&VfsDirectory> 
     root.find_directory(&path)
 }
 
-pub fn find_file(root: &VfsDirectory, path: &str) -> Option<&VfsFile> {
+pub fn find_file<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsFile> {
     let path = normalize_vfs_path(path);
 
     if path.is_empty() {
@@ -152,7 +152,9 @@ mod tests {
     fn returns_not_found_when_opening_missing_file() {
         let root = VfsDirectory::with_children("", vec![]);
 
-        let err = open_file(&root, "missing.txt").unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        match open_file(&root, "missing.txt") {
+            Ok(_) => panic!("expected missing file to return NotFound"),
+            Err(err) => assert_eq!(err.kind(), io::ErrorKind::NotFound),
+        }
     }
 }

--- a/src/core/vfs_resolver.rs
+++ b/src/core/vfs_resolver.rs
@@ -4,7 +4,7 @@ use crate::core::reader::Reader;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::core::vfs_reader::open_vfs_file;
 
-pub fn find_node<'a>(root: &'a VfsDirectory, path: &str) -> Option<&'a VfsNode> {
+pub fn find_node(root: &VfsDirectory, path: &str) -> Option<&VfsNode> {
     let path = normalize_vfs_path(path);
 
     if path.is_empty() {


### PR DESCRIPTION
## 🚀 feat(phase3): add VFS resolver and readable file abstraction

### Summary

Introduce a path-based resolver layer for the Virtual File System (VFS), enabling lookup and reading of files regardless of backing source.

This completes the core abstraction required to treat real and generated files uniformly and prepares the project for FUSE integration.

---

### ✨ What’s Included

#### 🗂️ VFS Resolver

New module: `vfs_resolver`

- `find_node()` – resolve any node (file or directory) by path  
- `find_directory()` – resolve directories (empty path → root)  
- `find_file()` – resolve files  
- `open_file()` – open a file as a `Reader`  

#### 🔄 Path Normalisation

- Converts Windows-style paths (`\`) → POSIX (`/`)
- Trims leading/trailing slashes
- Ensures consistent resolution across platforms

#### 📦 File Backing Integration

- `FileBacking::Inline` → in-memory data  
- `FileBacking::Source` → real filesystem via `SourceRef`  
- `open_vfs_file()` bridges backing → `Reader`

#### 🧠 VFS Structure Enhancements

- `VfsDirectory::find_node()` now supports recursive resolution
- `find_file()` / `find_directory()` delegate through node resolution
- Clean separation:
  - VFS = structure
  - Resolver = traversal logic

---

### 🧪 Tests

Coverage added for:

- Resolving files and directories by path
- Root directory handling
- Inline-backed file reads
- Source-backed file reads
- Windows path compatibility
- Proper error handling for missing files

---

### 🔧 Fixes Included

- Restore explicit lifetimes in resolver (`&'a VfsDirectory → &'a VfsNode`)
- Replace `unwrap_err()` with match to avoid `Debug` bound on `Reader`

---

### ✅ Result

The VFS is now:

- 🔍 Navigable via path
- 📖 Readable via a unified interface
- 🔌 Backing-agnostic (inline vs source)
- 🧱 Ready for filesystem mounting

---

### 🗺️ Next Steps

- Implement read-only FUSE layer:
  - `lookup` → `find_node`
  - `readdir` → `children`
  - `read` → `open_file + read_at`
- Add file metadata support (size, timestamps)
- Introduce inode/path caching if needed

---

### 🎯 Milestone

This PR delivers the first **fully usable VFS abstraction**, enabling real-world interaction with presented content.

The next step is exposing this via FUSE to create a mountable filesystem.