### PR TITLE
refactor(core): implement D-004 and eliminate ROM filename leakage from model

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -183,6 +183,6 @@ The architecture review work in this directory aims to:
 
 ## Next Focus Areas
 
-- F-004: ensure the core model remains presentation-agnostic
+- review the next architectural boundary concern after D-004
 - improve module-level documentation
 - introduce diagrams for better visualization of the pipeline

--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -179,8 +179,8 @@ The Encoder must **not**:
 ### Decode → Core Model
 
 - Produces `Content` / `GameContent`
-- Must not leak container or source-specific details
-- Must not encode presentation decisions
+- May retain source provenance needed for semantic interpretation
+- Must not encode presentation decisions such as filenames, extensions, or naming conventions
 
 ---
 
@@ -226,4 +226,4 @@ The Encoder must **not**:
 - [x] F-001: input vs inputs naming ambiguity (resolved via `builtin_inputs` rename)
 - [x] F-002: loader vs pipeline orchestration ambiguity (resolved via D-002)
 - [x] F-003: presenter vs encoder responsibility boundary (resolved via D-003)
-- [ ] F-004: potential core model presentation leakage
+- [x] F-004: core model presentation leakage (resolved via D-004)

--- a/docs/architecture/cleanup-tracker.md
+++ b/docs/architecture/cleanup-tracker.md
@@ -39,10 +39,14 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 
 ### F-004: Core model leaking presentation concerns
 
-- [ ] Audit `GameContent`, `DiscPart`, `RomPart` for presentation-specific fields
-- [ ] Identify fields that exist only to support current presenter
-- [ ] Define stricter core model responsibilities
-- [ ] Remove or relocate presentation-derived data where appropriate
+### F-004: Core model leaking presentation concerns
+
+- [x] Audit `GameContent`, `DiscPart`, `RomPart`, and `RomContent` for presentation-specific fields
+- [x] Identify fields that exist only to support current presenter/CLI output
+- [x] Define stricter core model responsibilities
+- [x] Remove or relocate presentation-derived data where appropriate
+- [x] Move ROM filename derivation out of normalized model types
+- [x] Update documentation and findings
 
 ---
 
@@ -63,6 +67,9 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 
 ## Completed decisions
 
+## Completed decisions
+
 - [x] D-001: clarify input vs builtin_inputs boundary
 - [x] D-002: consolidate orchestration onto pipeline
 - [x] D-003: enforce presenter/encoder separation
+- [x] D-004: ensure core model remains presentation-agnostic

--- a/docs/architecture/cleanup-tracker.md
+++ b/docs/architecture/cleanup-tracker.md
@@ -39,8 +39,6 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 
 ### F-004: Core model leaking presentation concerns
 
-### F-004: Core model leaking presentation concerns
-
 - [x] Audit `GameContent`, `DiscPart`, `RomPart`, and `RomContent` for presentation-specific fields
 - [x] Identify fields that exist only to support current presenter/CLI output
 - [x] Define stricter core model responsibilities

--- a/docs/architecture/cleanup-tracker.md
+++ b/docs/architecture/cleanup-tracker.md
@@ -67,8 +67,6 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 
 ## Completed decisions
 
-## Completed decisions
-
 - [x] D-001: clarify input vs builtin_inputs boundary
 - [x] D-002: consolidate orchestration onto pipeline
 - [x] D-003: enforce presenter/encoder separation

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -235,3 +235,86 @@ This aligns with the pipeline design:
 
 This decision has been fully implemented.  
 The Presenter/Encoder boundary is now enforced in code, with no remaining responsibility overlap.
