### PR TITLE
Feature/phase3 vfs browse

### DIFF
--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -31,34 +31,70 @@ impl VfsDirectory {
         }
     }
 
-    pub fn with_children(name: impl Into<String>, children: Vec<VfsNode>) -> Self {
+    pub fn with_children(name: impl Into<String>, mut children: Vec<VfsNode>) -> Self {
+        sort_nodes(&mut children);
+
         Self {
             name: name.into(),
             children,
         }
     }
 
+    pub fn add_child(&mut self, child: VfsNode) {
+        self.children.push(child);
+        sort_nodes(&mut self.children);
+    }
+
+    pub fn children(&self) -> &[VfsNode] {
+        &self.children
+    }
+
+    pub fn files(&self) -> impl Iterator<Item = &VfsFile> {
+        self.children.iter().filter_map(|node| match node {
+            VfsNode::File(file) => Some(file),
+            VfsNode::Directory(_) => None,
+        })
+    }
+
+    pub fn directories(&self) -> impl Iterator<Item = &VfsDirectory> {
+        self.children.iter().filter_map(|node| match node {
+            VfsNode::Directory(dir) => Some(dir),
+            VfsNode::File(_) => None,
+        })
+    }
+
     pub fn find_node(&self, path: &str) -> Option<&VfsNode> {
-        let path = path.trim_matches('/');
+        let path = normalize_vfs_path(path);
 
         if path.is_empty() {
             return None;
         }
 
+        let (head, remainder) = split_path(&path);
+
         for child in &self.children {
             match child {
-                VfsNode::File(file) if file.name == path => return Some(child),
-                VfsNode::Directory(dir) if dir.name == path => return Some(child),
+                VfsNode::File(file) => {
+                    if remainder.is_none() && file.name == head {
+                        return Some(child);
+                    }
+
+                    if file.name == path {
+                        return Some(child);
+                    }
+                }
                 VfsNode::Directory(dir) => {
-                    if let Some(remainder) = path.strip_prefix(&dir.name) {
-                        if let Some(remainder) = remainder.strip_prefix('/') {
-                            if let Some(node) = dir.find_node(remainder) {
-                                return Some(node);
+                    if dir.name == head {
+                        match remainder {
+                            Some(remainder) => {
+                                if let Some(node) = dir.find_node(remainder) {
+                                    return Some(node);
+                                }
                             }
+                            None => return Some(child),
                         }
                     }
                 }
-                _ => {}
             }
         }
 
@@ -73,7 +109,13 @@ impl VfsDirectory {
     }
 
     pub fn find_directory(&self, path: &str) -> Option<&VfsDirectory> {
-        match self.find_node(path) {
+        let path = normalize_vfs_path(path);
+
+        if path.is_empty() {
+            return Some(self);
+        }
+
+        match self.find_node(&path) {
             Some(VfsNode::Directory(dir)) => Some(dir),
             _ => None,
         }
@@ -113,6 +155,31 @@ impl VfsFile {
             backing: FileBacking::Inline(contents),
         }
     }
+}
+
+fn normalize_vfs_path(path: &str) -> String {
+    path.split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn split_path(path: &str) -> (&str, Option<&str>) {
+    match path.split_once('/') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (path, None),
+    }
+}
+
+fn node_sort_key(node: &VfsNode) -> (u8, &str) {
+    match node {
+        VfsNode::Directory(dir) => (0, &dir.name),
+        VfsNode::File(file) => (1, &file.name),
+    }
+}
+
+fn sort_nodes(nodes: &mut [VfsNode]) {
+    nodes.sort_by_key(node_sort_key);
 }
 
 #[cfg(test)]
@@ -201,6 +268,22 @@ mod tests {
     }
 
     #[test]
+    fn finds_root_directory_for_empty_path() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "game",
+                vec![],
+            ))],
+        );
+
+        let dir = root
+            .find_directory("")
+            .expect("root directory should exist");
+        assert_eq!(dir.name, "");
+    }
+
+    #[test]
     fn finds_node_for_root_file() {
         let root =
             VfsDirectory::with_children("", vec![VfsNode::File(VfsFile::new("mixed/notes.txt"))]);
@@ -234,5 +317,76 @@ mod tests {
             VfsNode::Directory(dir) => assert_eq!(dir.name, "game"),
             other => panic!("expected directory node, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn normalizes_repeated_slashes_in_paths() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::Directory(VfsDirectory::with_children(
+                "game",
+                vec![VfsNode::File(VfsFile::inline(
+                    "game.m3u",
+                    b"game (Disc 1).cue\ngame (Disc 2).cue\n".to_vec(),
+                ))],
+            ))],
+        );
+
+        let file = root
+            .find_file("//game///game.m3u")
+            .expect("file should exist");
+        assert_eq!(file.name, "game.m3u");
+    }
+
+    #[test]
+    fn exposes_directory_browse_helpers() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![
+                VfsNode::Directory(VfsDirectory::with_children("a-dir", vec![])),
+                VfsNode::File(VfsFile::new("b-file.txt")),
+            ],
+        );
+
+        assert_eq!(root.children().len(), 2);
+        assert_eq!(root.directories().count(), 1);
+        assert_eq!(root.files().count(), 1);
+    }
+
+    #[test]
+    fn sorts_directories_before_files_alphabetically() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![
+                VfsNode::File(VfsFile::new("z-file.txt")),
+                VfsNode::Directory(VfsDirectory::with_children("b-dir", vec![])),
+                VfsNode::File(VfsFile::new("a-file.txt")),
+                VfsNode::Directory(VfsDirectory::with_children("a-dir", vec![])),
+            ],
+        );
+
+        let names: Vec<_> = root.children().iter().map(|node| node.name()).collect();
+
+        assert_eq!(names, vec!["a-dir", "b-dir", "a-file.txt", "z-file.txt"]);
+    }
+
+    #[test]
+    fn add_child_maintains_stable_ordering() {
+        let mut root = VfsDirectory::new("");
+
+        root.add_child(VfsNode::File(VfsFile::new("z-file.txt")));
+        root.add_child(VfsNode::Directory(VfsDirectory::with_children(
+            "b-dir",
+            vec![],
+        )));
+        root.add_child(VfsNode::File(VfsFile::new("a-file.txt")));
+        root.add_child(VfsNode::Directory(VfsDirectory::with_children(
+            "a-dir",
+            vec![],
+        )));
+
+        let names: Vec<_> = root.children().iter().map(|node| node.name()).collect();
+
+        assert_eq!(names, vec!["a-dir", "b-dir", "a-file.txt", "z-file.txt"]);
     }
 }

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -175,6 +175,11 @@ fn sort_nodes(nodes: &mut [VfsNode]) {
     nodes.sort_by(|left, right| {
         node_kind_order(left)
             .cmp(&node_kind_order(right))
+            .then_with(|| {
+                left.name()
+                    .to_ascii_lowercase()
+                    .cmp(&right.name().to_ascii_lowercase())
+            })
             .then_with(|| left.name().cmp(right.name()))
     });
 }
