### PR TITLE
output: enforce presenter/encoder boundary and complete D-003

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -183,7 +183,6 @@ The architecture review work in this directory aims to:
 
 ## Next Focus Areas
 
-- F-003: clarify presenter vs encoder responsibilities
 - F-004: ensure the core model remains presentation-agnostic
 - improve module-level documentation
 - introduce diagrams for better visualization of the pipeline

--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -1,6 +1,6 @@
 # Architecture Boundaries
 
-This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation and D-002 (pipeline orchestration unification).
+This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation and D-002/D-003.
 
 ---
 
@@ -12,7 +12,8 @@ Retromount uses a single orchestration model based on the Phase 3 pipeline:
 2. Identify
 3. Decode
 4. Normalize (Core Model)
-5. Present / Encode (VFS)
+5. Present (structure)
+6. Encode (materialization → VFS)
 
 All execution paths (preview, inspect, and configured/runtime execution) flow through this pipeline.
 
@@ -102,24 +103,59 @@ This stage answers:
 
 ---
 
-### 5. Present / Encode
+### 5. Present (structure)
 
 Responsible for:
 
-- transforming normalized content into a view
-- producing filesystem-like output via the VFS
+- defining output structure (directories and hierarchy)
+- grouping related content (e.g. multi-disc games)
+- determining layout decisions (e.g. root vs nested placement)
+- deciding when compound artifacts are required (e.g. playlists)
+- constructing the logical VFS tree
 
 Key components:
 
 - `OutputPresenter`
 - `GenericPresenter`
+
+This stage answers:
+
+> “What should the output look like?”
+
+The Presenter must **not**:
+
+- generate filenames or extensions
+- determine file backing (inline vs source-backed)
+- generate file contents
+- perform representation-specific transformations
+
+---
+
+### 6. Encode (materialization → VFS)
+
+Responsible for:
+
+- generating filenames and extensions
+- mapping content to file representations
+- determining file backing (inline vs source-backed)
+- generating file contents (e.g. playlists)
+- applying representation-specific transformations
+
+Key components:
+
+- `OutputEncoder`
 - `BasicEncoder`
-- `VfsDirectory`
 - `VfsFile`
 
 This stage answers:
 
-> “How should this content be represented to a consumer?”
+> “How is this specific item represented?”
+
+The Encoder must **not**:
+
+- define directory structure or layout
+- group content into collections
+- make global presentation decisions
 
 ---
 
@@ -156,16 +192,26 @@ This stage answers:
 
 ---
 
+### Presenter → Encoder
+
+- Presenter defines structure and grouping
+- Encoder defines representation of each item
+- Presenter must not implement representation logic
+- Encoder must not influence structure
+
+---
+
 ## Design Principles
 
 - **Single orchestration model**  
   All processing flows through the pipeline
 
-- **Separation of concerns**
+- **Strict separation of concerns**
   - Input handles enumeration
   - Identify/Decode handle interpretation
   - Core model represents semantics
-  - Presenter/Encoder handle output
+  - Presenter defines structure
+  - Encoder defines representation
 
 - **Presentation independence**
   The core model must not encode output-specific assumptions
@@ -179,5 +225,5 @@ This stage answers:
 
 - [x] F-001: input vs inputs naming ambiguity (resolved via `builtin_inputs` rename)
 - [x] F-002: loader vs pipeline orchestration ambiguity (resolved via D-002)
-- [ ] F-003: presenter vs encoder responsibility boundary
+- [x] F-003: presenter vs encoder responsibility boundary (resolved via D-003)
 - [ ] F-004: potential core model presentation leakage

--- a/docs/architecture/cleanup-tracker.md
+++ b/docs/architecture/cleanup-tracker.md
@@ -1,28 +1,68 @@
 # Cleanup Tracker
 
-## High priority
+This document tracks architectural findings (F-XXX) and the concrete work required to resolve them.
 