+---
+
+## D-004: Ensure core model remains presentation-agnostic
+
+**Date:** 2026-03-26  
+**Status:** Implemented  
+**Related:** F-004  
+
+---
+
+### Decision
+
+The core model (`Content`, `GameContent`, `GamePart`) will contain only semantic information about content and must not encode presentation or representation decisions.
+
+- The core model defines *what the content is*
+- The Presenter defines *how content is structured*
+- The Encoder defines *how content is represented*
+
+---
+
+### Rules
+
+The core model may include:
+
+- intrinsic identifiers (e.g. title, platform)
+- structural relationships (e.g. multi-disc ordering)
+- source references and sizes
+
+The core model must not include:
+
+- filenames or extensions
+- formatting or naming conventions
+- output-specific representation details
+
+---
+
+### Changes
+
+- removed filename-related data from `RomPart`
+- ensured all filename generation is handled exclusively by `OutputEncoder`
+- updated encoder logic to derive filenames from source information
+
+---
+
+### Rationale
+
+This enforces a strict separation between semantics and representation:
+
+- eliminates presentation leakage into the core model
+- ensures consistency with D-003 (Presenter vs Encoder boundary)
+- enables alternate output formats without modifying core structures
+- simplifies reasoning about data flow through the pipeline
+
+---
+
+### Consequences
+
+- the core model is now fully presentation-agnostic
+- all naming and representation logic is centralized in the Encoder
+- Presenter operates purely on structure without relying on embedded naming hints
+- future encoders can define entirely different naming schemes without impacting core logic
+
+---
+
+### Alternatives considered
+
+- **Retain filename in `RomPart` for convenience**  
+  Rejected — introduces representation concerns into the core model and duplicates encoder responsibility
+
+- **Remove disc numbering from `DiscPart`**  
+  Rejected — disc ordering is intrinsic to the content and required for correct grouping and semantics
+
+---
+
+### Notes
+
+This decision builds directly on D-003 and completes the separation between:
+
+- semantic model (core)
+- structural layout (presenter)
+- representation (encoder)
+
+The pipeline is now cleanly layered end-to-end.

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -235,27 +235,32 @@ This aligns with the pipeline design:
 
 This decision has been fully implemented.  
 The Presenter/Encoder boundary is now enforced in code, with no remaining responsibility overlap.
+
 ---
 
 ## D-004: Ensure core model remains presentation-agnostic
 
 **Date:** 2026-03-26  
 **Status:** Implemented  
-**Related:** F-004  
+**Related:** F-004
 
----
+### D-004 Context
 
-### Decision
+The core model should describe content semantically, independently from how that content is presented or materialized in output views.
+
+Earlier iterations of the model included filename-oriented data in `RomPart`, which introduced representation concerns into the normalization layer.
+
+This created tension with D-003, which established that naming and materialization belong to the Encoder, not the core model.
+
+### D-004 Decision
 
 The core model (`Content`, `GameContent`, `GamePart`) will contain only semantic information about content and must not encode presentation or representation decisions.
 
-- The core model defines *what the content is*
-- The Presenter defines *how content is structured*
-- The Encoder defines *how content is represented*
+- The core model defines what the content is
+- The Presenter defines how content is structured
+- The Encoder defines how content is represented
 
----
-
-### Rules
+### D-004 Rules
 
 The core model may include:
 
@@ -269,17 +274,13 @@ The core model must not include:
 - formatting or naming conventions
 - output-specific representation details
 
----
-
-### Changes
+### D-004 Changes
 
 - removed filename-related data from `RomPart`
 - ensured all filename generation is handled exclusively by `OutputEncoder`
 - updated encoder logic to derive filenames from source information
 
----
-
-### Rationale
+### D-004 Rationale
 
 This enforces a strict separation between semantics and representation:
 
@@ -288,18 +289,14 @@ This enforces a strict separation between semantics and representation:
 - enables alternate output formats without modifying core structures
 - simplifies reasoning about data flow through the pipeline
 
----
-
-### Consequences
+### D-004 Consequences
 
 - the core model is now fully presentation-agnostic
 - all naming and representation logic is centralized in the Encoder
 - Presenter operates purely on structure without relying on embedded naming hints
 - future encoders can define entirely different naming schemes without impacting core logic
 
----
-
-### Alternatives considered
+### D-004 Alternatives considered
 
 - **Retain filename in `RomPart` for convenience**  
   Rejected — introduces representation concerns into the core model and duplicates encoder responsibility
@@ -307,14 +304,12 @@ This enforces a strict separation between semantics and representation:
 - **Remove disc numbering from `DiscPart`**  
   Rejected — disc ordering is intrinsic to the content and required for correct grouping and semantics
 
----
-
-### Notes
+### D-004 Notes
 
 This decision builds directly on D-003 and completes the separation between:
 
 - semantic model (core)