@@ -358,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    fn sorts_directories_before_files_alphabetically() {
+    fn sorts_directories_before_files_case_insensitively() {
         let root = VfsDirectory::with_children(
             "",
             vec![
@@ -392,5 +397,21 @@ mod tests {
         let names: Vec<_> = root.children().iter().map(|node| node.name()).collect();
 
         assert_eq!(names, vec!["a-dir", "b-dir", "a-file.txt", "z-file.txt"]);
+    }
+
+    #[test]
+    fn sorts_names_case_insensitively_for_browse_order() {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![
+                VfsNode::File(VfsFile::new("zeta.txt")),
+                VfsNode::File(VfsFile::new("Alpha.txt")),
+                VfsNode::File(VfsFile::new("beta.txt")),
+            ],
+        );
+
+        let names: Vec<_> = root.children().iter().map(|node| node.name()).collect();
+
+        assert_eq!(names, vec!["Alpha.txt", "beta.txt", "zeta.txt"]);
     }
 }

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -171,15 +171,19 @@ fn split_path(path: &str) -> (&str, Option<&str>) {
     }
 }
 
-fn node_sort_key(node: &VfsNode) -> (u8, &str) {
-    match node {
-        VfsNode::Directory(dir) => (0, dir.name.as_str()),
-        VfsNode::File(file) => (1, file.name.as_str()),
-    }
+fn sort_nodes(nodes: &mut [VfsNode]) {
+    nodes.sort_by(|left, right| {
+        node_kind_order(left)
+            .cmp(&node_kind_order(right))
+            .then_with(|| left.name().cmp(right.name()))
+    });
 }
 
-fn sort_nodes(nodes: &mut [VfsNode]) {
-    nodes.sort_by(|left, right| node_sort_key(left).cmp(&node_sort_key(right)));
+fn node_kind_order(node: &VfsNode) -> u8 {
+    match node {
+        VfsNode::Directory(_) => 0,
+        VfsNode::File(_) => 1,
+    }
 }
 
 #[cfg(test)]

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -200,12 +200,12 @@ mod tests {
             ))],
         );
 