-- [x] Audit `src/input` vs `src/inputs`
-- [x] Identify canonical orchestration path
-- [x] Remove obsolete transitional helpers from Phase 3
+---
 
-### F-002 migration checklist
+## High priority (architecture boundary fixes)
+
+### F-001: Input vs builtin_inputs naming ambiguity
+
+- [x] Rename `src/inputs` → `src/builtin_inputs`
+- [x] Update imports and module references
+- [x] Update architecture documentation
+
+---
+
+### F-002: Loader vs pipeline orchestration ambiguity
 
 - [x] Audit `Loader` responsibilities
 - [x] Identify all `Loader` call sites
-- [x] Map each `Loader` responsibility to a pipeline-aligned destination
-- [x] Rework configured/runtime execution to use pipeline output
+- [x] Map each responsibility to pipeline stages
+- [x] Rework configured/runtime execution to use pipeline
 - [x] Remove `Loader`
-- [x] Remove dead `InputRegistry` / `VirtualFile`-only orchestration code if obsolete
+- [x] Remove dead `InputRegistry` / `VirtualFile` orchestration paths
 - [x] Update architecture docs and findings
 
-## Medium priority
+---
 
-- [ ] Review naming consistency for presenter/view/output terminology
-- [ ] Review registry composition and default registration
-- [ ] Remove dead code and unused helpers
+### F-003: Presenter vs encoder responsibility boundary
 
-## Low priority
+- [x] Move file naming into encoder
+- [x] Remove duplicated naming logic from presenter
+- [x] Introduce encoder support for game parts
+- [x] Introduce encoder support for playlist generation
+- [x] Move file materialization (inline vs source-backed) into encoder
+- [x] Update presenter to consume fully-encoded outputs
 
-- [ ] Add diagrams
-- [ ] Improve module-level docs
+---
+
+### F-004: Core model leaking presentation concerns
+
+- [ ] Audit `GameContent`, `DiscPart`, `RomPart` for presentation-specific fields
+- [ ] Identify fields that exist only to support current presenter
+- [ ] Define stricter core model responsibilities
+- [ ] Remove or relocate presentation-derived data where appropriate
+
+---
+
+## Medium priority (post-boundary cleanup)
+
+- [ ] Review naming consistency for presenter / encoder / output terminology
+- [ ] Review default encoder/presenter composition strategy
+- [ ] Remove dead code and unused helpers after refactors
+- [ ] Audit test coverage for new encoder boundary
+
+---
+
+## Low priority (documentation & polish)
+
+- [ ] Add architecture diagrams (pipeline + boundaries)
+- [ ] Improve module-level documentation
+- [ ] Add examples for alternate encoders/presenters
+
+## Completed decisions
+
+- [x] D-001: clarify input vs builtin_inputs boundary
+- [x] D-002: consolidate orchestration onto pipeline
+- [x] D-003: enforce presenter/encoder separation

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -103,16 +103,16 @@ Configured and runtime execution are migrated onto the pipeline, and `engine::Lo
 
 ### D-002 Notes
 
-This decision has been implemented. The Loader and associated discovery orchestration model have been removed.  
+This decision has been implemented. The Loader and associated discovery orchestration model have been removed.
 
 ---
 
 ## D-003: Define clear boundary between Presenter and Encoder responsibilities
 
 **Date:** 2026-03-25  
-**Related findings:** F-003  
-**Issue:** #43  
-**Status:** Accepted
+**Status:** Implemented  
+**Related:** F-003  
+**Issue:** #43
 
 ---
 
@@ -136,7 +136,7 @@ The Presenter operates on normalized content (`Content`, `GameContent`, `GamePar
 - defining the output structure (directories and hierarchy)
 - grouping related content (e.g. multi-disc games)
 - determining layout decisions (e.g. root vs nested placement)
-- deciding when compound artifacts are required (e.g. M3U playlists)
+- deciding when compound artifacts are required (e.g. playlists)
 - constructing the logical VFS tree
 
 The Presenter answers:
@@ -146,7 +146,8 @@ The Presenter answers:
 The Presenter must **not**:
 
 - implement filename or extension rules
-- perform low-level file representation logic
+- perform file materialization logic
+- determine backing type (inline vs source-backed)
 - reinterpret raw inputs or bypass normalized content
 
 ---
@@ -157,8 +158,9 @@ The Encoder operates at the level of individual output items and is responsible 
 
 - generating filenames and extensions
 - defining how a content item is materialized as a file
-- mapping content parts to VFS file nodes
-- determining whether content is inline, generated, or source-backed
+- determining file backing (inline vs source-backed)
+- generating file contents (e.g. playlists)
+- mapping content parts to file representations
 - applying representation-specific transformations (e.g. `.nfo` → `.txt`)
 
 The Encoder answers:
@@ -179,11 +181,13 @@ The Encoder must **not**:
 |-----------------------------------------|-----------|
 | Multi-disc games as directories         | Presenter |
 | Platform-based folder structure         | Presenter |
-| Whether to generate an M3U playlist     | Presenter |
+| Whether to generate a playlist          | Presenter |
 | Disc filename `(Disc 1).cue`            | Encoder   |
 | ROM filename and extension              | Encoder   |
 | Text file normalization (`.nfo → .txt`) | Encoder   |
 | Binary output naming (`.bin`)           | Encoder   |
+| File backing (inline vs source-backed)  | Encoder   |
+| Playlist file contents                  | Encoder   |
 
 ---
 
@@ -191,12 +195,13 @@ The Encoder must **not**:
 
 Separating structure from representation provides:
 
-- clearer architectural boundaries
-- easier reasoning about output behavior
-- improved extensibility for future output formats
-- better support for plugin-style view customization
+- clear and enforceable architectural boundaries
+- elimination of duplicated representation logic
+- easier reasoning about output behaviour
+- improved extensibility for alternate output formats
+- a clean extension point for future plugin systems
 
-This aligns with the overall pipeline design:
+This aligns with the pipeline design:
 
 - normalization defines *what the content is*
 - presentation defines *how it is organized*
@@ -206,11 +211,10 @@ This aligns with the overall pipeline design:
 
 ### Consequences
 
-- existing Presenter and Encoder implementations should be reviewed for responsibility leaks
-- logic currently implemented in the wrong layer should be migrated:
-  - structural/grouping logic → Presenter
-  - naming/representation logic → Encoder
-- future features (e.g. alternate views, export formats) should target the appropriate abstraction
+- naming and representation logic has been removed from Presenter implementations
+- file materialization (including backing type and generated content) is now owned by Encoder
+- Presenter operates purely as a structural transformation over normalized content
+- `OutputEncoder` becomes a primary extension point for output formats
 
 ---
 
@@ -229,5 +233,5 @@ This aligns with the overall pipeline design:
 
 ### Notes
 
-This decision clarifies the output boundary without introducing new functionality.  
-Implementation will focus on aligning existing code with this responsibility split.
+This decision has been fully implemented.  
+The Presenter/Encoder boundary is now enforced in code, with no remaining responsibility overlap.

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -25,6 +25,24 @@ impl BasicEncoder {
         }
     }
 