-- structural layout (presenter)
-- representation (encoder)
+- structural layout (Presenter)
+- representation (Encoder)
 
 The pipeline is now cleanly layered end-to-end.

--- a/docs/architecture/review-findings.md
+++ b/docs/architecture/review-findings.md
@@ -164,21 +164,22 @@ TBD
 
 ## F-004: The core model boundary needs review to ensure `Content` and `GameContent` remain presentation-agnostic
 
-**Status:** Open  
-**Issue:** [#44](https://github.com/lloydsmart/retromount/issues/44)
+**Status:** Resolved  
+**Issue:** [#44](https://github.com/lloydsmart/retromount/issues/44)  
+**Resolved by:** D-004
 
 ### F-004 Context
 
-The current core model represents the project's normalized understanding of games and content, but it is not yet fully confirmed that these types are free from presentation-specific assumptions.
+The current core model represents the project's normalized understanding of games and content, and must remain independent from output/view decisions.
 
-This finding focuses on keeping the normalized model clean, reusable, and independent from output/view decisions.
+This finding focused on ensuring that `Content`, `GameContent`, and `GamePart` describe semantic content only, without carrying representation-specific details such as filenames.
 
 ### F-004 Evidence
 
 - Phase 3 introduced stronger normalization around `Content` and `GameContent`
-- the system now distinguishes between internal normalized content and output presentation
-- multi-disc grouping, naming conventions, and playable output representation all put pressure on the core/output boundary
-- some output behavior may currently depend on assumptions embedded in normalized model structures
+- the system distinguishes between internal normalized content and output presentation
+- ROM-related filename data had existed in normalized model types (`RomContent` and `RomPart`)
+- output behavior such as filenames and display naming is now handled outside the core model, based on source information and encoder logic
 
 ### F-004 Why it matters
 
@@ -199,4 +200,8 @@ If presentation-specific assumptions leak into `Content` or `GameContent`, then:
 
 ### F-004 Decision
 
-TBD
+Resolved by D-004.
+
+Filename-oriented data has been removed from normalized ROM model types, and ROM naming/metadata presentation is now derived from source information at the encoder and inspection/CLI layers.
+
+The normalized core model now carries semantic information only.

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -135,9 +135,9 @@ pub struct GameContent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub enum GamePart {
-    Rom(RomPart),
-    Disc(DiscPart),
+pub struct RomPart {
+    pub source: SourceRef,
+    pub size: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -111,7 +111,6 @@ pub struct BytesContent {
 pub struct RomContent {
     pub id: ContentId,
     pub source: SourceRef,
-    pub file_name: String,
     pub size: u64,
 }
 
@@ -135,15 +134,14 @@ pub struct GameContent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct RomPart {
-    pub source: SourceRef,
-    pub size: u64,
+pub enum GamePart {
+    Rom(RomPart),
+    Disc(DiscPart),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RomPart {
     pub source: SourceRef,
-    pub file_name: String,
     pub size: u64,
 }
 
@@ -171,7 +169,6 @@ mod tests {
         let content = Content::Rom(RomContent {
             id: ContentId::new("game"),
             source: SourceRef::new("src:game"),
-            file_name: "game.sfc".to_string(),
             size: 123,
         });
 
@@ -188,7 +185,6 @@ mod tests {
             platform: Platform::Snes,
             parts: vec![GamePart::Rom(RomPart {
                 source: SourceRef::new("file:/roms/game.sfc"),
-                file_name: "game.sfc".to_string(),
                 size: 123,
             })],
             consumed_sources: vec![],

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -45,7 +45,6 @@ pub fn normalize_content(contents: Vec<Content>, options: &NormalizationOptions)
                         .unwrap_or_else(|| derive_platform(&rom.file_name)),
                     parts: vec![GamePart::Rom(RomPart {
                         source: rom.source,
-                        file_name: rom.file_name,
                         size: rom.size,
                     })],
                     consumed_sources: vec![],

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -38,11 +38,11 @@ pub fn normalize_content(contents: Vec<Content>, options: &NormalizationOptions)
                 pending.push(PendingOutput::Direct(Content::Game(GameContent {
                     id: rom.id.clone(),
                     source: rom.source.clone(),
-                    title: leaf_stem(&rom.file_name),
+                    title: leaf_stem_from_source(&rom.source),
                     platform: options
                         .platform_hint
                         .clone()
-                        .unwrap_or_else(|| derive_platform(&rom.file_name)),
+                        .unwrap_or_else(|| derive_platform_from_source(&rom.source)),
                     parts: vec![GamePart::Rom(RomPart {
                         source: rom.source,
                         size: rom.size,
@@ -94,6 +94,25 @@ fn derive_platform(path: &str) -> Platform {
     let normalized = path.to_lowercase().replace('\\', "/");
 
     platform_from_segments(&normalized).unwrap_or_else(|| platform_from_extension(&normalized))
+}
+
+fn derive_platform_from_source(source: &SourceRef) -> Platform {
+    let normalized = source_path_for_matching(source);
+    derive_platform(&normalized)
+}
+
+fn source_path_for_matching(source: &SourceRef) -> String {
+    let raw = source.0.as_ref();
+
+    match raw.split_once('#') {
+        Some((_, member)) => member.replace('\\', "/"),
+        None => raw.replace('\\', "/"),
+    }
+}
+
+fn leaf_stem_from_source(source: &SourceRef) -> String {
+    let normalized = source_path_for_matching(source);
+    leaf_stem(&normalized)
 }
 
 fn platform_from_segments(path: &str) -> Option<Platform> {
@@ -173,7 +192,7 @@ fn normalize_disc_group(
         platform: options
             .platform_hint
             .clone()
-            .unwrap_or_else(|| derive_platform(&primary.source.to_string())),
+            .unwrap_or_else(|| derive_platform_from_source(&primary.source)),
         parts,
         consumed_sources,
     }
@@ -225,7 +244,6 @@ mod tests {
             vec![Content::Rom(RomContent {
                 id: ContentId::new("smw"),
                 source: SourceRef::new("file:/roms/Super Mario World.sfc"),
-                file_name: "Super Mario World.sfc".to_string(),
                 size: 4096,
             })],
             &NormalizationOptions::default(),
@@ -244,7 +262,6 @@ mod tests {
 
         match &game.parts[0] {
             GamePart::Rom(part) => {
-                assert_eq!(part.file_name, "Super Mario World.sfc");
                 assert_eq!(part.size, 4096);
             }
             other => panic!("expected rom part, got {other:?}"),
@@ -302,7 +319,6 @@ mod tests {
                 Content::Rom(RomContent {
                     id: ContentId::new("discs/ps1_multi/game_disc1.bin"),
                     source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.bin"),
-                    file_name: "discs/ps1_multi/game_disc1.bin".to_string(),
                     size: 6,
                 }),
                 Content::Disc(DiscContent {
@@ -360,12 +376,11 @@ mod tests {
     }
 
     #[test]
-    fn derives_rom_game_title_from_leaf_name() {
+    fn derives_rom_game_title_from_source_leaf_name() {
         let normalized = normalize_content(
             vec![Content::Rom(RomContent {
                 id: ContentId::new("roms/snes/Super Mario World.sfc"),
                 source: SourceRef::new("file:/roms/snes/Super Mario World.sfc"),
-                file_name: "roms/snes/Super Mario World.sfc".to_string(),
                 size: 4096,
             })],
             &NormalizationOptions::default(),
@@ -399,5 +414,12 @@ mod tests {
         assert_eq!(derive_platform("roms/game.smc"), Platform::Snes);
         assert_eq!(derive_platform("roms/game.nes"), Platform::Nes);
         assert_eq!(derive_platform("roms/game.cue"), Platform::Unknown);
+    }
+
+    #[test]
+    fn derives_platform_from_zip_member_source() {
+        let source =
+            SourceRef::new("zip:/roms/collection.zip#roms/megadrive/Sonic the Hedgehog.bin");
+        assert_eq!(derive_platform_from_source(&source), Platform::Megadrive);
     }
 }

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -9,6 +9,17 @@ impl SourceRef {
     pub fn new(value: impl Into<Arc<str>>) -> Self {
         Self(value.into())
     }
+
+    pub fn file_name(&self) -> String {
+        let normalized = self.0.replace('\\', "/");
+
+        let leaf = match normalized.rsplit_once('#') {
+            Some((_, member)) => member,
+            None => normalized.rsplit('/').next().unwrap_or(&normalized),
+        };
+
+        leaf.to_string()
+    }
 }
 
 impl fmt::Display for SourceRef {
@@ -31,5 +42,17 @@ mod tests {
     fn creates_source_ref() {
         let source = SourceRef::new("zip:/roms/snes.zip#game.sfc");
         assert_eq!(source.to_string(), "zip:/roms/snes.zip#game.sfc");
+    }
+
+    #[test]
+    fn derives_file_name_from_filesystem_source() {
+        let source = SourceRef::new("file:/roms/Super Mario World.sfc");
+        assert_eq!(source.file_name(), "Super Mario World.sfc");
+    }
+
+    #[test]
+    fn derives_file_name_from_zip_member_source() {
+        let source = SourceRef::new("zip:/roms/megadrive.zip#Sonic the Hedgehog.bin");
+        assert_eq!(source.file_name(), "Sonic the Hedgehog.bin");
     }
 }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -2,6 +2,7 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use crate::core::content::{Content, GamePart};
+use crate::core::source::SourceRef;
 use crate::error::RetromountError;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
@@ -98,7 +99,11 @@ fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Res
             writeln!(writer, "    Decoded: Rom")?;
             writeln!(writer, "      ID: {}", rom.id)?;
             writeln!(writer, "      Source: {}", rom.source)?;
-            writeln!(writer, "      File name: {}", rom.file_name)?;
+            writeln!(
+                writer,
+                "      File name: {}",
+                file_name_from_source(&rom.source)
+            )?;
             writeln!(writer, "      Size: {}", rom.size)?;
         }
         Content::Disc(disc) => {
@@ -121,7 +126,11 @@ fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Res
                     GamePart::Rom(rom) => {
                         writeln!(writer, "      Part {}: Rom", index + 1)?;
                         writeln!(writer, "        Source: {}", rom.source)?;
-                        writeln!(writer, "        File name: {}", rom.file_name)?;
+                        writeln!(
+                            writer,
+                            "        File name: {}",
+                            file_name_from_source(&rom.source)
+                        )?;
                         writeln!(writer, "        Size: {}", rom.size)?;
                     }
                     GamePart::Disc(disc) => {
@@ -149,6 +158,17 @@ fn yes_no(value: bool) -> &'static str {
     } else {
         "no"
     }
+}
+
+fn file_name_from_source(source: &SourceRef) -> String {
+    let normalized = source.0.replace('\\', "/");
+
+    let leaf = match normalized.rsplit_once('#') {
+        Some((_, member)) => member,
+        None => normalized.rsplit('/').next().unwrap_or(&normalized),
+    };
+
+    leaf.to_string()
 }
 
 #[cfg(test)]

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -151,22 +151,10 @@ fn yes_no(value: bool) -> &'static str {
     }
 }
 
-fn file_name_from_source(source: &SourceRef) -> String {
-    let normalized = source.0.replace('\\', "/");
-
-    let leaf = match normalized.rsplit_once('#') {
-        Some((_, member)) => member,
-        None => normalized.rsplit('/').next().unwrap_or(&normalized),
-    };
-
-    leaf.to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::core::content::{BytesContent, ContentId};
-    use crate::core::source::{SourceObject, SourceRef};
     use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
     use crate::engine::pipeline::TracedObject;
     use crate::input::identify::InputIdentity;

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -155,6 +155,7 @@ fn yes_no(value: bool) -> &'static str {
 mod tests {
     use super::*;
     use crate::core::content::{BytesContent, ContentId};
+    use crate::core::source::{SourceObject, SourceRef};
     use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
     use crate::engine::pipeline::TracedObject;
     use crate::input::identify::InputIdentity;

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -2,7 +2,6 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use crate::core::content::{Content, GamePart};
-use crate::core::source::SourceRef;
 use crate::error::RetromountError;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
@@ -99,11 +98,7 @@ fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Res
             writeln!(writer, "    Decoded: Rom")?;
             writeln!(writer, "      ID: {}", rom.id)?;
             writeln!(writer, "      Source: {}", rom.source)?;
-            writeln!(
-                writer,
-                "      File name: {}",
-                file_name_from_source(&rom.source)
-            )?;
+            writeln!(writer, "      File name: {}", rom.source.file_name())?;
             writeln!(writer, "      Size: {}", rom.size)?;
         }
         Content::Disc(disc) => {
@@ -126,11 +121,7 @@ fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Res
                     GamePart::Rom(rom) => {
                         writeln!(writer, "      Part {}: Rom", index + 1)?;
                         writeln!(writer, "        Source: {}", rom.source)?;
-                        writeln!(
-                            writer,
-                            "        File name: {}",
-                            file_name_from_source(&rom.source)
-                        )?;
+                        writeln!(writer, "        File name: {}", rom.source.file_name())?;
                         writeln!(writer, "        Size: {}", rom.size)?;
                     }
                     GamePart::Disc(disc) => {

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -64,7 +64,6 @@ impl InputDecoder for BasicInputDecoder {
                     Content::Rom(RomContent {
                         id,
                         source: object.source.clone(),
-                        file_name: object.name.clone(),
                         size,
                     })
                 } else {
@@ -213,11 +212,6 @@ fn path_without_extension(name: &str) -> String {
 fn parse_disc_info_from_name(name: &str) -> (String, u32) {
     let lower = name.to_lowercase();
 
-    // patterns like:
-    // game_disc1
-    // game-disc2
-    // game cd1
-    // game (disc 2)
     let patterns = ["disc", "cd", "disk", "vol"];
 
     for pattern in patterns {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use retromount::core::content::{Content, GamePart, Platform as ContentPlatform};
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
-use retromount::core::source::SourceRef;
 use retromount::engine::inspect::run_phase3_inspect;
 use retromount::engine::pipeline::run_pipeline_with_options;
 use retromount::engine::preview::{build_input_source, run_phase3_preview, write_vfs_tree};
@@ -115,11 +114,7 @@ fn log_content_summary(content: &Content) {
             for part in &game.parts {
                 match part {
                     GamePart::Rom(rom) => {
-                        info!(
-                            "    Rom: {} ({} bytes)",
-                            file_name_from_source(&rom.source),
-                            rom.size
-                        );
+                        info!("    Rom: {} ({} bytes)", rom.source.file_name(), rom.size);
                     }
                     GamePart::Disc(disc) => {
                         info!("    Disc {}: {}", disc.disc_number, disc.source);
@@ -133,15 +128,4 @@ fn log_content_summary(content: &Content) {
             info!("    Source: {}", other.source());
         }
     }
-}
-
-fn file_name_from_source(source: &SourceRef) -> String {
-    let normalized = source.0.replace('\\', "/");
-
-    let leaf = match normalized.rsplit_once('#') {
-        Some((_, member)) => member,
-        None => normalized.rsplit('/').next().unwrap_or(&normalized),
-    };
-
-    leaf.to_string()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use log::{debug, info};
 use std::path::PathBuf;
 
+use crate::core::source::SourceRef;
+
 use retromount::core::content::{Content, GamePart, Platform as ContentPlatform};
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
@@ -114,7 +116,11 @@ fn log_content_summary(content: &Content) {
             for part in &game.parts {
                 match part {
                     GamePart::Rom(rom) => {
-                        info!("    Rom: {} ({} bytes)", rom.file_name, rom.size);
+                        info!(
+                            "    Rom: {} ({} bytes)",
+                            file_name_from_source(&rom.source),
+                            rom.size
+                        );
                     }
                     GamePart::Disc(disc) => {
                         info!("    Disc {}: {}", disc.disc_number, disc.source);
@@ -128,4 +134,15 @@ fn log_content_summary(content: &Content) {
             info!("    Source: {}", other.source());
         }
     }
+}
+
+fn file_name_from_source(source: &SourceRef) -> String {
+    let normalized = source.0.replace('\\', "/");
+
+    let leaf = match normalized.rsplit_once('#') {
+        Some((_, member)) => member,
+        None => normalized.rsplit('/').next().unwrap_or(&normalized),
+    };
+
+    leaf.to_string()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
 use log::{debug, info};
 use std::path::PathBuf;
 
-use crate::core::source::SourceRef;
-
 use retromount::core::content::{Content, GamePart, Platform as ContentPlatform};
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
+use retromount::core::source::SourceRef;
 use retromount::engine::inspect::run_phase3_inspect;
 use retromount::engine::pipeline::run_pipeline_with_options;
 use retromount::engine::preview::{build_input_source, run_phase3_preview, write_vfs_tree};

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -1,4 +1,5 @@
 use crate::core::content::{Content, GameContent, GamePart};
+use crate::core::source::SourceRef;
 use crate::output::encode::{EncodedBacking, EncodedFile, OutputEncoder};
 
 pub struct BasicEncoder;
@@ -20,6 +21,17 @@ impl BasicEncoder {
                 unreachable!("BasicEncoder should only encode normalized playable content")
             }
         }
+    }
+
+    fn file_name_from_source(source: &SourceRef) -> String {
+        let normalized = source.0.replace('\\', "/");
+
+        let leaf = match normalized.rsplit_once('#') {
+            Some((_, member)) => member,
+            None => normalized.rsplit('/').next().unwrap_or(&normalized),
+        };
+
+        leaf.to_string()
     }
 
     fn backing_for(&self, content: &Content) -> EncodedBacking {
@@ -47,7 +59,7 @@ impl BasicEncoder {
 
     fn file_name_for_game_part(&self, game: &GameContent, part: &GamePart) -> String {
         match part {
-            GamePart::Rom(rom) => rom.file_name.clone(),
+            GamePart::Rom(rom) => Self::file_name_from_source(&rom.source),
             GamePart::Disc(disc) => format!("{} (Disc {}).cue", game.title, disc.disc_number),
         }
     }
@@ -163,7 +175,6 @@ mod tests {
             platform: Platform::Snes,
             parts: vec![GamePart::Rom(RomPart {
                 source: SourceRef::new("file:/roms/Super Mario World.sfc"),
-                file_name: "Super Mario World.sfc".to_string(),
                 size: 4096,
             })],
             consumed_sources: vec![],
@@ -325,5 +336,31 @@ mod tests {
                 source: SourceRef::new("roms/snes/game.nfo"),
             }
         );
+    }
+
+    #[test]
+    fn derives_rom_file_name_from_zip_member_source() {
+        let encoder = BasicEncoder::new();
+
+        let game = GameContent {
+            id: ContentId::new("sonic"),
+            source: SourceRef::new("zip:/roms/megadrive.zip#Sonic the Hedgehog.bin"),
+            title: "Sonic the Hedgehog".to_string(),
+            platform: Platform::Megadrive,
+            parts: vec![],
+            consumed_sources: vec![],
+        };
+
+        let encoded = encoder
+            .encode_game_part(
+                &game,
+                &GamePart::Rom(RomPart {
+                    source: SourceRef::new("zip:/roms/megadrive.zip#Sonic the Hedgehog.bin"),
+                    size: 1024,
+                }),
+            )
+            .unwrap();
+
+        assert_eq!(encoded.name, "Sonic the Hedgehog.bin");
     }
 }

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -131,6 +131,7 @@ mod tests {
         BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, Platform, RomPart,
         TextContent,
     };
+    use crate::core::source::SourceRef;
 
     #[test]
     fn encodes_bytes_content() {

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -1,5 +1,4 @@
 use crate::core::content::{Content, GameContent, GamePart};
-use crate::core::source::SourceRef;
 use crate::output::encode::{EncodedBacking, EncodedFile, OutputEncoder};
 
 pub struct BasicEncoder;
@@ -132,7 +131,6 @@ mod tests {
         BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, Platform, RomPart,
         TextContent,
     };
-    use crate::core::source::SourceRef;
 
     #[test]
     fn encodes_bytes_content() {

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -23,17 +23,6 @@ impl BasicEncoder {
         }
     }
 
-    fn file_name_from_source(source: &SourceRef) -> String {
-        let normalized = source.0.replace('\\', "/");
-
-        let leaf = match normalized.rsplit_once('#') {
-            Some((_, member)) => member,
-            None => normalized.rsplit('/').next().unwrap_or(&normalized),
-        };
-
-        leaf.to_string()
-    }
-
     fn backing_for(&self, content: &Content) -> EncodedBacking {
         match content {
             Content::Bytes(bytes) => EncodedBacking::SourceBacked {
@@ -59,7 +48,7 @@ impl BasicEncoder {
 
     fn file_name_for_game_part(&self, game: &GameContent, part: &GamePart) -> String {
         match part {
-            GamePart::Rom(rom) => Self::file_name_from_source(&rom.source),
+            GamePart::Rom(rom) => rom.source.file_name(),
             GamePart::Disc(disc) => format!("{} (Disc {}).cue", game.title, disc.disc_number),
         }
     }

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -223,7 +223,6 @@ mod tests {
                 platform: Platform::Megadrive,
                 parts: vec![GamePart::Rom(RomPart {
                     source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
-                    file_name: "Sonic the Hedgehog.bin".to_string(),
                     size: 1024,
                 })],
                 consumed_sources: vec![],
@@ -264,7 +263,6 @@ mod tests {
             platform: Platform::Snes,
             parts: vec![GamePart::Rom(RomPart {
                 source: SourceRef::new("file:/roms/Super Mario World.sfc"),
-                file_name: "Super Mario World.sfc".to_string(),
                 size: 4096,
             })],
             consumed_sources: vec![],
@@ -368,7 +366,6 @@ mod tests {
                 platform: Platform::Ps1,
                 parts: vec![GamePart::Rom(RomPart {
                     source: SourceRef::new("file:/roms/Crash Bandicoot.bin"),
-                    file_name: "Crash Bandicoot.bin".to_string(),
                     size: 1024,
                 })],
                 consumed_sources: vec![],


### PR DESCRIPTION
## Refactor core model boundary (D-004) and eliminate ROM filename leakage

### Summary

This PR completes **D-004 (core model boundary cleanup)** by removing presentation-specific filename data from the normalized core model and centralising filename derivation at the source/encoder boundary.

It ensures that the core model remains fully **presentation-agnostic**, aligning with the architectural goals defined during the boundary review.

---

### Related

- Resolves **F-004** (core model leaking presentation concerns)
- Implements **D-004**
- Closes #44

---

### Key Changes

#### 1. Remove filename from core model

- Removed `file_name` from:
  - `RomContent`
  - `RomPart`
- Updated all normalization logic to stop propagating filename data into the model

This ensures the core model represents **semantic content only**, not how it is presented.

---

#### 2. Move ROM naming responsibility to encoder

- Updated `BasicEncoder` to derive ROM filenames from `SourceRef`
- Ensures:
  - consistent naming across all output paths
  - encoder remains the single source of truth for representation

---

#### 3. Centralise filename derivation on `SourceRef`

- Introduced:

```rust
impl SourceRef {
    pub fn file_name(&self) -> String
}
```

- Removed duplicated `file_name_from_source` helpers from:
  - encoder
  - inspect
  - CLI (`main.rs`)

This consolidates source parsing logic into a single canonical location.

---

#### 4. Update inspect and CLI output

- Replaced all direct filename access with:
  - `source.file_name()`
- Ensures debug/inspect output does not depend on model fields

---

#### 5. Update tests

- Removed `file_name` usage from all test fixtures
- Restored required `SourceRef` / `SourceObject` imports in test modules
- Added coverage for `SourceRef::file_name()`

---

#### 6. Documentation updates

- Marked **F-004 as resolved** in:
  - `review-findings.md`
  - `cleanup-tracker.md`
  - `boundaries.md`
- Added D-004 to completed decisions
- Clarified that:
  - filenames are **not part of the core model**
  - representation is handled by encoder/output layers

---

### Architectural Impact

This change enforces a strict boundary:

- **Core model (`Content`, `GameContent`, `GamePart`)**
  - describes *what the content is*
  - contains no presentation-specific data

- **Encoder**
  - responsible for filenames, formats, and representation

- **SourceRef**
  - responsible for interpreting source-level metadata (e.g. filename extraction)

This significantly improves:

- separation of concerns
- future extensibility (e.g. alternate encoders)
- plugin readiness
- testability of individual layers

---

### Validation

- ✅ `cargo fmt`
- ✅ `cargo clippy -- -D warnings`
- ✅ `cargo test`
- ✅ `markdownlint` clean

---

### Follow-ups / Next Steps

- Consider centralising additional source-derived helpers (if needed)
- Begin next boundary review step (potential D-005)
- Continue aligning model with plugin-oriented architecture

---

### Notes

This PR is intentionally scoped to **model boundary correctness**, not behavioural changes.

All output behaviour remains unchanged — only the ownership of that behaviour has been corrected.