-        assert_eq!(root.children.len(), 1);
+        assert_eq!(root.children().len(), 1);
 
-        match &root.children[0] {
+        match &root.children()[0] {
             VfsNode::Directory(dir) => {
                 assert_eq!(dir.name, "snes");
-                assert_eq!(dir.children.len(), 1);
+                assert_eq!(dir.children().len(), 1);
             }
             _ => panic!("expected directory"),
         }

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -173,13 +173,13 @@ fn split_path(path: &str) -> (&str, Option<&str>) {
 
 fn node_sort_key(node: &VfsNode) -> (u8, &str) {
     match node {
-        VfsNode::Directory(dir) => (0, &dir.name),
-        VfsNode::File(file) => (1, &file.name),
+        VfsNode::Directory(dir) => (0, dir.name.as_str()),
+        VfsNode::File(file) => (1, file.name.as_str()),
     }
 }
 
 fn sort_nodes(nodes: &mut [VfsNode]) {
-    nodes.sort_by_key(node_sort_key);
+    nodes.sort_by(|left, right| node_sort_key(left).cmp(&node_sort_key(right)));
 }
 
 #[cfg(test)]

--- a/src/engine/preview.rs
+++ b/src/engine/preview.rs
@@ -49,7 +49,7 @@ pub fn build_input_source(path: &Path) -> Result<Box<dyn InputSource>, Retromoun
 pub fn write_vfs_tree<W: Write>(writer: &mut W, root: &VfsDirectory) -> io::Result<()> {
     writeln!(writer, "/")?;
 
-    for child in &root.children {
+    for child in root.children() {
         write_vfs_node(writer, child, 1)?;
     }
 
@@ -66,7 +66,7 @@ fn write_vfs_node<W: Write>(writer: &mut W, node: &VfsNode, depth: usize) -> io:
         VfsNode::Directory(dir) => {
             writeln!(writer, "{indent}{}/", dir.name)?;
 
-            for child in &dir.children {
+            for child in dir.children() {
                 write_vfs_node(writer, child, depth + 1)?;
             }
         }
@@ -95,7 +95,7 @@ mod tests {
         write_vfs_tree(&mut output, &root).unwrap();
 
         let rendered = String::from_utf8(output).unwrap();
-        assert_eq!(rendered, "/\n  mario.sfc\n  readme.txt\n  blob.dat.bin\n");
+        assert_eq!(rendered, "/\n  blob.dat.bin\n  mario.sfc\n  readme.txt\n");
     }
 
     #[test]

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -141,22 +141,21 @@ where
             .map(|(_, entry)| entry.encoded.name.clone())
             .collect();
 
-        let mut children: Vec<VfsNode> = disc_entries
-            .into_iter()
-            .map(|(_, entry)| {
-                VfsNode::File(VfsFile::source_backed(
-                    entry.encoded.name.clone(),
-                    entry.encoded.size,
-                    entry.content.source().clone(),
-                ))
-            })
-            .collect();
+        let mut dir = VfsDirectory::new(&key.title);
 
-        children.push(VfsNode::File(
+        for (_, entry) in disc_entries {
+            dir.add_child(VfsNode::File(VfsFile::source_backed(
+                entry.encoded.name.clone(),
+                entry.encoded.size,
+                entry.content.source().clone(),
+            )));
+        }
+
+        dir.add_child(VfsNode::File(
             self.build_m3u_file(&key.title, &disc_file_names),
         ));
 
-        VfsDirectory::with_children(&key.title, children)
+        dir
     }
 
     fn build_m3u_file(&self, title: &str, disc_file_names: &[String]) -> VfsFile {
@@ -220,20 +219,20 @@ mod tests {
         let root = presenter.present(&content);
 
         assert_eq!(root.name, "");
-        assert_eq!(root.children.len(), 4);
+        assert_eq!(root.children().len(), 4);
 
-        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
+        let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
         assert_eq!(
             names,
             vec![
                 "bios.bin",
-                "Sonic the Hedgehog.bin",
                 "Final Fantasy VII (Disc 1).cue",
                 "manifest.txt",
+                "Sonic the Hedgehog.bin",
             ]
         );
 
-        match &root.children[0] {
+        match &root.children()[0] {
             VfsNode::File(file) => match &file.backing {
                 FileBacking::Source(source) => {
                     assert_eq!(source.to_string(), "file:/roms/bios");
@@ -273,16 +272,20 @@ mod tests {
 
         let root = presenter.present(&content);
 
-        assert_eq!(root.children.len(), 2);
-        assert_eq!(root.children[0].name(), "Crash Bandicoot.bin");
-        assert_eq!(root.children[1].name(), "Final Fantasy VII");
+        assert_eq!(root.children().len(), 2);
+        assert_eq!(root.children()[0].name(), "Crash Bandicoot.bin");
+        assert_eq!(root.children()[1].name(), "Final Fantasy VII");
 
-        let directory = match &root.children[1] {
+        let directory = match &root.children()[1] {
             VfsNode::Directory(directory) => directory,
             other => panic!("expected directory, got {other:?}"),
         };
 
-        let child_names: Vec<&str> = directory.children.iter().map(|node| node.name()).collect();
+        let child_names: Vec<&str> = directory
+            .children()
+            .iter()
+            .map(|node| node.name())
+            .collect();
         assert_eq!(
             child_names,
             vec![
@@ -292,7 +295,9 @@ mod tests {
             ]
         );
 
-        let playlist = match &directory.children[2] {
+        assert_eq!(directory.files().count(), 3);
+
+        let playlist = match &directory.children()[2] {
             VfsNode::File(file) => file,
             other => panic!("expected file, got {other:?}"),
         };
@@ -322,8 +327,8 @@ mod tests {
 
         let root = presenter.present(&content);
 
-        assert_eq!(root.children.len(), 1);
-        assert_eq!(root.children[0].name(), "Metal Gear Solid (Disc 1).cue");
+        assert_eq!(root.children().len(), 1);
+        assert_eq!(root.children()[0].name(), "Metal Gear Solid (Disc 1).cue");
     }
 
     #[test]
@@ -356,17 +361,21 @@ mod tests {
 
         let root = presenter.present(&content);
 
-        assert_eq!(root.children.len(), 2);
+        assert_eq!(root.children().len(), 2);
 
-        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
+        let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["game", "game (Disc 1).cue"]);
 
-        let multi_dir = match &root.children[0] {
+        let multi_dir = match &root.children()[0] {
             VfsNode::Directory(directory) => directory,
             other => panic!("expected directory, got {other:?}"),
         };
 
-        let child_names: Vec<&str> = multi_dir.children.iter().map(|node| node.name()).collect();
+        let child_names: Vec<&str> = multi_dir
+            .children()
+            .iter()
+            .map(|node| node.name())
+            .collect();
         assert_eq!(
             child_names,
             vec!["game (Disc 1).cue", "game (Disc 2).cue", "game.m3u"]

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -225,10 +225,10 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "Final Fantasy VII (Disc 1).cue",
-                "Sonic the Hedgehog.bin",
                 "bios.bin",
+                "Final Fantasy VII (Disc 1).cue",
                 "manifest.txt",
+                "Sonic the Hedgehog.bin",
             ]
         );
 

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -225,10 +225,10 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "bios.bin",
                 "Final Fantasy VII (Disc 1).cue",
-                "manifest.txt",
                 "Sonic the Hedgehog.bin",
+                "bios.bin",
+                "manifest.txt",
             ]
         );
 
@@ -273,10 +273,10 @@ mod tests {
         let root = presenter.present(&content);
 
         assert_eq!(root.children().len(), 2);
-        assert_eq!(root.children()[0].name(), "Crash Bandicoot.bin");
-        assert_eq!(root.children()[1].name(), "Final Fantasy VII");
+        assert_eq!(root.children()[0].name(), "Final Fantasy VII");
+        assert_eq!(root.children()[1].name(), "Crash Bandicoot.bin");
 
-        let directory = match &root.children()[1] {
+        let directory = match &root.children()[0] {
             VfsNode::Directory(directory) => directory,
             other => panic!("expected directory, got {other:?}"),
         };


### PR DESCRIPTION
## Summary

This PR completes the `phase3-vfs-browse` slice by making the VFS easier and more consistent to traverse for callers.

It adds canonical browse helpers to `VfsDirectory`, introduces deterministic child ordering, and updates preview/presenter code and tests to align with the new VFS traversal behaviour.

## What changed

### VFS browse API
- Added `children()` accessor on `VfsDirectory`
- Added `files()` iterator helper
- Added `directories()` iterator helper
- Added `add_child()` helper for incremental construction

### VFS traversal behaviour
- Kept path lookup helpers in place for files/directories/nodes
- Kept root directory lookup via empty path
- Preserved current case-sensitive lookup semantics

### Directory ordering
- Added deterministic ordering for VFS directory contents
- Directories are sorted before files
- Browse ordering is case-insensitive for more natural user-facing output
- Original name is still used as a tie-breaker for deterministic results

### Preview / inspect / presenter alignment
- Updated preview tree rendering to use VFS browse APIs instead of direct child access
- Kept inspect delegating VFS rendering through the preview helper
- Updated `GenericPresenter` to use `add_child()` for multi-disc directory construction
- Updated presenter tests to reflect deterministic browse ordering

## Why

This moves the VFS further from being just a data container and closer to being a real filesystem abstraction.

In particular, it gives us:
- a canonical way to browse directory contents
- predictable output ordering
- more natural user-facing listings
- a cleaner base for future work around hierarchical layout and mount preparation

## Testing

Verified with:
- `cargo test`
- local Linux run of `retromount inspect ./retromount-testdata`
- CI green

Current test status:
- 100 tests passing locally
- CI passing

## Example outcome

Presented VFS output is now deterministic and user-friendly, for example:

```text
/
  game/
    game (Disc 1).cue
    game (Disc 2).cue
    game.m3u
  game (Disc 1).cue
  mixed/game1.nes
  mixed/nested.zip.bin
  mixed/notes.txt
  mixed/screenshot.png.bin
  roms/snes/cover.jpg.bin
  roms/snes/game.txt
  roms/snes/Super Mario World.sfc
  roms/snes/Zelda.sfc
  zips/gameboy_collection.zip.bin
  zips_ps1/ps1_game.zip.bin