### PR TITLE
Phase 3: normalize games into a platform-based library view

### DIFF
--- a/generate-testdata.sh
+++ b/generate-testdata.sh
@@ -13,7 +13,7 @@ mkdir -p "$BASE"
 mkdir -p "$BASE/roms/snes"
 
 echo "fake rom data" > "$BASE/roms/snes/Super Mario World.sfc"
-echo "fake rom data" > "$BASE/roms/snes/Zelda.sfc"
+echo "fake rom data" > "$BASE/roms/snes/Super Castlevania IV.sfc"
 
 # junk files
 echo "Some release notes" > "$BASE/roms/snes/game.nfo"
@@ -24,8 +24,8 @@ echo "cover image" > "$BASE/roms/snes/cover.jpg"
 # ----------------------------
 mkdir -p "$BASE/zips/tmp"
 
-echo "rom1" > "$BASE/zips/tmp/game1.gb"
-echo "rom2" > "$BASE/zips/tmp/game2.gb"
+echo "rom1" > "$BASE/zips/tmp/DrMario.gb"
+echo "rom2" > "$BASE/zips/tmp/Tetris.gb"
 echo "readme" > "$BASE/zips/tmp/readme.txt"
 
 (
@@ -40,10 +40,10 @@ rm -rf "$BASE/zips/tmp"
 # ----------------------------
 mkdir -p "$BASE/discs/ps1_single"
 
-echo "binarydata" > "$BASE/discs/ps1_single/game.bin"
+echo "binarydata" > "$BASE/discs/ps1_single/Crash Bandicoot.bin"
 
-cat > "$BASE/discs/ps1_single/game.cue" <<EOF
-FILE "game.bin" BINARY
+cat > "$BASE/discs/ps1_single/Crash Bandicoot.cue" <<EOF
+FILE "Crash Bandicoot.bin" BINARY
   TRACK 01 MODE2/2352
     INDEX 01 00:00:00
 EOF
@@ -54,10 +54,10 @@ EOF
 mkdir -p "$BASE/discs/ps1_multi"
 
 for i in 1 2; do
-  echo "disc$i" > "$BASE/discs/ps1_multi/game_disc${i}.bin"
+  echo "disc$i" > "$BASE/discs/ps1_multi/Final Fantasy VII (Disc $i).bin"
 
-  cat > "$BASE/discs/ps1_multi/game_disc${i}.cue" <<EOF
-FILE "game_disc${i}.bin" BINARY
+  cat > "$BASE/discs/ps1_multi/Final Fantasy VII (Disc $i).cue" <<EOF
+FILE "Final Fantasy VII (Disc $i).bin" BINARY
   TRACK 01 MODE2/2352
     INDEX 01 00:00:00
 EOF
@@ -68,10 +68,10 @@ done
 # ----------------------------
 mkdir -p "$BASE/zips_ps1/tmp"
 
-echo "discdata" > "$BASE/zips_ps1/tmp/game.bin"
+echo "discdata" > "$BASE/zips_ps1/tmp/Metal Gear Solid.bin"
 
-cat > "$BASE/zips_ps1/tmp/game.cue" <<EOF
-FILE "game.bin" BINARY
+cat > "$BASE/zips_ps1/tmp/Metal Gear Solid.cue" <<EOF
+FILE "Metal Gear Solid.bin" BINARY
   TRACK 01 MODE2/2352
     INDEX 01 00:00:00
 EOF
@@ -88,13 +88,13 @@ rm -rf "$BASE/zips_ps1/tmp"
 # ----------------------------
 mkdir -p "$BASE/mixed"
 
-echo "rom" > "$BASE/mixed/game1.nes"
+echo "rom" > "$BASE/mixed/Castlevania.nes"
 echo "random text" > "$BASE/mixed/notes.txt"
 echo "image" > "$BASE/mixed/screenshot.png"
 
 # nested zip
 mkdir -p "$BASE/mixed/tmp"
-echo "nested rom" > "$BASE/mixed/tmp/nested.gb"
+echo "nested rom" > "$BASE/mixed/tmp/KirbysDreamLand.gb"
 (
   cd "$BASE/mixed/tmp"
   zip -q ../nested.zip *

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -14,6 +14,29 @@ pub enum ContentKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum Platform {
+    Snes,
+    Ps1,
+    Nes,
+    Megadrive,
+    Unknown,
+}
+
+impl fmt::Display for Platform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Snes => "snes",
+            Self::Ps1 => "ps1",
+            Self::Nes => "nes",
+            Self::Megadrive => "megadrive",
+            Self::Unknown => "unknown",
+        };
+
+        write!(f, "{value}")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ContentId(pub Arc<str>);
 
 impl ContentId {
@@ -106,6 +129,7 @@ pub struct GameContent {
     pub id: ContentId,
     pub source: SourceRef,
     pub title: String,
+    pub platform: Platform,
     pub parts: Vec<GamePart>,
     pub consumed_sources: Vec<SourceRef>,
 }
@@ -161,6 +185,7 @@ mod tests {
             id: ContentId::new("game"),
             source: SourceRef::new("file:/roms/game.sfc"),
             title: "game".to_string(),
+            platform: Platform::Snes,
             parts: vec![GamePart::Rom(RomPart {
                 source: SourceRef::new("file:/roms/game.sfc"),
                 file_name: "game.sfc".to_string(),
@@ -198,6 +223,7 @@ mod tests {
             id: ContentId::new("ff7"),
             source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
             title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
             parts: vec![GamePart::Disc(DiscPart {
                 source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
                 disc_number: 1,
@@ -211,5 +237,14 @@ mod tests {
             content.consumed_sources()[0].to_string(),
             "cue:/roms/ff7-disc1.bin"
         );
+    }
+
+    #[test]
+    fn formats_platform_as_expected() {
+        assert_eq!(Platform::Snes.to_string(), "snes");
+        assert_eq!(Platform::Ps1.to_string(), "ps1");
+        assert_eq!(Platform::Nes.to_string(), "nes");
+        assert_eq!(Platform::Megadrive.to_string(), "megadrive");
+        assert_eq!(Platform::Unknown.to_string(), "unknown");
     }
 }

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -9,6 +9,7 @@ pub enum ContentKind {
     Bytes,
     Rom,
     Disc,
+    Game,
     Text,
 }
 
@@ -32,6 +33,7 @@ pub enum Content {
     Bytes(BytesContent),
     Rom(RomContent),
     Disc(DiscContent),
+    Game(GameContent),
     Text(TextContent),
 }
 
@@ -41,6 +43,7 @@ impl Content {
             Self::Bytes(_) => ContentKind::Bytes,
             Self::Rom(_) => ContentKind::Rom,
             Self::Disc(_) => ContentKind::Disc,
+            Self::Game(_) => ContentKind::Game,
             Self::Text(_) => ContentKind::Text,
         }
     }
@@ -50,6 +53,7 @@ impl Content {
             Self::Bytes(v) => &v.id,
             Self::Rom(v) => &v.id,
             Self::Disc(v) => &v.id,
+            Self::Game(v) => &v.id,
             Self::Text(v) => &v.id,
         }
     }
@@ -59,6 +63,7 @@ impl Content {
             Self::Bytes(v) => &v.source,
             Self::Rom(v) => &v.source,
             Self::Disc(v) => &v.source,
+            Self::Game(v) => &v.source,
             Self::Text(v) => &v.source,
         }
     }
@@ -66,6 +71,7 @@ impl Content {
     pub fn consumed_sources(&self) -> &[SourceRef] {
         match self {
             Self::Disc(v) => &v.consumed_sources,
+            Self::Game(v) => &v.consumed_sources,
             _ => &[],
         }
     }
@@ -96,6 +102,35 @@ pub struct DiscContent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GameContent {
+    pub id: ContentId,
+    pub source: SourceRef,
+    pub title: String,
+    pub parts: Vec<GamePart>,
+    pub consumed_sources: Vec<SourceRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum GamePart {
+    Rom(RomPart),
+    Disc(DiscPart),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RomPart {
+    pub source: SourceRef,
+    pub file_name: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DiscPart {
+    pub source: SourceRef,
+    pub disc_number: u32,
+    pub consumed_sources: Vec<SourceRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TextContent {
     pub id: ContentId,
     pub source: SourceRef,
@@ -121,6 +156,25 @@ mod tests {
     }
 
     #[test]
+    fn returns_game_content_kind() {
+        let content = Content::Game(GameContent {
+            id: ContentId::new("game"),
+            source: SourceRef::new("file:/roms/game.sfc"),
+            title: "game".to_string(),
+            parts: vec![GamePart::Rom(RomPart {
+                source: SourceRef::new("file:/roms/game.sfc"),
+                file_name: "game.sfc".to_string(),
+                size: 123,
+            })],
+            consumed_sources: vec![],
+        });
+
+        assert_eq!(content.kind(), ContentKind::Game);
+        assert_eq!(content.id().to_string(), "game");
+        assert_eq!(content.source().to_string(), "file:/roms/game.sfc");
+    }
+
+    #[test]
     fn returns_source_and_consumed_sources() {
         let content = Content::Disc(DiscContent {
             id: ContentId::new("game"),
@@ -135,6 +189,27 @@ mod tests {
         assert_eq!(
             content.consumed_sources()[0].to_string(),
             "cue:/roms/game.bin"
+        );
+    }
+
+    #[test]
+    fn returns_game_consumed_sources() {
+        let content = Content::Game(GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            parts: vec![GamePart::Disc(DiscPart {
+                source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
+            })],
+            consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
+        });
+
+        assert_eq!(content.consumed_sources().len(), 1);
+        assert_eq!(
+            content.consumed_sources()[0].to_string(),
+            "cue:/roms/ff7-disc1.bin"
         );
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod game_image;
 pub mod input_handler;
 pub mod input_registry;
 pub mod junk_filter;
+pub mod normalizer;
 pub mod platform;
 pub mod reader;
 pub mod reader_factory;

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core::content::{
-    Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, RomPart,
+    Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, Platform, RomPart,
 };
 use crate::core::source::SourceRef;
 
@@ -34,6 +34,7 @@ pub fn normalize_content(contents: Vec<Content>) -> Vec<Content> {
                     id: rom.id.clone(),
                     source: rom.source.clone(),
                     title: leaf_stem(&rom.file_name),
+                    platform: derive_platform(&rom.file_name),
                     parts: vec![GamePart::Rom(RomPart {
                         source: rom.source,
                         file_name: rom.file_name,
@@ -82,6 +83,28 @@ fn consumed_rom_sources(contents: &[Content]) -> HashSet<SourceRef> {
         .collect()
 }
 
+fn derive_platform(path: &str) -> Platform {
+    let path = path.to_lowercase();
+
+    let mappings = [
+        ("snes", Platform::Snes),
+        ("ps1", Platform::Ps1),
+        ("psx", Platform::Ps1),
+        ("playstation", Platform::Ps1),
+        ("nes", Platform::Nes),
+        ("megadrive", Platform::Megadrive),
+        ("genesis", Platform::Megadrive),
+    ];
+
+    for (needle, platform) in mappings {
+        if path.contains(needle) {
+            return platform;
+        }
+    }
+
+    Platform::Unknown
+}
+
 fn normalize_disc_group(key: &DiscGroupKey, mut discs: Vec<DiscContent>) -> GameContent {
     discs.sort_by(|left, right| {
         left.disc_number
@@ -113,6 +136,7 @@ fn normalize_disc_group(key: &DiscGroupKey, mut discs: Vec<DiscContent>) -> Game
         id: ContentId::new(game_id_for(key)),
         source: primary.source.clone(),
         title: primary.title.clone(),
+        platform: derive_platform(&primary.source.to_string()),
         parts,
         consumed_sources,
     }
@@ -175,6 +199,7 @@ mod tests {
         };
 
         assert_eq!(game.title, "Super Mario World");
+        assert_eq!(game.platform, Platform::Snes);
         assert_eq!(game.parts.len(), 1);
 
         match &game.parts[0] {
@@ -213,6 +238,7 @@ mod tests {
         };
 
         assert_eq!(game.title, "Final Fantasy VII");
+        assert_eq!(game.platform, Platform::Ps1);
         assert_eq!(game.parts.len(), 2);
 
         match &game.parts[0] {
@@ -297,5 +323,23 @@ mod tests {
         };
 
         assert_eq!(game.title, "Super Mario World");
+    }
+
+    #[test]
+    fn derives_platform_from_path() {
+        assert_eq!(derive_platform("roms/snes/game.sfc"), Platform::Snes);
+        assert_eq!(derive_platform("roms/ps1/game.cue"), Platform::Ps1);
+        assert_eq!(derive_platform("roms/psx/game.cue"), Platform::Ps1);
+        assert_eq!(derive_platform("roms/playstation/game.cue"), Platform::Ps1);
+        assert_eq!(derive_platform("roms/nes/game.nes"), Platform::Nes);
+        assert_eq!(
+            derive_platform("roms/megadrive/game.bin"),
+            Platform::Megadrive
+        );
+        assert_eq!(
+            derive_platform("roms/genesis/game.bin"),
+            Platform::Megadrive
+        );
+        assert_eq!(derive_platform("roms/unknown/game.bin"), Platform::Unknown);
     }
 }

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -1,0 +1,229 @@
+use std::collections::HashMap;
+
+use crate::core::content::{
+    Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, RomPart,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DiscGroupKey {
+    parent: String,
+    title: String,
+}
+
+#[derive(Debug, Clone)]
+enum PendingOutput {
+    Direct(Content),
+    DiscGroup(DiscGroupKey),
+}
+
+pub fn normalize_content(contents: Vec<Content>) -> Vec<Content> {
+    let mut pending = Vec::new();
+    let mut disc_groups: HashMap<DiscGroupKey, Vec<DiscContent>> = HashMap::new();
+
+    for content in contents {
+        match content {
+            Content::Rom(rom) => {
+                pending.push(PendingOutput::Direct(Content::Game(GameContent {
+                    id: rom.id.clone(),
+                    source: rom.source.clone(),
+                    title: strip_extension(&rom.file_name),
+                    parts: vec![GamePart::Rom(RomPart {
+                        source: rom.source,
+                        file_name: rom.file_name,
+                        size: rom.size,
+                    })],
+                    consumed_sources: vec![],
+                })));
+            }
+            Content::Disc(disc) => {
+                let key = disc_group_key(&disc);
+
+                if !disc_groups.contains_key(&key) {
+                    pending.push(PendingOutput::DiscGroup(key.clone()));
+                }
+
+                disc_groups.entry(key).or_default().push(disc);
+            }
+            other => pending.push(PendingOutput::Direct(other)),
+        }
+    }
+
+    let mut normalized = Vec::new();
+
+    for item in pending {
+        match item {
+            PendingOutput::Direct(content) => normalized.push(content),
+            PendingOutput::DiscGroup(key) => {
+                if let Some(discs) = disc_groups.remove(&key) {
+                    normalized.push(Content::Game(normalize_disc_group(&key, discs)));
+                }
+            }
+        }
+    }
+
+    normalized
+}
+
+fn normalize_disc_group(key: &DiscGroupKey, mut discs: Vec<DiscContent>) -> GameContent {
+    discs.sort_by(|left, right| {
+        left.disc_number
+            .cmp(&right.disc_number)
+            .then_with(|| left.id.0.cmp(&right.id.0))
+    });
+
+    let primary = discs
+        .first()
+        .expect("normalize_disc_group called with empty disc list");
+
+    let parts = discs
+        .iter()
+        .map(|disc| {
+            GamePart::Disc(DiscPart {
+                source: disc.source.clone(),
+                disc_number: disc.disc_number,
+                consumed_sources: disc.consumed_sources.clone(),
+            })
+        })
+        .collect();
+
+    let consumed_sources = discs
+        .iter()
+        .flat_map(|disc| disc.consumed_sources.iter().cloned())
+        .collect();
+
+    GameContent {
+        id: ContentId::new(game_id_for(key)),
+        source: primary.source.clone(),
+        title: primary.title.clone(),
+        parts,
+        consumed_sources,
+    }
+}
+
+fn disc_group_key(content: &DiscContent) -> DiscGroupKey {
+    DiscGroupKey {
+        parent: logical_parent_path(content.id.0.as_ref()),
+        title: content.title.clone(),
+    }
+}
+
+fn logical_parent_path(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+
+    match normalized.rsplit_once('/') {
+        Some((parent, _)) => parent.to_string(),
+        None => String::new(),
+    }
+}
+
+fn game_id_for(key: &DiscGroupKey) -> String {
+    if key.parent.is_empty() {
+        key.title.clone()
+    } else {
+        format!("{}/{}", key.parent, key.title)
+    }
+}
+
+fn strip_extension(name: &str) -> String {
+    match name.rsplit_once('.') {
+        Some((base, _)) => base.to_string(),
+        None => name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::content::{Content, ContentId, DiscContent, GamePart, RomContent};
+    use crate::core::source::SourceRef;
+
+    #[test]
+    fn normalizes_rom_to_game() {
+        let normalized = normalize_content(vec![Content::Rom(RomContent {
+            id: ContentId::new("smw"),
+            source: SourceRef::new("file:/roms/Super Mario World.sfc"),
+            file_name: "Super Mario World.sfc".to_string(),
+            size: 4096,
+        })]);
+
+        assert_eq!(normalized.len(), 1);
+
+        let game = match &normalized[0] {
+            Content::Game(game) => game,
+            other => panic!("expected game, got {other:?}"),
+        };
+
+        assert_eq!(game.title, "Super Mario World");
+        assert_eq!(game.parts.len(), 1);
+
+        match &game.parts[0] {
+            GamePart::Rom(part) => {
+                assert_eq!(part.file_name, "Super Mario World.sfc");
+                assert_eq!(part.size, 4096);
+            }
+            other => panic!("expected rom part, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn groups_discs_into_single_game() {
+        let normalized = normalize_content(vec![
+            Content::Disc(DiscContent {
+                id: ContentId::new("ps1/ff7-disc2"),
+                source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+                title: "Final Fantasy VII".to_string(),
+                disc_number: 2,
+                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("ps1/ff7-disc1"),
+                source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+                title: "Final Fantasy VII".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
+            }),
+        ]);
+
+        assert_eq!(normalized.len(), 1);
+
+        let game = match &normalized[0] {
+            Content::Game(game) => game,
+            other => panic!("expected game, got {other:?}"),
+        };
+
+        assert_eq!(game.title, "Final Fantasy VII");
+        assert_eq!(game.parts.len(), 2);
+
+        match &game.parts[0] {
+            GamePart::Disc(part) => assert_eq!(part.disc_number, 1),
+            other => panic!("expected disc part, got {other:?}"),
+        }
+
+        match &game.parts[1] {
+            GamePart::Disc(part) => assert_eq!(part.disc_number, 2),
+            other => panic!("expected disc part, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn does_not_merge_same_title_from_different_directories() {
+        let normalized = normalize_content(vec![
+            Content::Disc(DiscContent {
+                id: ContentId::new("ps1_multi/game_disc1.cue"),
+                source: SourceRef::new("file:/roms/ps1_multi/game_disc1.cue"),
+                title: "game".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("file:/roms/ps1_multi/game_disc1.bin")],
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("ps1_single/game.cue"),
+                source: SourceRef::new("file:/roms/ps1_single/game.cue"),
+                title: "game".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("file:/roms/ps1_single/game.bin")],
+            }),
+        ]);
+
+        assert_eq!(normalized.len(), 2);
+    }
+}

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -84,25 +84,35 @@ fn consumed_rom_sources(contents: &[Content]) -> HashSet<SourceRef> {
 }
 
 fn derive_platform(path: &str) -> Platform {
-    let path = path.to_lowercase();
+    let normalized = path.to_lowercase().replace('\\', "/");
 
-    let mappings = [
-        ("snes", Platform::Snes),
-        ("ps1", Platform::Ps1),
-        ("psx", Platform::Ps1),
-        ("playstation", Platform::Ps1),
-        ("nes", Platform::Nes),
-        ("megadrive", Platform::Megadrive),
-        ("genesis", Platform::Megadrive),
-    ];
+    platform_from_segments(&normalized).unwrap_or_else(|| platform_from_extension(&normalized))
+}
 
-    for (needle, platform) in mappings {
-        if path.contains(needle) {
-            return platform;
-        }
+fn platform_from_segments(path: &str) -> Option<Platform> {
+    for segment in path.split('/').filter(|segment| !segment.is_empty()) {
+        let platform = match segment {
+            "snes" => Platform::Snes,
+            "ps1" | "psx" | "playstation" => Platform::Ps1,
+            "nes" => Platform::Nes,
+            "megadrive" | "genesis" => Platform::Megadrive,
+            _ => continue,
+        };
+
+        return Some(platform);
     }
 
-    Platform::Unknown
+    None
+}
+
+fn platform_from_extension(path: &str) -> Platform {
+    if path.ends_with(".sfc") || path.ends_with(".smc") {
+        Platform::Snes
+    } else if path.ends_with(".nes") {
+        Platform::Nes
+    } else {
+        Platform::Unknown
+    }
 }
 
 fn normalize_disc_group(key: &DiscGroupKey, mut discs: Vec<DiscContent>) -> GameContent {
@@ -216,17 +226,17 @@ mod tests {
         let normalized = normalize_content(vec![
             Content::Disc(DiscContent {
                 id: ContentId::new("ps1/ff7-disc2"),
-                source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+                source: SourceRef::new("cue:/roms/ps1/ff7-disc2.cue"),
                 title: "Final Fantasy VII".to_string(),
                 disc_number: 2,
-                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+                consumed_sources: vec![SourceRef::new("cue:/roms/ps1/ff7-disc2.bin")],
             }),
             Content::Disc(DiscContent {
                 id: ContentId::new("ps1/ff7-disc1"),
-                source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+                source: SourceRef::new("cue:/roms/ps1/ff7-disc1.cue"),
                 title: "Final Fantasy VII".to_string(),
                 disc_number: 1,
-                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
+                consumed_sources: vec![SourceRef::new("cue:/roms/ps1/ff7-disc1.bin")],
             }),
         ]);
 
@@ -341,5 +351,9 @@ mod tests {
             Platform::Megadrive
         );
         assert_eq!(derive_platform("roms/unknown/game.bin"), Platform::Unknown);
+        assert_eq!(derive_platform("roms/game.sfc"), Platform::Snes);
+        assert_eq!(derive_platform("roms/game.smc"), Platform::Snes);
+        assert_eq!(derive_platform("roms/game.nes"), Platform::Nes);
+        assert_eq!(derive_platform("roms/game.cue"), Platform::Unknown);
     }
 }

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -1,8 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::core::content::{
     Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, RomPart,
 };
+use crate::core::source::SourceRef;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct DiscGroupKey {
@@ -17,16 +18,22 @@ enum PendingOutput {
 }
 
 pub fn normalize_content(contents: Vec<Content>) -> Vec<Content> {
+    let consumed_by_discs = consumed_rom_sources(&contents);
+
     let mut pending = Vec::new();
     let mut disc_groups: HashMap<DiscGroupKey, Vec<DiscContent>> = HashMap::new();
 
     for content in contents {
         match content {
             Content::Rom(rom) => {
+                if consumed_by_discs.contains(&rom.source) {
+                    continue;
+                }
+
                 pending.push(PendingOutput::Direct(Content::Game(GameContent {
                     id: rom.id.clone(),
                     source: rom.source.clone(),
-                    title: strip_extension(&rom.file_name),
+                    title: leaf_stem(&rom.file_name),
                     parts: vec![GamePart::Rom(RomPart {
                         source: rom.source,
                         file_name: rom.file_name,
@@ -62,6 +69,17 @@ pub fn normalize_content(contents: Vec<Content>) -> Vec<Content> {
     }
 
     normalized
+}
+
+fn consumed_rom_sources(contents: &[Content]) -> HashSet<SourceRef> {
+    contents
+        .iter()
+        .filter_map(|content| match content {
+            Content::Disc(disc) => Some(disc),
+            _ => None,
+        })
+        .flat_map(|disc| disc.consumed_sources.iter().cloned())
+        .collect()
 }
 
 fn normalize_disc_group(key: &DiscGroupKey, mut discs: Vec<DiscContent>) -> GameContent {
@@ -124,10 +142,13 @@ fn game_id_for(key: &DiscGroupKey) -> String {
     }
 }
 
-fn strip_extension(name: &str) -> String {
-    match name.rsplit_once('.') {
+fn leaf_stem(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    let leaf = normalized.rsplit('/').next().unwrap_or(&normalized);
+
+    match leaf.rsplit_once('.') {
         Some((base, _)) => base.to_string(),
-        None => name.to_string(),
+        None => leaf.to_string(),
     }
 }
 
@@ -206,6 +227,40 @@ mod tests {
     }
 
     #[test]
+    fn suppresses_roms_consumed_by_discs() {
+        let normalized = normalize_content(vec![
+            Content::Rom(RomContent {
+                id: ContentId::new("discs/ps1_multi/game_disc1.bin"),
+                source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.bin"),
+                file_name: "discs/ps1_multi/game_disc1.bin".to_string(),
+                size: 6,
+            }),
+            Content::Disc(DiscContent {
+                id: ContentId::new("discs/ps1_multi/game_disc1.cue"),
+                source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.cue"),
+                title: "game".to_string(),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.bin")],
+            }),
+        ]);
+
+        assert_eq!(normalized.len(), 1);
+
+        let game = match &normalized[0] {
+            Content::Game(game) => game,
+            other => panic!("expected game, got {other:?}"),
+        };
+
+        assert_eq!(game.title, "game");
+        assert_eq!(game.parts.len(), 1);
+
+        match &game.parts[0] {
+            GamePart::Disc(part) => assert_eq!(part.disc_number, 1),
+            other => panic!("expected disc part, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn does_not_merge_same_title_from_different_directories() {
         let normalized = normalize_content(vec![
             Content::Disc(DiscContent {
@@ -225,5 +280,22 @@ mod tests {
         ]);
 
         assert_eq!(normalized.len(), 2);
+    }
+
+    #[test]
+    fn derives_rom_game_title_from_leaf_name() {
+        let normalized = normalize_content(vec![Content::Rom(RomContent {
+            id: ContentId::new("roms/snes/Super Mario World.sfc"),
+            source: SourceRef::new("file:/roms/snes/Super Mario World.sfc"),
+            file_name: "roms/snes/Super Mario World.sfc".to_string(),
+            size: 4096,
+        })]);
+
+        let game = match &normalized[0] {
+            Content::Game(game) => game,
+            other => panic!("expected game, got {other:?}"),
+        };
+
+        assert_eq!(game.title, "Super Mario World");
     }
 }

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -91,18 +91,31 @@ fn derive_platform(path: &str) -> Platform {
 
 fn platform_from_segments(path: &str) -> Option<Platform> {
     for segment in path.split('/').filter(|segment| !segment.is_empty()) {
-        let platform = match segment {
-            "snes" => Platform::Snes,
-            "ps1" | "psx" | "playstation" => Platform::Ps1,
-            "nes" => Platform::Nes,
-            "megadrive" | "genesis" => Platform::Megadrive,
-            _ => continue,
+        let platform = if matches_platform_segment(segment, &["snes"]) {
+            Platform::Snes
+        } else if matches_platform_segment(segment, &["ps1", "psx", "playstation"]) {
+            Platform::Ps1
+        } else if matches_platform_segment(segment, &["nes"]) {
+            Platform::Nes
+        } else if matches_platform_segment(segment, &["megadrive", "genesis"]) {
+            Platform::Megadrive
+        } else {
+            continue;
         };
 
         return Some(platform);
     }
 
     None
+}
+
+fn matches_platform_segment(segment: &str, aliases: &[&str]) -> bool {
+    aliases.iter().any(|alias| {
+        segment == *alias
+            || segment
+                .strip_prefix(alias)
+                .is_some_and(|rest| rest.starts_with('_') || rest.starts_with('-'))
+    })
 }
 
 fn platform_from_extension(path: &str) -> Platform {

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 use std::path::Path;
 
-use crate::core::content::Content;
+use crate::core::content::{Content, GamePart};
 use crate::error::RetromountError;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
@@ -69,6 +69,17 @@ pub fn write_inspect_report<W: Write>(
     }
 
     writeln!(writer)?;
+    writeln!(writer, "Normalized:")?;
+    if trace.normalized.is_empty() {
+        writeln!(writer, "  (none)")?;
+    } else {
+        for content in &trace.normalized {
+            writeln!(writer, "  - {:?}", content.kind())?;
+            write_content_summary(writer, content)?;
+        }
+    }
+
+    writeln!(writer)?;
     writeln!(writer, "Presented VFS:")?;
     write_vfs_tree(writer, &trace.presented)?;
 
@@ -96,6 +107,29 @@ fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Res
             writeln!(writer, "      Source: {}", disc.source)?;
             writeln!(writer, "      Title: {}", disc.title)?;
             writeln!(writer, "      Disc number: {}", disc.disc_number)?;
+        }
+        Content::Game(game) => {
+            writeln!(writer, "    Decoded: Game")?;
+            writeln!(writer, "      ID: {}", game.id)?;
+            writeln!(writer, "      Source: {}", game.source)?;
+            writeln!(writer, "      Title: {}", game.title)?;
+            writeln!(writer, "      Parts: {}", game.parts.len())?;
+
+            for (index, part) in game.parts.iter().enumerate() {
+                match part {
+                    GamePart::Rom(rom) => {
+                        writeln!(writer, "      Part {}: Rom", index + 1)?;
+                        writeln!(writer, "        Source: {}", rom.source)?;
+                        writeln!(writer, "        File name: {}", rom.file_name)?;
+                        writeln!(writer, "        Size: {}", rom.size)?;
+                    }
+                    GamePart::Disc(disc) => {
+                        writeln!(writer, "      Part {}: Disc", index + 1)?;
+                        writeln!(writer, "        Source: {}", disc.source)?;
+                        writeln!(writer, "        Disc number: {}", disc.disc_number)?;
+                    }
+                }
+            }
         }
         Content::Text(text) => {
             writeln!(writer, "    Decoded: Text")?;
@@ -141,6 +175,11 @@ mod tests {
                     size: 0,
                 })],
             }],
+            normalized: vec![Content::Bytes(BytesContent {
+                id: ContentId::new("blob.dat"),
+                source: SourceRef::new("zip:/tmp/library.zip#misc/blob.dat"),
+                size: 0,
+            })],
             presented: VfsDirectory::with_children(
                 "",
                 vec![VfsNode::File(VfsFile::new("blob.dat.bin"))],
@@ -160,6 +199,7 @@ mod tests {
         assert!(rendered.contains("Identity: File"));
         assert!(rendered.contains("Supported: yes"));
         assert!(rendered.contains("Decoded: Bytes"));
+        assert!(rendered.contains("Normalized:"));
         assert!(rendered.contains("Presented VFS:"));
         assert!(rendered.contains("blob.dat.bin"));
     }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -113,6 +113,7 @@ fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Res
             writeln!(writer, "      ID: {}", game.id)?;
             writeln!(writer, "      Source: {}", game.source)?;
             writeln!(writer, "      Title: {}", game.title)?;
+            writeln!(writer, "      Platform: {}", game.platform)?;
             writeln!(writer, "      Parts: {}", game.parts.len())?;
 
             for (index, part) in game.parts.iter().enumerate() {

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -116,7 +116,7 @@ mod tests {
         let root = run_pipeline(&source, &identifier, &decoder, &presenter).unwrap();
 
         let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
-        assert_eq!(names, vec!["blob.dat.bin", "mario.sfc", "readme.txt"]);
+        assert_eq!(names, vec!["snes", "blob.dat.bin", "readme.txt"]);
     }
 
     #[test]
@@ -152,7 +152,7 @@ mod tests {
         let root = run_pipeline(&source, &identifier, &decoder, &presenter).unwrap();
 
         let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
-        assert_eq!(names, vec!["blob.dat.bin", "readme.txt", "sonic.bin"]);
+        assert_eq!(names, vec!["unknown", "blob.dat.bin", "readme.txt"]);
     }
 
     #[test]
@@ -178,7 +178,7 @@ mod tests {
             .iter()
             .map(|node| node.name())
             .collect();
-        assert_eq!(names, vec!["blob.dat.bin", "mario.sfc", "readme.txt"]);
+        assert_eq!(names, vec!["snes", "blob.dat.bin", "readme.txt"]);
 
         assert_eq!(trace.objects[0].object.name, "blob.dat");
         assert_eq!(trace.objects[0].identity, InputIdentity::File);

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::io;
 
 use crate::core::content::Content;
+use crate::core::normalizer::normalize_content;
 use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;
 use crate::input::decode::InputDecoder;
@@ -13,6 +14,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize)]
 pub struct PipelineTrace {
     pub objects: Vec<TracedObject>,
+    pub normalized: Vec<Content>,
     pub presented: VfsDirectory,
 }
 
@@ -63,11 +65,13 @@ pub fn run_pipeline_with_trace(
         });
     }
 
-    let presented_content = suppress_consumed_content(&all_content);
+    let normalized = normalize_content(all_content);
+    let presented_content = suppress_consumed_content(&normalized);
     let presented = presenter.present(&presented_content);
 
     Ok(PipelineTrace {
         objects: traced_objects,
+        normalized,
         presented,
     })
 }
@@ -166,6 +170,7 @@ mod tests {
         let trace = run_pipeline_with_trace(&source, &identifier, &decoder, &presenter).unwrap();
 
         assert_eq!(trace.objects.len(), 3);
+        assert_eq!(trace.normalized.len(), 3);
 
         let names: Vec<&str> = trace
             .presented
@@ -188,95 +193,13 @@ mod tests {
         assert_eq!(trace.objects[1].decoded[0].kind(), ContentKind::Rom);
 
         assert_eq!(trace.objects[2].object.name, "readme.txt");
-        assert_eq!(trace.objects[2].identity, InputIdentity::Text);
-        assert!(trace.objects[2].supported);
-        assert_eq!(trace.objects[2].decoded.len(), 1);
-        assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Text);
-    }
-
-    #[test]
-    fn traces_end_to_end_zip_pipeline() {
-        use std::fs::File;
-        use std::io::Write;
-
-        use crate::input::zip_source::ZipInputSource;
-
-        let temp_dir = tempfile::tempdir().unwrap();
-        let zip_path = temp_dir.path().join("library.zip");
-
-        let file = File::create(&zip_path).unwrap();
-        let mut zip = zip::ZipWriter::new(file);
-        let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
-
-        zip.start_file("roms/sonic.bin", options).unwrap();
-        zip.write_all(b"rom").unwrap();
-
-        zip.start_file("docs/readme.txt", options).unwrap();
-        zip.write_all(b"hello").unwrap();
-
-        zip.start_file("misc/blob.dat", options).unwrap();
-        zip.write_all(b"xyz").unwrap();
-
-        zip.finish().unwrap();
-
-        let source = ZipInputSource::new(&zip_path);
-        let identifier = BasicInputIdentifier::new();
-        let decoder = BasicInputDecoder::new();
-        let presenter = GenericPresenter::new(BasicEncoder::new());
-
-        let trace = run_pipeline_with_trace(&source, &identifier, &decoder, &presenter).unwrap();
-
-        assert_eq!(trace.objects.len(), 3);
-
-        let names: Vec<&str> = trace
-            .presented
-            .children
-            .iter()
-            .map(|node| node.name())
-            .collect();
-        assert_eq!(names, vec!["blob.dat.bin", "readme.txt", "sonic.bin"]);
-
-        assert_eq!(trace.objects[0].object.name, "blob.dat");
-        assert_eq!(trace.objects[0].identity, InputIdentity::File);
-        assert!(trace.objects[0].supported);
-        assert_eq!(trace.objects[0].decoded.len(), 1);
-        assert_eq!(trace.objects[0].decoded[0].kind(), ContentKind::Bytes);
-
-        assert_eq!(trace.objects[1].object.name, "readme.txt");
-        assert_eq!(trace.objects[1].identity, InputIdentity::Text);
-        assert!(trace.objects[1].supported);
-        assert_eq!(trace.objects[1].decoded.len(), 1);
-        assert_eq!(trace.objects[1].decoded[0].kind(), ContentKind::Text);
-
-        assert_eq!(trace.objects[2].object.name, "sonic.bin");
         assert_eq!(trace.objects[2].identity, InputIdentity::File);
         assert!(trace.objects[2].supported);
         assert_eq!(trace.objects[2].decoded.len(), 1);
-        assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Rom);
-    }
+        assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Text);
 
-    #[test]
-    fn suppresses_disc_backing_files_from_presented_output() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        fs::write(temp_dir.path().join("game.bin"), b"discdata").unwrap();
-        fs::write(
-            temp_dir.path().join("game.cue"),
-            r#"
-    FILE "game.bin" BINARY
-    TRACK 01 MODE2/2352
-        INDEX 01 00:00:00
-    "#,
-        )
-        .unwrap();
-
-        let source = DirectoryInputSource::new(temp_dir.path());
-        let identifier = BasicInputIdentifier::new();
-        let decoder = BasicInputDecoder::new();
-        let presenter = GenericPresenter::new(BasicEncoder::new());
-
-        let root = run_pipeline(&source, &identifier, &decoder, &presenter).unwrap();
-
-        let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
-        assert_eq!(names, vec!["game (Disc 1).cue"]);
+        assert_eq!(trace.normalized[0].kind(), ContentKind::Bytes);
+        assert_eq!(trace.normalized[1].kind(), ContentKind::Game);
+        assert_eq!(trace.normalized[2].kind(), ContentKind::Text);
     }
 }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -193,7 +193,7 @@ mod tests {
         assert_eq!(trace.objects[1].decoded[0].kind(), ContentKind::Rom);
 
         assert_eq!(trace.objects[2].object.name, "readme.txt");
-        assert_eq!(trace.objects[2].identity, InputIdentity::File);
+        assert_eq!(trace.objects[2].identity, InputIdentity::Text);
         assert!(trace.objects[2].supported);
         assert_eq!(trace.objects[2].decoded.len(), 1);
         assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Text);

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -66,8 +66,8 @@ pub fn run_pipeline_with_trace(
     }
 
     let normalized = normalize_content(all_content);
-    let presented_content = suppress_consumed_content(&normalized);
-    let presented = presenter.present(&presented_content);
+    let normalized_presentable_content = suppress_consumed_content(&normalized);
+    let presented = presenter.present(&normalized_presentable_content);
 
     Ok(PipelineTrace {
         objects: traced_objects,
@@ -191,12 +191,14 @@ mod tests {
         assert!(trace.objects[1].supported);
         assert_eq!(trace.objects[1].decoded.len(), 1);
         assert_eq!(trace.objects[1].decoded[0].kind(), ContentKind::Rom);
+        assert_eq!(trace.normalized[1].kind(), ContentKind::Game);
 
         assert_eq!(trace.objects[2].object.name, "readme.txt");
         assert_eq!(trace.objects[2].identity, InputIdentity::Text);
         assert!(trace.objects[2].supported);
         assert_eq!(trace.objects[2].decoded.len(), 1);
         assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Text);
+        assert_eq!(trace.normalized[2].kind(), ContentKind::Text);
 
         assert_eq!(trace.normalized[0].kind(), ContentKind::Bytes);
         assert_eq!(trace.normalized[1].kind(), ContentKind::Game);

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -3,6 +3,8 @@ use crate::output::encode::{EncodedFile, OutputEncoder};
 
 pub struct BasicEncoder;
 
+pub struct BasicEncoder;
+
 impl BasicEncoder {
     pub fn new() -> Self {
         Self
@@ -37,12 +39,9 @@ impl BasicEncoder {
     }
 }
 
-fn normalize_text_name(path: &str) -> String {
-    let normalized = path.replace('\\', "/");
-
-    match normalized.rsplit_once('.') {
-        Some((base, _)) => format!("{base}.txt"),
-        None => format!("{normalized}.txt"),
+impl Default for BasicEncoder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -3,8 +3,6 @@ use crate::output::encode::{EncodedFile, OutputEncoder};
 
 pub struct BasicEncoder;
 
-pub struct BasicEncoder;
-
 impl BasicEncoder {
     pub fn new() -> Self {
         Self
@@ -17,7 +15,9 @@ impl BasicEncoder {
             Content::Disc(disc) => format!("{} (Disc {}).cue", disc.title, disc.disc_number),
             Content::Game(game) => match game.parts.as_slice() {
                 [GamePart::Rom(rom)] => rom.file_name.clone(),
-                [GamePart::Disc(disc)] => format!("{} (Disc {}).cue", game.title, disc.disc_number),
+                [GamePart::Disc(disc)] => {
+                    format!("{} (Disc {}).cue", game.title, disc.disc_number)
+                }
                 _ => game.title.clone(),
             },
             Content::Text(text) => normalize_text_name(text.id.0.as_ref()),
@@ -42,6 +42,15 @@ impl BasicEncoder {
 impl Default for BasicEncoder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn normalize_text_name(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+
+    match normalized.rsplit_once('.') {
+        Some((base, _)) => format!("{base}.txt"),
+        None => format!("{normalized}.txt"),
     }
 }
 

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -11,8 +11,6 @@ impl BasicEncoder {
     fn file_name_for(&self, content: &Content) -> String {
         match content {
             Content::Bytes(bytes) => format!("{}.bin", bytes.id),
-            Content::Rom(rom) => rom.file_name.clone(),
-            Content::Disc(disc) => format!("{} (Disc {}).cue", disc.title, disc.disc_number),
             Content::Game(game) => match game.parts.as_slice() {
                 [GamePart::Rom(rom)] => rom.file_name.clone(),
                 [GamePart::Disc(disc)] => {
@@ -21,20 +19,24 @@ impl BasicEncoder {
                 _ => game.title.clone(),
             },
             Content::Text(text) => normalize_text_name(text.id.0.as_ref()),
+            Content::Rom(_) | Content::Disc(_) => {
+                unreachable!("BasicEncoder should only encode normalized playable content")
+            }
         }
     }
 
     fn size_for(&self, content: &Content) -> u64 {
         match content {
             Content::Bytes(bytes) => bytes.size,
-            Content::Rom(rom) => rom.size,
-            Content::Disc(_) => 0,
             Content::Game(game) => match game.parts.as_slice() {
                 [GamePart::Rom(rom)] => rom.size,
                 [GamePart::Disc(_)] => 0,
                 _ => 0,
             },
             Content::Text(text) => text.size,
+            Content::Rom(_) | Content::Disc(_) => {
+                unreachable!("BasicEncoder should only encode normalized playable content")
+            }
         }
     }
 }
@@ -88,37 +90,6 @@ mod tests {
         let encoded = encoder.encode(&content).unwrap();
         assert_eq!(encoded.name, "bios.bin");
         assert_eq!(encoded.size, 512);
-    }
-
-    #[test]
-    fn encodes_rom_content() {
-        let encoder = BasicEncoder::new();
-        let content = Content::Rom(RomContent {
-            id: ContentId::new("mario-world"),
-            source: SourceRef::new("zip:/roms/snes.zip#smw.sfc"),
-            file_name: "Super Mario World.sfc".to_string(),
-            size: 4096,
-        });
-
-        let encoded = encoder.encode(&content).unwrap();
-        assert_eq!(encoded.name, "Super Mario World.sfc");
-        assert_eq!(encoded.size, 4096);
-    }
-
-    #[test]
-    fn encodes_disc_content() {
-        let encoder = BasicEncoder::new();
-        let content = Content::Disc(DiscContent {
-            id: ContentId::new("ff7-disc1"),
-            source: SourceRef::new("cue:/roms/ff7.cue"),
-            title: "Final Fantasy VII".to_string(),
-            disc_number: 1,
-            consumed_sources: vec![SourceRef::new("cue:/roms/ff7.bin")],
-        });
-
-        let encoded = encoder.encode(&content).unwrap();
-        assert_eq!(encoded.name, "Final Fantasy VII (Disc 1).cue");
-        assert_eq!(encoded.size, 0);
     }
 
     #[test]

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -1,7 +1,6 @@
-use crate::core::content::Content;
+use crate::core::content::{Content, GamePart};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 
-#[derive(Debug, Default)]
 pub struct BasicEncoder;
 
 impl BasicEncoder {
@@ -14,7 +13,12 @@ impl BasicEncoder {
             Content::Bytes(bytes) => format!("{}.bin", bytes.id),
             Content::Rom(rom) => rom.file_name.clone(),
             Content::Disc(disc) => format!("{} (Disc {}).cue", disc.title, disc.disc_number),
-            Content::Text(text) => format!("{}.txt", text.id),
+            Content::Game(game) => match game.parts.as_slice() {
+                [GamePart::Rom(rom)] => rom.file_name.clone(),
+                [GamePart::Disc(disc)] => format!("{} (Disc {}).cue", game.title, disc.disc_number),
+                _ => game.title.clone(),
+            },
+            Content::Text(text) => normalize_text_name(text.id.0.as_ref()),
         }
     }
 
@@ -23,8 +27,22 @@ impl BasicEncoder {
             Content::Bytes(bytes) => bytes.size,
             Content::Rom(rom) => rom.size,
             Content::Disc(_) => 0,
+            Content::Game(game) => match game.parts.as_slice() {
+                [GamePart::Rom(rom)] => rom.size,
+                [GamePart::Disc(_)] => 0,
+                _ => 0,
+            },
             Content::Text(text) => text.size,
         }
+    }
+}
+
+fn normalize_text_name(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+
+    match normalized.rsplit_once('.') {
+        Some((base, _)) => format!("{base}.txt"),
+        None => format!("{normalized}.txt"),
     }
 }
 
@@ -45,7 +63,8 @@ impl OutputEncoder for BasicEncoder {
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, Content, ContentId, DiscContent, RomContent, TextContent,
+        BytesContent, Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, RomContent,
+        RomPart, TextContent,
     };
     use crate::core::source::SourceRef;
 
@@ -91,6 +110,46 @@ mod tests {
 
         let encoded = encoder.encode(&content).unwrap();
         assert_eq!(encoded.name, "Final Fantasy VII (Disc 1).cue");
+        assert_eq!(encoded.size, 0);
+    }
+
+    #[test]
+    fn encodes_single_rom_game_content() {
+        let encoder = BasicEncoder::new();
+        let content = Content::Game(GameContent {
+            id: ContentId::new("smw"),
+            source: SourceRef::new("file:/roms/Super Mario World.sfc"),
+            title: "Super Mario World".to_string(),
+            parts: vec![GamePart::Rom(RomPart {
+                source: SourceRef::new("file:/roms/Super Mario World.sfc"),
+                file_name: "Super Mario World.sfc".to_string(),
+                size: 4096,
+            })],
+            consumed_sources: vec![],
+        });
+
+        let encoded = encoder.encode(&content).unwrap();
+        assert_eq!(encoded.name, "Super Mario World.sfc");
+        assert_eq!(encoded.size, 4096);
+    }
+
+    #[test]
+    fn encodes_single_disc_game_content() {
+        let encoder = BasicEncoder::new();
+        let content = Content::Game(GameContent {
+            id: ContentId::new("mgs"),
+            source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
+            title: "Metal Gear Solid".to_string(),
+            parts: vec![GamePart::Disc(DiscPart {
+                source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("cue:/roms/mgs-disc1.bin")],
+            })],
+            consumed_sources: vec![SourceRef::new("cue:/roms/mgs-disc1.bin")],
+        });
+
+        let encoded = encoder.encode(&content).unwrap();
+        assert_eq!(encoded.name, "Metal Gear Solid (Disc 1).cue");
         assert_eq!(encoded.size, 0);
     }
 

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -73,7 +73,8 @@ impl OutputEncoder for BasicEncoder {
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, RomPart, TextContent,
+        BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, Platform, RomPart,
+        TextContent,
     };
     use crate::core::source::SourceRef;
 
@@ -98,6 +99,7 @@ mod tests {
             id: ContentId::new("smw"),
             source: SourceRef::new("file:/roms/Super Mario World.sfc"),
             title: "Super Mario World".to_string(),
+            platform: Platform::Snes,
             parts: vec![GamePart::Rom(RomPart {
                 source: SourceRef::new("file:/roms/Super Mario World.sfc"),
                 file_name: "Super Mario World.sfc".to_string(),
@@ -118,6 +120,7 @@ mod tests {
             id: ContentId::new("mgs"),
             source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
             title: "Metal Gear Solid".to_string(),
+            platform: Platform::Ps1,
             parts: vec![GamePart::Disc(DiscPart {
                 source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
                 disc_number: 1,

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -73,8 +73,7 @@ impl OutputEncoder for BasicEncoder {
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, RomContent,
-        RomPart, TextContent,
+        BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, RomPart, TextContent,
     };
     use crate::core::source::SourceRef;
 

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -419,8 +419,8 @@ mod tests {
         let root = presenter.present(&content);
 
         assert_eq!(root.children().len(), 2);
-        assert_eq!(root.children()[0].name(), "Crash Bandicoot.bin");
-        assert_eq!(root.children()[1].name(), "Final Fantasy VII");
+        assert_eq!(root.children()[0].name(), "Final Fantasy VII");
+        assert_eq!(root.children()[1].name(), "Crash Bandicoot.bin");
     }
 
     #[test]

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -265,7 +265,7 @@ mod tests {
         let root = presenter.present(&content);
 
         let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
-        assert_eq!(names, vec!["bios.bin", "manifest.txt", "megadrive", "ps1"]);
+        assert_eq!(names, vec!["megadrive", "ps1", "bios.bin", "manifest.txt"]);
     }
 
     #[test]

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,5 +1,4 @@
 use crate::core::content::{Content, DiscPart, GameContent, GamePart};
-use crate::core::source::SourceRef;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::core::content::Content;
+use crate::core::content::{Content, DiscContent, DiscPart, GameContent, GamePart};
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
@@ -37,18 +37,15 @@ where
             .iter()
             .filter(|item| self.encoder.can_encode(item))
             .filter_map(|item| {
-                self.encoder
-                    .encode(item)
-                    .ok()
-                    .map(|encoded| PresentedEntry {
-                        content: item.clone(),
-                        encoded,
-                    })
+                self.encoder.encode(item).ok().map(|encoded| PresentedEntry {
+                    content: item.clone(),
+                    encoded,
+                })
             })
             .collect()
     }
 
-    fn disc_group_key(content: &crate::core::content::DiscContent) -> DiscGroupKey {
+    fn disc_group_key(content: &DiscContent) -> DiscGroupKey {
         DiscGroupKey {
             parent: Self::logical_parent_path(content.id.0.as_ref()),
             title: content.title.clone(),
@@ -71,6 +68,9 @@ where
 
         for entry in entries {
             match &entry.content {
+                Content::Game(game) => {
+                    children.push(self.build_game_node(game, &entry.encoded));
+                }
                 Content::Disc(disc) => {
                     let key = Self::disc_group_key(disc);
 
@@ -97,6 +97,60 @@ where
         }
 
         children
+    }
+
+    fn build_game_node(&self, game: &GameContent, encoded: &EncodedFile) -> VfsNode {
+        if self.is_multi_disc_game(game) {
+            VfsNode::Directory(self.build_multi_disc_game_directory(game))
+        } else {
+            VfsNode::File(VfsFile::source_backed(
+                encoded.name.clone(),
+                encoded.size,
+                game.source.clone(),
+            ))
+        }
+    }
+
+    fn is_multi_disc_game(&self, game: &GameContent) -> bool {
+        game.parts.len() > 1
+            && game
+                .parts
+                .iter()
+                .all(|part| matches!(part, GamePart::Disc(_)))
+    }
+
+    fn build_multi_disc_game_directory(&self, game: &GameContent) -> VfsDirectory {
+        let mut disc_parts: Vec<&DiscPart> = game
+            .parts
+            .iter()
+            .filter_map(|part| match part {
+                GamePart::Disc(disc) => Some(disc),
+                _ => None,
+            })
+            .collect();
+
+        disc_parts.sort_by(|left, right| left.disc_number.cmp(&right.disc_number));
+
+        let disc_file_names: Vec<String> = disc_parts
+            .iter()
+            .map(|disc| format!("{} (Disc {}).cue", game.title, disc.disc_number))
+            .collect();
+
+        let mut dir = VfsDirectory::new(&game.title);
+
+        for disc in disc_parts {
+            dir.add_child(VfsNode::File(VfsFile::source_backed(
+                format!("{} (Disc {}).cue", game.title, disc.disc_number),
+                0,
+                disc.source.clone(),
+            )));
+        }
+
+        dir.add_child(VfsNode::File(
+            self.build_m3u_file(&game.title, &disc_file_names),
+        ));
+
+        dir
     }
 
     fn multi_disc_groups(&self, entries: &[PresentedEntry]) -> HashSet<DiscGroupKey> {
@@ -180,7 +234,8 @@ where
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, Content, ContentId, DiscContent, RomContent, TextContent,
+        BytesContent, Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, RomContent,
+        RomPart, TextContent,
     };
     use crate::core::source::SourceRef;
     use crate::core::vfs::FileBacking;
@@ -244,6 +299,94 @@ mod tests {
     }
 
     #[test]
+    fn presents_single_rom_game_as_file() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![Content::Game(GameContent {
+            id: ContentId::new("smw"),
+            source: SourceRef::new("file:/roms/Super Mario World.sfc"),
+            title: "Super Mario World".to_string(),
+            parts: vec![GamePart::Rom(RomPart {
+                source: SourceRef::new("file:/roms/Super Mario World.sfc"),
+                file_name: "Super Mario World.sfc".to_string(),
+                size: 4096,
+            })],
+            consumed_sources: vec![],
+        })];
+
+        let root = presenter.present(&content);
+
+        assert_eq!(root.children().len(), 1);
+        assert_eq!(root.children()[0].name(), "Super Mario World.sfc");
+    }
+
+    #[test]
+    fn presents_multi_disc_game_as_directory_with_playlist() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![Content::Game(GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            parts: vec![
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+                    disc_number: 2,
+                    consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+                }),
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+                    disc_number: 1,
+                    consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
+                }),
+            ],
+            consumed_sources: vec![
+                SourceRef::new("cue:/roms/ff7-disc2.bin"),
+                SourceRef::new("cue:/roms/ff7-disc1.bin"),
+            ],
+        })];
+
+        let root = presenter.present(&content);
+
+        assert_eq!(root.children().len(), 1);
+        assert_eq!(root.children()[0].name(), "Final Fantasy VII");
+
+        let directory = match &root.children()[0] {
+            VfsNode::Directory(directory) => directory,
+            other => panic!("expected directory, got {other:?}"),
+        };
+
+        let child_names: Vec<&str> = directory
+            .children()
+            .iter()
+            .map(|node| node.name())
+            .collect();
+        assert_eq!(
+            child_names,
+            vec![
+                "Final Fantasy VII (Disc 1).cue",
+                "Final Fantasy VII (Disc 2).cue",
+                "Final Fantasy VII.m3u",
+            ]
+        );
+
+        let playlist = match &directory.children()[2] {
+            VfsNode::File(file) => file,
+            other => panic!("expected file, got {other:?}"),
+        };
+
+        match &playlist.backing {
+            FileBacking::Inline(contents) => {
+                assert_eq!(
+                    contents,
+                    b"Final Fantasy VII (Disc 1).cue\nFinal Fantasy VII (Disc 2).cue\n"
+                );
+            }
+            other => panic!("expected inline backing, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn groups_multi_disc_sets_and_generates_playlist() {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
@@ -273,44 +416,8 @@ mod tests {
         let root = presenter.present(&content);
 
         assert_eq!(root.children().len(), 2);
-        assert_eq!(root.children()[0].name(), "Final Fantasy VII");
-        assert_eq!(root.children()[1].name(), "Crash Bandicoot.bin");
-
-        let directory = match &root.children()[0] {
-            VfsNode::Directory(directory) => directory,
-            other => panic!("expected directory, got {other:?}"),
-        };
-
-        let child_names: Vec<&str> = directory
-            .children()
-            .iter()
-            .map(|node| node.name())
-            .collect();
-        assert_eq!(
-            child_names,
-            vec![
-                "Final Fantasy VII (Disc 1).cue",
-                "Final Fantasy VII (Disc 2).cue",
-                "Final Fantasy VII.m3u",
-            ]
-        );
-
-        assert_eq!(directory.files().count(), 3);
-
-        let playlist = match &directory.children()[2] {
-            VfsNode::File(file) => file,
-            other => panic!("expected file, got {other:?}"),
-        };
-
-        match &playlist.backing {
-            FileBacking::Inline(contents) => {
-                assert_eq!(
-                    contents,
-                    b"Final Fantasy VII (Disc 1).cue\nFinal Fantasy VII (Disc 2).cue\n"
-                );
-            }
-            other => panic!("expected inline backing, got {other:?}"),
-        }
+        assert_eq!(root.children()[0].name(), "Crash Bandicoot.bin");
+        assert_eq!(root.children()[1].name(), "Final Fantasy VII");
     }
 
     #[test]

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,6 +1,4 @@
-use std::collections::{HashMap, HashSet};
-
-use crate::core::content::{Content, DiscContent, DiscPart, GameContent, GamePart};
+use crate::core::content::{Content, DiscPart, GameContent, GamePart};
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
@@ -16,12 +14,6 @@ where
 struct PresentedEntry {
     content: Content,
     encoded: EncodedFile,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct DiscGroupKey {
-    parent: String,
-    title: String,
 }
 
 impl<E> GenericPresenter<E>
@@ -48,25 +40,7 @@ where
             .collect()
     }
 
-    fn disc_group_key(content: &DiscContent) -> DiscGroupKey {
-        DiscGroupKey {
-            parent: Self::logical_parent_path(content.id.0.as_ref()),
-            title: content.title.clone(),
-        }
-    }
-
-    fn logical_parent_path(path: &str) -> String {
-        let normalized = path.replace('\\', "/");
-
-        match normalized.rsplit_once('/') {
-            Some((parent, _)) => parent.to_string(),
-            None => String::new(),
-        }
-    }
-
     fn build_root_children(&self, entries: &[PresentedEntry]) -> Vec<VfsNode> {
-        let multi_disc_groups = self.multi_disc_groups(entries);
-        let mut emitted_groups = HashSet::new();
         let mut children = Vec::new();
 
         for entry in entries {
@@ -74,28 +48,16 @@ where
                 Content::Game(game) => {
                     children.push(self.build_game_node(game, &entry.encoded));
                 }
-                Content::Disc(disc) => {
-                    let key = Self::disc_group_key(disc);
-
-                    if multi_disc_groups.contains(&key) {
-                        if emitted_groups.insert(key.clone()) {
-                            children.push(VfsNode::Directory(
-                                self.build_multi_disc_directory(&key, entries),
-                            ));
-                        }
-                    } else {
-                        children.push(VfsNode::File(VfsFile::source_backed(
-                            entry.encoded.name.clone(),
-                            entry.encoded.size,
-                            entry.content.source().clone(),
-                        )));
-                    }
+                Content::Bytes(_) | Content::Text(_) => {
+                    children.push(VfsNode::File(VfsFile::source_backed(
+                        entry.encoded.name.clone(),
+                        entry.encoded.size,
+                        entry.content.source().clone(),
+                    )));
                 }
-                _ => children.push(VfsNode::File(VfsFile::source_backed(
-                    entry.encoded.name.clone(),
-                    entry.encoded.size,
-                    entry.content.source().clone(),
-                ))),
+                Content::Rom(_) | Content::Disc(_) => {
+                    unreachable!("GenericPresenter should only receive normalized playable content")
+                }
             }
         }
 
@@ -156,65 +118,6 @@ where
         dir
     }
 
-    fn multi_disc_groups(&self, entries: &[PresentedEntry]) -> HashSet<DiscGroupKey> {
-        let mut disc_counts: HashMap<DiscGroupKey, usize> = HashMap::new();
-
-        for entry in entries {
-            if let Content::Disc(disc) = &entry.content {
-                let key = Self::disc_group_key(disc);
-                *disc_counts.entry(key).or_insert(0usize) += 1;
-            }
-        }
-
-        disc_counts
-            .into_iter()
-            .filter_map(|(key, count)| (count > 1).then_some(key))
-            .collect()
-    }
-
-    fn build_multi_disc_directory(
-        &self,
-        key: &DiscGroupKey,
-        entries: &[PresentedEntry],
-    ) -> VfsDirectory {
-        let mut disc_entries: Vec<_> = entries
-            .iter()
-            .filter_map(|entry| match &entry.content {
-                Content::Disc(disc) if Self::disc_group_key(disc) == *key => {
-                    Some((disc.disc_number, entry))
-                }
-                _ => None,
-            })
-            .collect();
-
-        disc_entries.sort_by(|(left_disc, left_entry), (right_disc, right_entry)| {
-            left_disc
-                .cmp(right_disc)
-                .then_with(|| left_entry.encoded.name.cmp(&right_entry.encoded.name))
-        });
-
-        let disc_file_names: Vec<String> = disc_entries
-            .iter()
-            .map(|(_, entry)| entry.encoded.name.clone())
-            .collect();
-
-        let mut dir = VfsDirectory::new(&key.title);
-
-        for (_, entry) in disc_entries {
-            dir.add_child(VfsNode::File(VfsFile::source_backed(
-                entry.encoded.name.clone(),
-                entry.encoded.size,
-                entry.content.source().clone(),
-            )));
-        }
-
-        dir.add_child(VfsNode::File(
-            self.build_m3u_file(&key.title, &disc_file_names),
-        ));
-
-        dir
-    }
-
     fn build_m3u_file(&self, title: &str, disc_file_names: &[String]) -> VfsFile {
         let playlist = disc_file_names.join("\n") + "\n";
         VfsFile::inline(format!("{title}.m3u"), playlist.into_bytes())
@@ -237,8 +140,7 @@ where
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, RomContent,
-        RomPart, TextContent,
+        BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, RomPart, TextContent,
     };
     use crate::core::source::SourceRef;
     use crate::core::vfs::FileBacking;
@@ -254,17 +156,26 @@ mod tests {
                 source: SourceRef::new("file:/roms/bios"),
                 size: 512,
             }),
-            Content::Rom(RomContent {
+            Content::Game(GameContent {
                 id: ContentId::new("sonic"),
                 source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
-                file_name: "Sonic the Hedgehog.bin".to_string(),
-                size: 1024,
+                title: "Sonic the Hedgehog".to_string(),
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
+                    file_name: "Sonic the Hedgehog.bin".to_string(),
+                    size: 1024,
+                })],
+                consumed_sources: vec![],
             }),
-            Content::Disc(DiscContent {
-                id: ContentId::new("ff7-disc1"),
+            Content::Game(GameContent {
+                id: ContentId::new("ff7"),
                 source: SourceRef::new("cue:/roms/ff7.cue"),
                 title: "Final Fantasy VII".to_string(),
-                disc_number: 1,
+                parts: vec![GamePart::Disc(DiscPart {
+                    source: SourceRef::new("cue:/roms/ff7.cue"),
+                    disc_number: 1,
+                    consumed_sources: vec![SourceRef::new("cue:/roms/ff7.bin")],
+                })],
                 consumed_sources: vec![SourceRef::new("cue:/roms/ff7.bin")],
             }),
             Content::Text(TextContent {
@@ -394,25 +305,37 @@ mod tests {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![
-            Content::Rom(RomContent {
+            Content::Game(GameContent {
                 id: ContentId::new("crash-bandicoot"),
                 source: SourceRef::new("file:/roms/Crash Bandicoot.bin"),
-                file_name: "Crash Bandicoot.bin".to_string(),
-                size: 1024,
+                title: "Crash Bandicoot".to_string(),
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("file:/roms/Crash Bandicoot.bin"),
+                    file_name: "Crash Bandicoot.bin".to_string(),
+                    size: 1024,
+                })],
+                consumed_sources: vec![],
             }),
-            Content::Disc(DiscContent {
-                id: ContentId::new("ff7/ff7-disc2"),
-                source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
-                title: "Final Fantasy VII".to_string(),
-                disc_number: 2,
-                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
-            }),
-            Content::Disc(DiscContent {
-                id: ContentId::new("ff7/ff7-disc1"),
+            Content::Game(GameContent {
+                id: ContentId::new("ff7"),
                 source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
                 title: "Final Fantasy VII".to_string(),
-                disc_number: 1,
-                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
+                parts: vec![
+                    GamePart::Disc(DiscPart {
+                        source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+                        disc_number: 2,
+                        consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+                    }),
+                    GamePart::Disc(DiscPart {
+                        source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+                        disc_number: 1,
+                        consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
+                    }),
+                ],
+                consumed_sources: vec![
+                    SourceRef::new("cue:/roms/ff7-disc2.bin"),
+                    SourceRef::new("cue:/roms/ff7-disc1.bin"),
+                ],
             }),
         ];
 
@@ -421,86 +344,5 @@ mod tests {
         assert_eq!(root.children().len(), 2);
         assert_eq!(root.children()[0].name(), "Final Fantasy VII");
         assert_eq!(root.children()[1].name(), "Crash Bandicoot.bin");
-    }
-
-    #[test]
-    fn does_not_generate_playlist_for_single_disc_title() {
-        let presenter = GenericPresenter::new(BasicEncoder::new());
-
-        let content = vec![Content::Disc(DiscContent {
-            id: ContentId::new("mgs/mgs-disc1"),
-            source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
-            title: "Metal Gear Solid".to_string(),
-            disc_number: 1,
-            consumed_sources: vec![SourceRef::new("cue:/roms/mgs-disc1.bin")],
-        })];
-
-        let root = presenter.present(&content);
-
-        assert_eq!(root.children().len(), 1);
-        assert_eq!(root.children()[0].name(), "Metal Gear Solid (Disc 1).cue");
-    }
-
-    #[test]
-    fn does_not_merge_same_title_from_different_directories() {
-        let presenter = GenericPresenter::new(BasicEncoder::new());
-
-        let content = vec![
-            Content::Disc(DiscContent {
-                id: ContentId::new("discs/ps1_multi/game_disc1.cue"),
-                source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.cue"),
-                title: "game".to_string(),
-                disc_number: 1,
-                consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.bin")],
-            }),
-            Content::Disc(DiscContent {
-                id: ContentId::new("discs/ps1_multi/game_disc2.cue"),
-                source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc2.cue"),
-                title: "game".to_string(),
-                disc_number: 2,
-                consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_multi/game_disc2.bin")],
-            }),
-            Content::Disc(DiscContent {
-                id: ContentId::new("discs/ps1_single/game.cue"),
-                source: SourceRef::new("file:/roms/discs/ps1_single/game.cue"),
-                title: "game".to_string(),
-                disc_number: 1,
-                consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_single/game.bin")],
-            }),
-        ];
-
-        let root = presenter.present(&content);
-
-        assert_eq!(root.children().len(), 2);
-
-        let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
-        assert_eq!(names, vec!["game", "game (Disc 1).cue"]);
-
-        let multi_dir = match &root.children()[0] {
-            VfsNode::Directory(directory) => directory,
-            other => panic!("expected directory, got {other:?}"),
-        };
-
-        let child_names: Vec<&str> = multi_dir
-            .children()
-            .iter()
-            .map(|node| node.name())
-            .collect();
-        assert_eq!(
-            child_names,
-            vec!["game (Disc 1).cue", "game (Disc 2).cue", "game.m3u"]
-        );
-    }
-
-    #[test]
-    fn normalizes_disc_group_parent_to_logical_path() {
-        let key = GenericPresenter::<BasicEncoder>::disc_group_key(&DiscContent {
-            id: ContentId::new(r"discs\ps1_multi\game_disc1.cue"),
-            source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.cue"),
-            title: "game".to_string(),
-            disc_number: 1,
-            consumed_sources: vec![SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.bin")],
-        });
-        assert_eq!(key.parent, "discs/ps1_multi");
     }
 }

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -140,7 +140,8 @@ where
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, RomPart, TextContent,
+        BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, Platform, RomPart,
+        TextContent,
     };
     use crate::core::source::SourceRef;
     use crate::core::vfs::FileBacking;
@@ -160,6 +161,7 @@ mod tests {
                 id: ContentId::new("sonic"),
                 source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
                 title: "Sonic the Hedgehog".to_string(),
+                platform: Platform::Megadrive,
                 parts: vec![GamePart::Rom(RomPart {
                     source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
                     file_name: "Sonic the Hedgehog.bin".to_string(),
@@ -171,6 +173,7 @@ mod tests {
                 id: ContentId::new("ff7"),
                 source: SourceRef::new("cue:/roms/ff7.cue"),
                 title: "Final Fantasy VII".to_string(),
+                platform: Platform::Ps1,
                 parts: vec![GamePart::Disc(DiscPart {
                     source: SourceRef::new("cue:/roms/ff7.cue"),
                     disc_number: 1,
@@ -220,6 +223,7 @@ mod tests {
             id: ContentId::new("smw"),
             source: SourceRef::new("file:/roms/Super Mario World.sfc"),
             title: "Super Mario World".to_string(),
+            platform: Platform::Snes,
             parts: vec![GamePart::Rom(RomPart {
                 source: SourceRef::new("file:/roms/Super Mario World.sfc"),
                 file_name: "Super Mario World.sfc".to_string(),
@@ -242,6 +246,7 @@ mod tests {
             id: ContentId::new("ff7"),
             source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
             title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
             parts: vec![
                 GamePart::Disc(DiscPart {
                     source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
@@ -309,6 +314,7 @@ mod tests {
                 id: ContentId::new("crash-bandicoot"),
                 source: SourceRef::new("file:/roms/Crash Bandicoot.bin"),
                 title: "Crash Bandicoot".to_string(),
+                platform: Platform::Ps1,
                 parts: vec![GamePart::Rom(RomPart {
                     source: SourceRef::new("file:/roms/Crash Bandicoot.bin"),
                     file_name: "Crash Bandicoot.bin".to_string(),
@@ -320,6 +326,7 @@ mod tests {
                 id: ContentId::new("ff7"),
                 source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
                 title: "Final Fantasy VII".to_string(),
+                platform: Platform::Ps1,
                 parts: vec![
                     GamePart::Disc(DiscPart {
                         source: SourceRef::new("cue:/roms/ff7-disc2.cue"),

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -37,10 +37,13 @@ where
             .iter()
             .filter(|item| self.encoder.can_encode(item))
             .filter_map(|item| {
-                self.encoder.encode(item).ok().map(|encoded| PresentedEntry {
-                    content: item.clone(),
-                    encoded,
-                })
+                self.encoder
+                    .encode(item)
+                    .ok()
+                    .map(|encoded| PresentedEntry {
+                        content: item.clone(),
+                        encoded,
+                    })
             })
             .collect()
     }

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -182,16 +182,22 @@ fn ensure_directory<'a>(root: &'a mut VfsDirectory, parents: &[String]) -> &'a m
     let mut current = root;
 
     for segment in parents {
-        let existing_index = current
+        let index = match current
             .children
             .iter()
-            .position(|node| matches!(node, VfsNode::Directory(dir) if dir.name == *segment));
-
-        let index = match existing_index {
+            .position(|node| matches!(node, VfsNode::Directory(dir) if dir.name == *segment))
+        {
             Some(index) => index,
             None => {
                 current.add_child(VfsNode::Directory(VfsDirectory::new(segment)));
-                current.children.len() - 1
+
+                current
+                    .children
+                    .iter()
+                    .position(
+                        |node| matches!(node, VfsNode::Directory(dir) if dir.name == *segment),
+                    )
+                    .expect("inserted directory should be present")
             }
         };
 

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,4 +1,5 @@
 use crate::core::content::{Content, DiscPart, GameContent, GamePart};
+use crate::core::source::SourceRef;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
@@ -41,19 +42,23 @@ where
     }
 
     fn build_root_children(&self, entries: &[PresentedEntry]) -> Vec<VfsNode> {
-        let mut children = Vec::new();
+        let mut root = VfsDirectory::new("");
 
         for entry in entries {
             match &entry.content {
                 Content::Game(game) => {
-                    children.push(self.build_game_node(game, &entry.encoded));
+                    self.insert_game_node(&mut root, game, &entry.encoded);
                 }
                 Content::Bytes(_) | Content::Text(_) => {
-                    children.push(VfsNode::File(VfsFile::source_backed(
-                        entry.encoded.name.clone(),
-                        entry.encoded.size,
-                        entry.content.source().clone(),
-                    )));
+                    self.insert_file_path(
+                        &mut root,
+                        &entry.encoded.name,
+                        VfsFile::source_backed(
+                            file_name(&entry.encoded.name),
+                            entry.encoded.size,
+                            entry.content.source().clone(),
+                        ),
+                    );
                 }
                 Content::Rom(_) | Content::Disc(_) => {
                     unreachable!("GenericPresenter should only receive normalized playable content")
@@ -61,30 +66,25 @@ where
             }
         }
 
-        children
+        root.children().to_vec()
     }
 
-    fn build_game_node(&self, game: &GameContent, encoded: &EncodedFile) -> VfsNode {
+    fn insert_game_node(&self, root: &mut VfsDirectory, game: &GameContent, encoded: &EncodedFile) {
+        let base_path = format!("{}/{}", game.platform, game.title);
+
         if self.is_multi_disc_game(game) {
-            VfsNode::Directory(self.build_multi_disc_game_directory(game))
+            self.insert_multi_disc_game(root, game, &base_path);
         } else {
-            VfsNode::File(VfsFile::source_backed(
-                encoded.name.clone(),
-                encoded.size,
-                game.source.clone(),
-            ))
+            let file_path = format!("{}/{}", base_path, file_name(&encoded.name));
+            self.insert_file_path(
+                root,
+                &file_path,
+                VfsFile::source_backed(file_name(&file_path), encoded.size, game.source.clone()),
+            );
         }
     }
 
-    fn is_multi_disc_game(&self, game: &GameContent) -> bool {
-        game.parts.len() > 1
-            && game
-                .parts
-                .iter()
-                .all(|part| matches!(part, GamePart::Disc(_)))
-    }
-
-    fn build_multi_disc_game_directory(&self, game: &GameContent) -> VfsDirectory {
+    fn insert_multi_disc_game(&self, root: &mut VfsDirectory, game: &GameContent, base_path: &str) {
         let mut disc_parts: Vec<&DiscPart> = game
             .parts
             .iter()
@@ -96,31 +96,45 @@ where
 
         disc_parts.sort_by(|left, right| left.disc_number.cmp(&right.disc_number));
 
-        let disc_file_names: Vec<String> = disc_parts
+        let disc_names: Vec<String> = disc_parts
             .iter()
             .map(|disc| format!("{} (Disc {}).cue", game.title, disc.disc_number))
             .collect();
 
-        let mut dir = VfsDirectory::new(&game.title);
-
-        for disc in disc_parts {
-            dir.add_child(VfsNode::File(VfsFile::source_backed(
-                format!("{} (Disc {}).cue", game.title, disc.disc_number),
-                0,
-                disc.source.clone(),
-            )));
+        for disc in &disc_parts {
+            let disc_path = format!(
+                "{}/{} (Disc {}).cue",
+                base_path, game.title, disc.disc_number
+            );
+            self.insert_file_path(
+                root,
+                &disc_path,
+                VfsFile::source_backed(file_name(&disc_path), 0, disc.source.clone()),
+            );
         }
 
-        dir.add_child(VfsNode::File(
-            self.build_m3u_file(&game.title, &disc_file_names),
-        ));
-
-        dir
+        let playlist_path = format!("{}/{}.m3u", base_path, game.title);
+        let playlist = disc_names.join("\n") + "\n";
+        self.insert_file_path(
+            root,
+            &playlist_path,
+            VfsFile::inline(file_name(&playlist_path), playlist.into_bytes()),
+        );
     }
 
-    fn build_m3u_file(&self, title: &str, disc_file_names: &[String]) -> VfsFile {
-        let playlist = disc_file_names.join("\n") + "\n";
-        VfsFile::inline(format!("{title}.m3u"), playlist.into_bytes())
+    fn insert_file_path(&self, root: &mut VfsDirectory, path: &str, file: VfsFile) {
+        let normalized = normalize_path(path);
+        let (parents, _) = split_parent_dirs(&normalized);
+        let directory = ensure_directory(root, &parents);
+        directory.add_child(VfsNode::File(file));
+    }
+
+    fn is_multi_disc_game(&self, game: &GameContent) -> bool {
+        game.parts.len() > 1
+            && game
+                .parts
+                .iter()
+                .all(|part| matches!(part, GamePart::Disc(_)))
     }
 }
 
@@ -136,6 +150,61 @@ where
     }
 }
 
+fn normalize_path(path: &str) -> String {
+    path.replace('\\', "/").trim_matches('/').to_string()
+}
+
+fn split_parent_dirs(path: &str) -> (Vec<String>, String) {
+    let normalized = normalize_path(path);
+
+    match normalized.rsplit_once('/') {
+        Some((parent, file_name)) => (
+            parent
+                .split('/')
+                .filter(|segment| !segment.is_empty())
+                .map(|segment| segment.to_string())
+                .collect(),
+            file_name.to_string(),
+        ),
+        None => (Vec::new(), normalized),
+    }
+}
+
+fn file_name(path: &str) -> String {
+    let normalized = normalize_path(path);
+
+    match normalized.rsplit_once('/') {
+        Some((_, file_name)) => file_name.to_string(),
+        None => normalized,
+    }
+}
+
+fn ensure_directory<'a>(root: &'a mut VfsDirectory, parents: &[String]) -> &'a mut VfsDirectory {
+    let mut current = root;
+
+    for segment in parents {
+        let existing_index = current
+            .children
+            .iter()
+            .position(|node| matches!(node, VfsNode::Directory(dir) if dir.name == *segment));
+
+        let index = match existing_index {
+            Some(index) => index,
+            None => {
+                current.add_child(VfsNode::Directory(VfsDirectory::new(segment)));
+                current.children.len() - 1
+            }
+        };
+
+        current = match current.children.get_mut(index) {
+            Some(VfsNode::Directory(dir)) => dir,
+            _ => unreachable!("directory entry should be a directory"),
+        };
+    }
+
+    current
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,13 +217,13 @@ mod tests {
     use crate::output::basic_encoder::BasicEncoder;
 
     #[test]
-    fn presents_mixed_content_as_root_files() {
+    fn presents_mixed_content_in_library_view() {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![
             Content::Bytes(BytesContent {
                 id: ContentId::new("bios"),
-                source: SourceRef::new("file:/roms/bios"),
+                source: SourceRef::new("bios"),
                 size: 512,
             }),
             Content::Game(GameContent {
@@ -190,33 +259,12 @@ mod tests {
 
         let root = presenter.present(&content);
 
-        assert_eq!(root.name, "");
-        assert_eq!(root.children().len(), 4);
-
         let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
-        assert_eq!(
-            names,
-            vec![
-                "bios.bin",
-                "Final Fantasy VII (Disc 1).cue",
-                "manifest.txt",
-                "Sonic the Hedgehog.bin",
-            ]
-        );
-
-        match &root.children()[0] {
-            VfsNode::File(file) => match &file.backing {
-                FileBacking::Source(source) => {
-                    assert_eq!(source.to_string(), "file:/roms/bios");
-                }
-                other => panic!("expected source backing, got {other:?}"),
-            },
-            other => panic!("expected file, got {other:?}"),
-        }
+        assert_eq!(names, vec!["bios.bin", "manifest.txt", "megadrive", "ps1"]);
     }
 
     #[test]
-    fn presents_single_rom_game_as_file() {
+    fn presents_single_rom_game_as_file_in_platform_title_directory() {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![Content::Game(GameContent {
@@ -235,11 +283,24 @@ mod tests {
         let root = presenter.present(&content);
 
         assert_eq!(root.children().len(), 1);
-        assert_eq!(root.children()[0].name(), "Super Mario World.sfc");
+        assert_eq!(root.children()[0].name(), "snes");
+
+        let snes = match &root.children()[0] {
+            VfsNode::Directory(dir) => dir,
+            other => panic!("expected directory, got {other:?}"),
+        };
+
+        let game = match &snes.children()[0] {
+            VfsNode::Directory(dir) => dir,
+            other => panic!("expected directory, got {other:?}"),
+        };
+
+        assert_eq!(game.name, "Super Mario World");
+        assert_eq!(game.children()[0].name(), "Super Mario World.sfc");
     }
 
     #[test]
-    fn presents_multi_disc_game_as_directory_with_playlist() {
+    fn presents_multi_disc_game_as_directory_with_playlist_in_library_view() {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![Content::Game(GameContent {
@@ -267,19 +328,19 @@ mod tests {
 
         let root = presenter.present(&content);
 
-        assert_eq!(root.children().len(), 1);
-        assert_eq!(root.children()[0].name(), "Final Fantasy VII");
+        assert_eq!(root.children()[0].name(), "ps1");
 
-        let directory = match &root.children()[0] {
-            VfsNode::Directory(directory) => directory,
+        let ps1 = match &root.children()[0] {
+            VfsNode::Directory(dir) => dir,
             other => panic!("expected directory, got {other:?}"),
         };
 
-        let child_names: Vec<&str> = directory
-            .children()
-            .iter()
-            .map(|node| node.name())
-            .collect();
+        let game_dir = match &ps1.children()[0] {
+            VfsNode::Directory(dir) => dir,
+            other => panic!("expected directory, got {other:?}"),
+        };
+
+        let child_names: Vec<&str> = game_dir.children().iter().map(|node| node.name()).collect();
         assert_eq!(
             child_names,
             vec![
@@ -289,7 +350,7 @@ mod tests {
             ]
         );
 
-        let playlist = match &directory.children()[2] {
+        let playlist = match &game_dir.children()[2] {
             VfsNode::File(file) => file,
             other => panic!("expected file, got {other:?}"),
         };
@@ -306,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn groups_multi_disc_sets_and_generates_playlist() {
+    fn presents_multiple_games_under_platform_directories() {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![
@@ -348,8 +409,15 @@ mod tests {
 
         let root = presenter.present(&content);
 
-        assert_eq!(root.children().len(), 2);
-        assert_eq!(root.children()[0].name(), "Final Fantasy VII");
-        assert_eq!(root.children()[1].name(), "Crash Bandicoot.bin");
+        assert_eq!(root.children().len(), 1);
+        assert_eq!(root.children()[0].name(), "ps1");
+
+        let ps1 = match &root.children()[0] {
+            VfsNode::Directory(dir) => dir,
+            other => panic!("expected directory, got {other:?}"),
+        };
+
+        let names: Vec<&str> = ps1.children().iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["Crash Bandicoot", "Final Fantasy VII"]);
     }
 }


### PR DESCRIPTION
## Summary

This PR completes a major Phase 3 refactor by moving Retromount from file-driven presentation toward a normalized, game-centric library view.

### What changed

- introduced a typed `Platform` enum with `Display`
- normalized playable content into a unified `Game` model
- suppressed CUE-consumed BIN files from standalone game normalization
- improved platform derivation to use path segments first, then safe extension fallback
- updated the presenter so normalized games are shown in a platform-based library structure:
  - `/{platform}/{title}/{title}.{ext}`
  - multi-disc titles become a game directory with disc files and an `.m3u`
- refreshed tests and fixture data to use distinct real-world style game names

### Result

Playable content now presents as a clean library, for example:

- `nes/Castlevania/Castlevania.nes`
- `ps1/Crash Bandicoot/Crash Bandicoot (Disc 1).cue`
- `ps1/Final Fantasy VII/...`
- `snes/Super Mario World/Super Mario World.sfc`

This establishes a much cleaner boundary between:
- decoding raw source files
- normalizing logical games
- presenting a user-facing library layout

### Notes

Non-game bytes/text content is still presented separately using source-relative paths for now. That policy can be refined in a follow-up.