+    fn file_name_for_game_part(&self, game: &GameContent, part: &GamePart) -> String {
+        match part {
+            GamePart::Rom(rom) => rom.file_name.clone(),
+            GamePart::Disc(disc) => format!("{} (Disc {}).cue", game.title, disc.disc_number),
+        }
+    }
+
+    fn size_for_game_part(&self, part: &GamePart) -> u64 {
+        match part {
+            GamePart::Rom(rom) => rom.size,
+            GamePart::Disc(_) => 0,
+        }
+    }
+
+    fn playlist_name_for(&self, game: &GameContent) -> String {
+        format!("{}.m3u", game.title)
+    }
+
     fn size_for(&self, content: &Content) -> u64 {
         match content {
             Content::Bytes(bytes) => bytes.size,
@@ -65,6 +83,28 @@ impl OutputEncoder for BasicEncoder {
         Ok(EncodedFile {
             name: self.file_name_for(content),
             size: self.size_for(content),
+        })
+    }
+
+    fn encode_game_part(
+        &self,
+        game: &GameContent,
+        part: &GamePart,
+    ) -> Result<EncodedFile, std::io::Error> {
+        Ok(EncodedFile {
+            name: self.file_name_for_game_part(game, part),
+            size: self.size_for_game_part(part),
+        })
+    }
+
+    fn encode_playlist(
+        &self,
+        game: &GameContent,
+        _entries: &[String],
+    ) -> Result<EncodedFile, std::io::Error> {
+        Ok(EncodedFile {
+            name: self.playlist_name_for(game),
+            size: 0,
         })
     }
 }

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -1,4 +1,4 @@
-use crate::core::content::{Content, GamePart};
+use crate::core::content::{Content, GameContent, GamePart};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 
 pub struct BasicEncoder;

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -1,5 +1,5 @@
 use crate::core::content::{Content, GameContent, GamePart};
-use crate::output::encode::{EncodedFile, OutputEncoder};
+use crate::output::encode::{EncodedBacking, EncodedFile, OutputEncoder};
 
 pub struct BasicEncoder;
 
@@ -12,13 +12,33 @@ impl BasicEncoder {
         match content {
             Content::Bytes(bytes) => format!("{}.bin", bytes.id),
             Content::Game(game) => match game.parts.as_slice() {
-                [GamePart::Rom(rom)] => rom.file_name.clone(),
-                [GamePart::Disc(disc)] => {
-                    format!("{} (Disc {}).cue", game.title, disc.disc_number)
-                }
+                [part] => self.file_name_for_game_part(game, part),
                 _ => game.title.clone(),
             },
             Content::Text(text) => normalize_text_name(text.id.0.as_ref()),
+            Content::Rom(_) | Content::Disc(_) => {
+                unreachable!("BasicEncoder should only encode normalized playable content")
+            }
+        }
+    }
+
+    fn backing_for(&self, content: &Content) -> EncodedBacking {
+        match content {
+            Content::Bytes(bytes) => EncodedBacking::SourceBacked {
+                size: bytes.size,
+                source: bytes.source.clone(),
+            },
+            Content::Game(game) => match game.parts.as_slice() {
+                [part] => self.backing_for_game_part(part),
+                _ => EncodedBacking::SourceBacked {
+                    size: 0,
+                    source: game.source.clone(),
+                },
+            },
+            Content::Text(text) => EncodedBacking::SourceBacked {
+                size: text.size,
+                source: text.source.clone(),
+            },
             Content::Rom(_) | Content::Disc(_) => {
                 unreachable!("BasicEncoder should only encode normalized playable content")
             }
@@ -32,10 +52,16 @@ impl BasicEncoder {
         }
     }
 
-    fn size_for_game_part(&self, part: &GamePart) -> u64 {
+    fn backing_for_game_part(&self, part: &GamePart) -> EncodedBacking {
         match part {
-            GamePart::Rom(rom) => rom.size,
-            GamePart::Disc(_) => 0,
+            GamePart::Rom(rom) => EncodedBacking::SourceBacked {
+                size: rom.size,
+                source: rom.source.clone(),
+            },
+            GamePart::Disc(disc) => EncodedBacking::SourceBacked {
+                size: 0,
+                source: disc.source.clone(),
+            },
         }
     }
 
@@ -43,19 +69,8 @@ impl BasicEncoder {
         format!("{}.m3u", game.title)
     }
 
-    fn size_for(&self, content: &Content) -> u64 {
-        match content {
-            Content::Bytes(bytes) => bytes.size,
-            Content::Game(game) => match game.parts.as_slice() {
-                [GamePart::Rom(rom)] => rom.size,
-                [GamePart::Disc(_)] => 0,
-                _ => 0,
-            },
-            Content::Text(text) => text.size,
-            Content::Rom(_) | Content::Disc(_) => {
-                unreachable!("BasicEncoder should only encode normalized playable content")
-            }
-        }
+    fn playlist_backing(&self, entries: &[String]) -> EncodedBacking {
+        EncodedBacking::Inline((entries.join("\n") + "\n").into_bytes())
     }
 }
 
@@ -82,7 +97,7 @@ impl OutputEncoder for BasicEncoder {
     fn encode(&self, content: &Content) -> Result<EncodedFile, std::io::Error> {
         Ok(EncodedFile {
             name: self.file_name_for(content),
-            size: self.size_for(content),
+            backing: self.backing_for(content),
         })
     }
 
@@ -93,18 +108,18 @@ impl OutputEncoder for BasicEncoder {
     ) -> Result<EncodedFile, std::io::Error> {
         Ok(EncodedFile {
             name: self.file_name_for_game_part(game, part),
-            size: self.size_for_game_part(part),
+            backing: self.backing_for_game_part(part),
         })
     }
 
     fn encode_playlist(
         &self,
         game: &GameContent,
-        _entries: &[String],
+        entries: &[String],
     ) -> Result<EncodedFile, std::io::Error> {
         Ok(EncodedFile {
             name: self.playlist_name_for(game),
-            size: 0,
+            backing: self.playlist_backing(entries),
         })
     }
 }
@@ -129,7 +144,13 @@ mod tests {
 
         let encoded = encoder.encode(&content).unwrap();
         assert_eq!(encoded.name, "bios.bin");
-        assert_eq!(encoded.size, 512);
+        assert_eq!(
+            encoded.backing,
+            EncodedBacking::SourceBacked {
+                size: 512,
+                source: SourceRef::new("file:/roms/bios"),
+            }
+        );
     }
 
     #[test]
@@ -150,7 +171,13 @@ mod tests {
 
         let encoded = encoder.encode(&content).unwrap();
         assert_eq!(encoded.name, "Super Mario World.sfc");
-        assert_eq!(encoded.size, 4096);
+        assert_eq!(
+            encoded.backing,
+            EncodedBacking::SourceBacked {
+                size: 4096,
+                source: SourceRef::new("file:/roms/Super Mario World.sfc"),
+            }
+        );
     }
 
     #[test]
@@ -171,7 +198,73 @@ mod tests {
 
         let encoded = encoder.encode(&content).unwrap();
         assert_eq!(encoded.name, "Metal Gear Solid (Disc 1).cue");
-        assert_eq!(encoded.size, 0);
+        assert_eq!(
+            encoded.backing,
+            EncodedBacking::SourceBacked {
+                size: 0,
+                source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
+            }
+        );
+    }
+
+    #[test]
+    fn encodes_disc_part() {
+        let encoder = BasicEncoder::new();
+        let game = GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![],
+            consumed_sources: vec![],
+        };
+
+        let part = GamePart::Disc(DiscPart {
+            source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+            disc_number: 2,
+            consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+        });
+
+        let encoded = encoder.encode_game_part(&game, &part).unwrap();
+        assert_eq!(encoded.name, "Final Fantasy VII (Disc 2).cue");
+        assert_eq!(
+            encoded.backing,
+            EncodedBacking::SourceBacked {
+                size: 0,
+                source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+            }
+        );
+    }
+
+    #[test]
+    fn encodes_playlist() {
+        let encoder = BasicEncoder::new();
+        let game = GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![],
+            consumed_sources: vec![],
+        };
+
+        let encoded = encoder
+            .encode_playlist(
+                &game,
+                &[
+                    "Final Fantasy VII (Disc 1).cue".to_string(),
+                    "Final Fantasy VII (Disc 2).cue".to_string(),
+                ],
+            )
+            .unwrap();
+
+        assert_eq!(encoded.name, "Final Fantasy VII.m3u");
+        assert_eq!(
+            encoded.backing,
+            EncodedBacking::Inline(
+                b"Final Fantasy VII (Disc 1).cue\nFinal Fantasy VII (Disc 2).cue\n".to_vec()
+            )
+        );
     }
 
     #[test]
@@ -185,7 +278,13 @@ mod tests {
 
         let encoded = encoder.encode(&content).unwrap();
         assert_eq!(encoded.name, "readme.txt");
-        assert_eq!(encoded.size, 128);
+        assert_eq!(
+            encoded.backing,
+            EncodedBacking::SourceBacked {
+                size: 128,
+                source: SourceRef::new("file:/roms/readme"),
+            }
+        );
     }
 
     #[test]
@@ -199,7 +298,13 @@ mod tests {
 
         let encoded = encoder.encode(&content).unwrap();
         assert_eq!(encoded.name, "mixed/notes.txt");
-        assert_eq!(encoded.size, 10);
+        assert_eq!(
+            encoded.backing,
+            EncodedBacking::SourceBacked {
+                size: 10,
+                source: SourceRef::new("mixed/notes.txt"),
+            }
+        );
     }
 
     #[test]
@@ -213,6 +318,12 @@ mod tests {
 
         let encoded = encoder.encode(&content).unwrap();
         assert_eq!(encoded.name, "roms/snes/game.txt");
-        assert_eq!(encoded.size, 19);
+        assert_eq!(
+            encoded.backing,
+            EncodedBacking::SourceBacked {
+                size: 19,
+                source: SourceRef::new("roms/snes/game.nfo"),
+            }
+        );
     }
 }

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -1,4 +1,4 @@
-use crate::core::content::Content;
+use crate::core::content::{Content, GameContent, GamePart};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncodedFile {
@@ -6,7 +6,22 @@ pub struct EncodedFile {
     pub size: u64,
 }
 
-pub trait OutputEncoder: Send + Sync {
+pub trait OutputEncoder {
     fn can_encode(&self, content: &Content) -> bool;
+
     fn encode(&self, content: &Content) -> Result<EncodedFile, std::io::Error>;
+
+    /// Encode an individual game part (ROM or Disc)
+    fn encode_game_part(
+        &self,
+        game: &GameContent,
+        part: &GamePart,
+    ) -> Result<EncodedFile, std::io::Error>;
+
+    /// Encode a playlist file for a multi-disc game
+    fn encode_playlist(
+        &self,
+        game: &GameContent,
+        entries: &[String],
+    ) -> Result<EncodedFile, std::io::Error>;
 }

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -1,9 +1,35 @@
 use crate::core::content::{Content, GameContent, GamePart};
+use crate::core::source::SourceRef;
+use crate::core::vfs::VfsFile;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncodedBacking {
+    SourceBacked { size: u64, source: SourceRef },
+    Inline(Vec<u8>),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EncodedFile {
     pub name: String,
-    pub size: u64,
+    pub backing: EncodedBacking,
+}
+
+impl EncodedFile {
+    pub fn to_vfs_file(&self) -> VfsFile {
+        match &self.backing {
+            EncodedBacking::SourceBacked { size, source } => {
+                VfsFile::source_backed(self.name.clone(), *size, source.clone())
+            }
+            EncodedBacking::Inline(bytes) => VfsFile::inline(self.name.clone(), bytes.clone()),
+        }
+    }
+
+    pub fn size(&self) -> u64 {
+        match &self.backing {
+            EncodedBacking::SourceBacked { size, .. } => *size,
+            EncodedBacking::Inline(bytes) => bytes.len() as u64,
+        }
+    }
 }
 
 pub trait OutputEncoder {
@@ -11,14 +37,12 @@ pub trait OutputEncoder {
 
     fn encode(&self, content: &Content) -> Result<EncodedFile, std::io::Error>;
 
-    /// Encode an individual game part (ROM or Disc)
     fn encode_game_part(
         &self,
         game: &GameContent,
         part: &GamePart,
     ) -> Result<EncodedFile, std::io::Error>;
 
-    /// Encode a playlist file for a multi-disc game
     fn encode_playlist(
         &self,
         game: &GameContent,

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -74,7 +74,7 @@ where
         if self.is_multi_disc_game(game) {
             self.insert_multi_disc_game(root, game, &base_path);
         } else {
-            let file_path = format!("{}/{}", base_path, file_name(&encoded.name));
+            let file_path = format!("{}/{}", base_path, encoded.name);
             self.insert_file_path(
                 root,
                 &file_path,
@@ -95,25 +95,32 @@ where
 
         disc_parts.sort_by(|left, right| left.disc_number.cmp(&right.disc_number));
 
-        let disc_names: Vec<String> = disc_parts
-            .iter()
-            .map(|disc| format!("{} (Disc {}).cue", game.title, disc.disc_number))
-            .collect();
+        let mut disc_names = Vec::new();
 
         for disc in &disc_parts {
-            let disc_path = format!(
-                "{}/{} (Disc {}).cue",
-                base_path, game.title, disc.disc_number
-            );
+            let encoded = self
+                .encoder
+                .encode_game_part(game, &GamePart::Disc((*disc).clone()))
+                .expect("disc part should encode");
+
+            disc_names.push(encoded.name.clone());
+
+            let disc_path = format!("{}/{}", base_path, encoded.name);
             self.insert_file_path(
                 root,
                 &disc_path,
-                VfsFile::source_backed(file_name(&disc_path), 0, disc.source.clone()),
+                VfsFile::source_backed(file_name(&disc_path), encoded.size, disc.source.clone()),
             );
         }
 
-        let playlist_path = format!("{}/{}.m3u", base_path, game.title);
+        let playlist_encoded = self
+            .encoder
+            .encode_playlist(game, &disc_names)
+            .expect("playlist should encode");
+
+        let playlist_path = format!("{}/{}", base_path, playlist_encoded.name);
         let playlist = disc_names.join("\n") + "\n";
+
         self.insert_file_path(
             root,
             &playlist_path,

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,5 +1,5 @@
 use crate::core::content::{Content, DiscPart, GameContent, GamePart};
-use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
+use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
 
@@ -52,11 +52,7 @@ where
                     self.insert_file_path(
                         &mut root,
                         &entry.encoded.name,
-                        VfsFile::source_backed(
-                            file_name(&entry.encoded.name),
-                            entry.encoded.size,
-                            entry.content.source().clone(),
-                        ),
+                        entry.encoded.to_vfs_file(),
                     );
                 }
                 Content::Rom(_) | Content::Disc(_) => {
@@ -75,11 +71,7 @@ where
             self.insert_multi_disc_game(root, game, &base_path);
         } else {
             let file_path = format!("{}/{}", base_path, encoded.name);
-            self.insert_file_path(
-                root,
-                &file_path,
-                VfsFile::source_backed(file_name(&file_path), encoded.size, game.source.clone()),
-            );
+            self.insert_file_path(root, &file_path, encoded.to_vfs_file());
         }
     }
 
@@ -106,11 +98,7 @@ where
             disc_names.push(encoded.name.clone());
 
             let disc_path = format!("{}/{}", base_path, encoded.name);
-            self.insert_file_path(
-                root,
-                &disc_path,
-                VfsFile::source_backed(file_name(&disc_path), encoded.size, disc.source.clone()),
-            );
+            self.insert_file_path(root, &disc_path, encoded.to_vfs_file());
         }
 
         let playlist_encoded = self
@@ -119,16 +107,15 @@ where
             .expect("playlist should encode");
 
         let playlist_path = format!("{}/{}", base_path, playlist_encoded.name);
-        let playlist = disc_names.join("\n") + "\n";
-
-        self.insert_file_path(
-            root,
-            &playlist_path,
-            VfsFile::inline(file_name(&playlist_path), playlist.into_bytes()),
-        );
+        self.insert_file_path(root, &playlist_path, playlist_encoded.to_vfs_file());
     }
 
-    fn insert_file_path(&self, root: &mut VfsDirectory, path: &str, file: VfsFile) {
+    fn insert_file_path(
+        &self,
+        root: &mut VfsDirectory,
+        path: &str,
+        file: crate::core::vfs::VfsFile,
+    ) {
         let normalized = normalize_path(path);
         let (parents, _) = split_parent_dirs(&normalized);
         let directory = ensure_directory(root, &parents);
@@ -173,15 +160,6 @@ fn split_parent_dirs(path: &str) -> (Vec<String>, String) {
             file_name.to_string(),
         ),
         None => (Vec::new(), normalized),
-    }
-}
-
-fn file_name(path: &str) -> String {
-    let normalized = normalize_path(path);
-
-    match normalized.rsplit_once('/') {
-        Some((_, file_name)) => file_name.to_string(),
-        None => normalized,
     }
 }
 


### PR DESCRIPTION
## Title
output: enforce presenter/encoder boundary and complete D-003

---

## Summary

This PR completes **D-003 (Presenter vs Encoder boundary)** by fully separating structural concerns (Presenter) from representation/materialization concerns (Encoder).

It removes all remaining responsibility overlap between the two layers and establishes a clean, enforceable output boundary aligned with the Phase 3 pipeline architecture.

---

## Key Changes

### 1. Encoder now owns all representation concerns

- Moved filename generation entirely into `OutputEncoder`
- Introduced encoder support for:
  - per-`GamePart` file naming
  - playlist (`.m3u`) naming
  - file backing (inline vs source-backed)
  - generated file contents (e.g. playlist bodies)

- `BasicEncoder` now:
  - determines file names and extensions
  - determines file sizes
  - constructs final file representations

---

### 2. Presenter reduced to pure structural responsibility

- Removed all naming and materialization logic from `GenericPresenter`
- Presenter now only:
  - defines directory structure
  - groups content (e.g. multi-disc games)
  - determines layout
  - decides when compound artifacts (e.g. playlists) are required

- Presenter delegates all file creation to the encoder

---

### 3. Clear materialization boundary established

- Presenter: *"what the output looks like"*
- Encoder: *"how each item is represented"*

This removes:
- duplicated naming logic
- implicit coupling between structure and representation
- ambiguity in ownership of file construction

---

### 4. Documentation aligned with implementation

Updated architecture documentation to reflect the new boundary:

- `docs/architecture/README.md`
- `docs/architecture/decisions.md`
- `docs/architecture/boundaries.md`
- `docs/architecture/cleanup-tracker.md`

Key updates:

- D-003 marked as **Implemented**
- Pipeline split into:
  - Present (structure)
  - Encode (materialization)
- F-003 marked as resolved

---

## Architectural Impact

This change completes the output side of the Phase 3 pipeline:

```
Input → Identify → Decode → Normalize → Present → Encode → VFS
```

The system now has:

- a single orchestration model (D-002)
- clean input/discovery boundaries (D-001)
- strict separation between structure and representation (D-003)

---

## Why this matters

- Eliminates responsibility overlap between Presenter and Encoder
- Enables alternate output formats without changing structure logic
- Provides a clean extension point for future plugin-based output systems
- Simplifies reasoning about output behaviour
- Reduces duplication and hidden coupling

---

## Follow-up Work

Next architectural focus:

- **F-004: Core model purity**
  - audit `GameContent` / `GamePart` for presentation leakage
  - ensure normalization layer remains fully presentation-agnostic

---

## Notes

- No intended behavioural changes beyond internal refactoring
- CI is green across all targets
- Existing tests updated where necessary to reflect new boundary
- This PR is a prerequisite for future extensibility work (alternate presenters/encoders)