### PR TITLE
Implement D-005: decoded/normalized content split

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -67,7 +67,7 @@ This structure ensures that:
 
 Retromount is built around a single, unified processing pipeline:
 
-Input → Identify → Decode → Normalize → Present → VFS
+Input → Identify → Decode (`DecodedContent`) → Normalize (`NormalizedContent`) → Present → Encode → VFS
 
 All execution modes (preview, inspect, and runtime) use this pipeline.
 
@@ -106,18 +106,18 @@ These steps transform raw input into structured data suitable for normalization.
 
 ---
 
-### Normalized core model
+### Decoded and normalized models
 
-The core model represents content in a presentation-agnostic way.
+Retromount separates decoded content from normalized content.
 
 Key types include:
 
-- `Content`
+- `DecodedContent`
+- `NormalizedContent`
 - `GameContent`
 - `GamePart`
-- `Disc`
 
-This layer defines what the content is, independent of how it will be shown.
+This split ensures that decoded artifacts and normalized semantic entities are not represented by the same top-level model.
 
 ---
 
@@ -183,6 +183,6 @@ The architecture review work in this directory aims to:
 
 ## Next Focus Areas
 
-- review the next architectural boundary concern after D-004
+- review the next architectural boundary concern after D-005
 - improve module-level documentation
 - introduce diagrams for better visualization of the pipeline

--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -1,6 +1,6 @@
 # Architecture Boundaries
 
-This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation and D-002/D-003.
+This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation and D-002 through D-005.
 
 ---
 
@@ -81,7 +81,7 @@ This stage answers:
 
 ---
 
-### 4. Normalize (Core Model)
+### 4. Normalize (Decoded → Normalized Boundary)
 
 Implemented in: `src/core`
 
@@ -92,10 +92,10 @@ Responsible for:
 
 Key types:
 
-- `Content`
+- `DecodedContent`
+- `NormalizedContent`
 - `GameContent`
 - `GamePart`
-- `Disc`
 
 This stage answers:
 
@@ -176,19 +176,20 @@ The Encoder must **not**:
 
 ---
 
-### Decode → Core Model
+### Decode → Normalize
 
-- Produces `Content` / `GameContent`
-- May retain source provenance needed for semantic interpretation
-- Must not encode presentation decisions such as filenames, extensions, or naming conventions
+- Decode produces `DecodedContent`
+- Normalize consumes `DecodedContent` and produces `NormalizedContent`
+- Source provenance may be retained where needed for semantic interpretation
+- Normalized content must not encode presentation decisions such as filenames, extensions, or naming conventions
 
 ---
 
-### Core Model → Presenter
+### Normalized Model → Presenter
 
-- Presenter consumes normalized model
+- Presenter consumes `NormalizedContent`
 - Must not re-interpret raw inputs
-- Must not depend on source/container details
+- Must not depend on decoder-specific details
 
 ---
 
@@ -227,6 +228,7 @@ The Encoder must **not**:
 - [x] F-002: loader vs pipeline orchestration ambiguity (resolved via D-002)
 - [x] F-003: presenter vs encoder responsibility boundary (resolved via D-003)
 - [x] F-004: core model presentation leakage (resolved via D-004)
+- [x] F-005: decoded vs normalized content boundary ambiguity (resolved via D-005)
 
 ## Decode → Normalize Boundary
 

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -112,7 +112,7 @@ This decision has been implemented. The Loader and associated discovery orchestr
 **Date:** 2026-03-25  
 **Status:** Implemented  
 **Related:** F-003  
-**Issue:** #43
+**Issue:** [#43](https://github.com/lloydsmart/retromount/issues/43)
 
 ---
 
@@ -131,7 +131,7 @@ These roles are complementary and must remain distinct.
 
 #### Presenter
 
-The Presenter operates on normalized content (`Content`, `GameContent`, `GamePart`) and is responsible for:
+The Presenter operates on normalized content (`NormalizedContent`, `GameContent`, `GamePart`) and is responsible for:
 
 - defining the output structure (directories and hierarchy)
 - grouping related content (e.g. multi-disc games)
@@ -254,7 +254,7 @@ This created tension with D-003, which established that naming and materializati
 
 ### D-004 Decision
 
-The core model (`Content`, `GameContent`, `GamePart`) will contain only semantic information about content and must not encode presentation or representation decisions.
+The normalized core model (`NormalizedContent`, `GameContent`, `GamePart`) will contain only semantic information about content and must not encode presentation or representation decisions.
 
 - The core model defines what the content is
 - The Presenter defines how content is structured
@@ -319,52 +319,48 @@ The pipeline is now cleanly layered end-to-end.
 ## D-005: Separate decoded content from normalized content
 
 **Date:** 2026-03-26  
-**Status:** Proposed  
+**Status:** Implemented  
 **Related:** F-005  
 **Issue:** [#53](https://github.com/lloydsmart/retromount/issues/53)
 
 ### D-005 Context
 
-Retromount currently uses `Content` to represent both decoded input artifacts and normalized semantic output.
+Retromount previously used a single `Content` model to represent both decoded input artifacts and normalized semantic output.
 
-This means the same model family spans multiple pipeline stages:
+This meant the same model family spanned multiple pipeline stages:
 
-- decode produces `Content`
-- normalize consumes `Content` and produces `Content`
-- present consumes normalized `Content`
-- encode consumes normalized `Content`
+- decode produced `Content`
+- normalize consumed `Content` and produced `Content`
+- present consumed normalized `Content`
+- encode consumed normalized `Content`
 
-In practice, later stages do not accept all `Content` variants equally.
+In practice, later stages did not accept all `Content` variants equally.
 
-For example, presenter and encoder logic already assume that certain pre-normalized variants such as `Rom` and `Disc` should no longer appear after normalization, and treat them as unreachable.
-
-This means the current type boundary is broader than the real stage contract.
+Presenter and encoder logic had to assume that certain pre-normalized variants such as `Rom` and `Disc` should no longer appear after normalization, which made the type boundary broader than the real stage contract.
 
 ### D-005 Decision
 
-Retromount will introduce an explicit type separation between decoded content and normalized content.
+Retromount now uses an explicit type separation between decoded content and normalized content.
 
-- **Decoded content** will represent the direct output of the decode stage
-- **Normalized content** will represent the semantic output of the normalize stage
-- presentation and encoding stages will consume only normalized content
-- pre-normalized variants will no longer be representable at post-normalization stage boundaries
+- **Decoded content** represents the direct output of the decode stage
+- **Normalized content** represents the semantic output of the normalize stage
+- presentation and encoding stages consume only normalized content
+- pre-normalized variants are no longer representable at post-normalization stage boundaries
 
 This makes the decode → normalize → present pipeline contract explicit in the type model.
 
-### D-005 Intended Model Shape
+### D-005 Implemented Model Shape
 
-The model will be split into two stage-aligned layers:
+The model is now split into two stage-aligned layers:
 
 - a decoded content model for artifacts discovered and interpreted from input sources
 - a normalized content model for semantic entities that are valid after normalization
 
-At minimum, this means:
+In practice:
 
 - ROM and disc artifacts belong to the decoded model
 - game-level semantic entities belong to the normalized model
-- presenter and encoder interfaces will be narrowed to consume normalized content only
-
-The exact type names and module layout may be refined during implementation, but the stage boundary itself must be explicit.
+- presenter and encoder interfaces consume normalized content only
 
 ### D-005 Rationale
 
@@ -383,15 +379,15 @@ This aligns with the architectural direction established by earlier review work:
 - D-002 clarified orchestration boundaries
 - D-003 clarified presenter vs encoder responsibilities
 - D-004 clarified semantic vs presentation boundaries
-- D-005 clarifies decode vs normalize boundaries
+- D-005 clarified decode vs normalize boundaries
 
 ### D-005 Consequences
 
-- decode will no longer produce the same top-level model used after normalization
-- normalization will become an explicit transformation between two model families
-- presenter and encoder APIs will need to change to consume normalized content only
-- some tests and helper code will need to be updated to reflect the new stage-aligned types
-- plugin/extensibility boundaries will become clearer and safer
+- decode no longer produces the same top-level model used after normalization
+- normalization is now an explicit transformation between two model families
+- presenter and encoder APIs consume normalized content only
+- the legacy `Content` abstraction has been removed
+- plugin/extensibility boundaries are clearer and safer
 
 ### D-005 Alternatives considered
 
@@ -406,8 +402,12 @@ This aligns with the architectural direction established by earlier review work:
 
 ### D-005 Notes
 
-This decision intentionally favors architectural clarity over minimal short-term churn.
+This decision has been fully implemented.
 
-The goal is not to redesign the pipeline, but to align the type model with the stage boundaries that already exist in practice.
+The pipeline is now explicitly layered as:
 
-See boundaries.md for the detailed model shape and pipeline contracts.
+- decoded content
+- normalized content
+- presented/encoded output
+
+See `boundaries.md` for the detailed model shape and pipeline contracts.

--- a/docs/architecture/review-findings.md
+++ b/docs/architecture/review-findings.md
@@ -85,19 +85,15 @@ This duality introduced ambiguity about the canonical execution model.
 
 ### F-002 Evidence
 
-- `main.rs` uses `engine::loader::Loader` in configured runtime execution
-- `Loader` orchestrates discovery through `InputRegistry` and returns either:
-  - `Vec<VirtualFile>` via `discover_path()`, or
-  - `GameImage` via `load_game_image()`
 - `engine::pipeline` orchestrates the Phase 3 semantic flow:
   - `InputSource`
   - `InputIdentifier`
   - `InputDecoder`
-  - `normalize_content()`
+  - `normalize_decoded_content()`
   - `OutputPresenter`
   - `VfsDirectory`
 - `engine::preview` and `engine::inspect` use the pipeline path rather than `Loader`
-- the two paths operate over different intermediate models (`VirtualFile` / `GameImage` vs `Content` / `VfsDirectory`)
+- the two paths operate over different intermediate models (`VirtualFile` / `GameImage` vs decoded/normalized pipeline models and `VfsDirectory`)
 
 ### F-002 Why it matters
 
@@ -210,34 +206,35 @@ The normalized core model now carries semantic information only.
 
 ## F-005: The boundary between decoded content and normalized playable content needs clarification
 
-**Status:** Open  
+**Status:** Resolved  
 **Issue:** [#53](https://github.com/lloydsmart/retromount/issues/53)  
+**Resolved by:** D-005
 
 ### F-005 Context
 
-Retromount currently uses `Content` to represent both decoded input artifacts and normalized semantic output.
+Retromount previously used a single `Content` model to represent both decoded input artifacts and normalized semantic output.
 
-This means the same top-level model family spans multiple stages of the pipeline:
+This meant the same top-level model family spanned multiple stages of the pipeline:
 
-- decode produces `Content`
-- normalize consumes and transforms `Content`
-- present consumes normalized `Content`
+- decode produced `Content`
+- normalize consumed and transformed `Content`
+- present consumed normalized `Content`
 
-While this is workable, it creates ambiguity about whether all `Content` values are equally valid at every post-decode stage.
+While workable, this created ambiguity about whether all `Content` values were equally valid at every post-decode stage.
 
-In particular, some variants represent pre-normalized artifacts (`Rom`, `Disc`, `Bytes`, `Text`), while others represent normalized semantic entities (`Game`).
+In particular, some variants represented pre-normalized artifacts (`Rom`, `Disc`, `Bytes`, `Text`), while others represented normalized semantic entities (`Game`).
 
 ### F-005 Evidence
 
-- `InputDecoder` produces `Content`
-- `normalize_content()` consumes `Vec<Content>` and produces `Vec<Content>`
-- `GenericPresenter` assumes it should only receive normalized playable content and treats `Content::Rom` / `Content::Disc` as unreachable
-- `BasicEncoder` similarly treats `Content::Rom` / `Content::Disc` as unreachable in presentation-time encoding
-- parts of the pipeline rely on convention rather than type-level distinction to know whether content is decoded or normalized
+- `InputDecoder` previously produced `Content`
+- `normalize_content()` previously consumed `Vec<Content>` and produced `Vec<Content>`
+- `GenericPresenter` previously assumed it should only receive normalized playable content and treated `Content::Rom` / `Content::Disc` as unreachable
+- `BasicEncoder` similarly treated `Content::Rom` / `Content::Disc` as unreachable in presentation-time encoding
+- parts of the pipeline relied on convention rather than type-level distinction to know whether content was decoded or normalized
 
 ### F-005 Why it matters
 
-This weakens the stage boundary between decode and normalize.
+This weakened the stage boundary between decode and normalize.
 
 If decoded content and normalized content share the same broad model without clearer separation, then:
 
@@ -255,6 +252,13 @@ If decoded content and normalized content share the same broad model without cle
 
 ### F-005 Decision
 
-TBD
+Resolved by D-005.
 
-Current evidence suggests the strongest resolution is to introduce an explicit type separation between decoded content and normalized content, rather than relying on a single `Content` model across both stages.
+Retromount now uses an explicit type separation between decoded content and normalized content:
+
+- decode produces `DecodedContent`
+- normalize consumes `DecodedContent` and produces `NormalizedContent`
+- present consumes `NormalizedContent`
+- encode consumes `NormalizedContent`
+
+This makes the decode → normalize → present pipeline contract explicit in the type model and removes impossible pre-normalized variants from post-normalization stage boundaries.

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -5,15 +5,6 @@ use std::sync::Arc;
 use crate::core::source::SourceRef;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub enum ContentKind {
-    Bytes,
-    Rom,
-    Disc,
-    Game,
-    Text,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum DecodedContentKind {
     Bytes,
     Rom,
@@ -63,59 +54,6 @@ impl ContentId {
 impl fmt::Display for ContentId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-/// Transitional model retained while D-005 is implemented incrementally.
-///
-/// This will be removed once decode/normalize/present stages are fully migrated
-/// onto `DecodedContent` and `NormalizedContent`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub enum Content {
-    Bytes(BytesContent),
-    Rom(RomContent),
-    Disc(DiscContent),
-    Game(GameContent),
-    Text(TextContent),
-}
-
-impl Content {
-    pub fn kind(&self) -> ContentKind {
-        match self {
-            Self::Bytes(_) => ContentKind::Bytes,
-            Self::Rom(_) => ContentKind::Rom,
-            Self::Disc(_) => ContentKind::Disc,
-            Self::Game(_) => ContentKind::Game,
-            Self::Text(_) => ContentKind::Text,
-        }
-    }
-
-    pub fn id(&self) -> &ContentId {
-        match self {
-            Self::Bytes(v) => &v.id,
-            Self::Rom(v) => &v.id,
-            Self::Disc(v) => &v.id,
-            Self::Game(v) => &v.id,
-            Self::Text(v) => &v.id,
-        }
-    }
-
-    pub fn source(&self) -> &SourceRef {
-        match self {
-            Self::Bytes(v) => &v.source,
-            Self::Rom(v) => &v.source,
-            Self::Disc(v) => &v.source,
-            Self::Game(v) => &v.source,
-            Self::Text(v) => &v.source,
-        }
-    }
-
-    pub fn consumed_sources(&self) -> &[SourceRef] {
-        match self {
-            Self::Disc(v) => &v.consumed_sources,
-            Self::Game(v) => &v.consumed_sources,
-            _ => &[],
-        }
     }
 }
 
@@ -211,22 +149,6 @@ pub struct BytesContent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct RomContent {
-    pub id: ContentId,
-    pub source: SourceRef,
-    pub size: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DiscContent {
-    pub id: ContentId,
-    pub source: SourceRef,
-    pub title: String,
-    pub disc_number: u32,
-    pub consumed_sources: Vec<SourceRef>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DecodedRomContent {
     pub id: ContentId,
     pub source: SourceRef,
@@ -278,95 +200,10 @@ pub struct TextContent {
     pub size: u64,
 }
 
-impl From<RomContent> for DecodedRomContent {
-    fn from(value: RomContent) -> Self {
-        Self {
-            id: value.id,
-            source: value.source,
-            size: value.size,
-        }
-    }
-}
-
-impl From<DiscContent> for DecodedDiscContent {
-    fn from(value: DiscContent) -> Self {
-        Self {
-            id: value.id,
-            source: value.source,
-            title: value.title,
-            disc_number: value.disc_number,
-            consumed_sources: value.consumed_sources,
-        }
-    }
-}
-
-impl From<DecodedRomContent> for RomContent {
-    fn from(value: DecodedRomContent) -> Self {
-        Self {
-            id: value.id,
-            source: value.source,
-            size: value.size,
-        }
-    }
-}
-
-impl From<DecodedDiscContent> for DiscContent {
-    fn from(value: DecodedDiscContent) -> Self {
-        Self {
-            id: value.id,
-            source: value.source,
-            title: value.title,
-            disc_number: value.disc_number,
-            consumed_sources: value.consumed_sources,
-        }
-    }
-}
-
-impl From<Content> for DecodedContent {
-    fn from(value: Content) -> Self {
-        match value {
-            Content::Bytes(v) => Self::Bytes(v),
-            Content::Rom(v) => Self::Rom(v.into()),
-            Content::Disc(v) => Self::Disc(v.into()),
-            Content::Text(v) => Self::Text(v),
-            Content::Game(_) => {
-                panic!("cannot convert normalized game content into DecodedContent")
-            }
-        }
-    }
-}
-
-impl TryFrom<Content> for NormalizedContent {
-    type Error = &'static str;
-
-    fn try_from(value: Content) -> Result<Self, Self::Error> {
-        match value {
-            Content::Bytes(v) => Ok(Self::Bytes(v)),
-            Content::Game(v) => Ok(Self::Game(v)),
-            Content::Text(v) => Ok(Self::Text(v)),
-            Content::Rom(_) | Content::Disc(_) => {
-                Err("pre-normalized content cannot be converted into NormalizedContent")
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::core::source::SourceRef;
-
-    #[test]
-    fn returns_content_kind() {
-        let content = Content::Rom(RomContent {
-            id: ContentId::new("game"),
-            source: SourceRef::new("src:game"),
-            size: 123,
-        });
-
-        assert_eq!(content.kind(), ContentKind::Rom);
-        assert_eq!(content.id().to_string(), "game");
-    }
 
     #[test]
     fn returns_decoded_content_kind() {
@@ -397,53 +234,6 @@ mod tests {
         assert_eq!(content.kind(), NormalizedContentKind::Game);
         assert_eq!(content.id().to_string(), "game");
         assert_eq!(content.source().to_string(), "file:/roms/game.sfc");
-    }
-
-    #[test]
-    fn returns_source_and_consumed_sources() {
-        let content = Content::Disc(DiscContent {
-            id: ContentId::new("game"),
-            source: SourceRef::new("cue:/roms/game.cue"),
-            title: "game".to_string(),
-            disc_number: 1,
-            consumed_sources: vec![SourceRef::new("cue:/roms/game.bin")],
-        });
-
-        assert_eq!(content.source().to_string(), "cue:/roms/game.cue");
-        assert_eq!(content.consumed_sources().len(), 1);
-        assert_eq!(
-            content.consumed_sources()[0].to_string(),
-            "cue:/roms/game.bin"
-        );
-    }
-
-    #[test]
-    fn converts_legacy_rom_content_to_decoded_rom_content() {
-        let decoded = DecodedContent::from(Content::Rom(RomContent {
-            id: ContentId::new("sonic"),
-            source: SourceRef::new("file:/roms/sonic.bin"),
-            size: 1024,
-        }));
-
-        match decoded {
-            DecodedContent::Rom(rom) => {
-                assert_eq!(rom.id.to_string(), "sonic");
-                assert_eq!(rom.source.to_string(), "file:/roms/sonic.bin");
-                assert_eq!(rom.size, 1024);
-            }
-            other => panic!("expected decoded rom content, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn rejects_pre_normalized_content_as_normalized_content() {
-        let result = NormalizedContent::try_from(Content::Rom(RomContent {
-            id: ContentId::new("sonic"),
-            source: SourceRef::new("file:/roms/sonic.bin"),
-            size: 1024,
-        }));
-
-        assert!(result.is_err());
     }
 
     #[test]

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -14,6 +14,21 @@ pub enum ContentKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum DecodedContentKind {
+    Bytes,
+    Rom,
+    Disc,
+    Text,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum NormalizedContentKind {
+    Bytes,
+    Game,
+    Text,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum Platform {
     Snes,
     Ps1,
@@ -51,6 +66,10 @@ impl fmt::Display for ContentId {
     }
 }
 
+/// Transitional model retained while D-005 is implemented incrementally.
+///
+/// This will be removed once decode/normalize/present stages are fully migrated
+/// onto `DecodedContent` and `NormalizedContent`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum Content {
     Bytes(BytesContent),
@@ -101,6 +120,90 @@ impl Content {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum DecodedContent {
+    Bytes(BytesContent),
+    Rom(DecodedRomContent),
+    Disc(DecodedDiscContent),
+    Text(TextContent),
+}
+
+impl DecodedContent {
+    pub fn kind(&self) -> DecodedContentKind {
+        match self {
+            Self::Bytes(_) => DecodedContentKind::Bytes,
+            Self::Rom(_) => DecodedContentKind::Rom,
+            Self::Disc(_) => DecodedContentKind::Disc,
+            Self::Text(_) => DecodedContentKind::Text,
+        }
+    }
+
+    pub fn id(&self) -> &ContentId {
+        match self {
+            Self::Bytes(v) => &v.id,
+            Self::Rom(v) => &v.id,
+            Self::Disc(v) => &v.id,
+            Self::Text(v) => &v.id,
+        }
+    }
+
+    pub fn source(&self) -> &SourceRef {
+        match self {
+            Self::Bytes(v) => &v.source,
+            Self::Rom(v) => &v.source,
+            Self::Disc(v) => &v.source,
+            Self::Text(v) => &v.source,
+        }
+    }
+
+    pub fn consumed_sources(&self) -> &[SourceRef] {
+        match self {
+            Self::Disc(v) => &v.consumed_sources,
+            _ => &[],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum NormalizedContent {
+    Bytes(BytesContent),
+    Game(GameContent),
+    Text(TextContent),
+}
+
+impl NormalizedContent {
+    pub fn kind(&self) -> NormalizedContentKind {
+        match self {
+            Self::Bytes(_) => NormalizedContentKind::Bytes,
+            Self::Game(_) => NormalizedContentKind::Game,
+            Self::Text(_) => NormalizedContentKind::Text,
+        }
+    }
+
+    pub fn id(&self) -> &ContentId {
+        match self {
+            Self::Bytes(v) => &v.id,
+            Self::Game(v) => &v.id,
+            Self::Text(v) => &v.id,
+        }
+    }
+
+    pub fn source(&self) -> &SourceRef {
+        match self {
+            Self::Bytes(v) => &v.source,
+            Self::Game(v) => &v.source,
+            Self::Text(v) => &v.source,
+        }
+    }
+
+    pub fn consumed_sources(&self) -> &[SourceRef] {
+        match self {
+            Self::Game(v) => &v.consumed_sources,
+            _ => &[],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BytesContent {
     pub id: ContentId,
     pub source: SourceRef,
@@ -116,6 +219,22 @@ pub struct RomContent {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DiscContent {
+    pub id: ContentId,
+    pub source: SourceRef,
+    pub title: String,
+    pub disc_number: u32,
+    pub consumed_sources: Vec<SourceRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DecodedRomContent {
+    pub id: ContentId,
+    pub source: SourceRef,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DecodedDiscContent {
     pub id: ContentId,
     pub source: SourceRef,
     pub title: String,
@@ -159,6 +278,79 @@ pub struct TextContent {
     pub size: u64,
 }
 
+impl From<RomContent> for DecodedRomContent {
+    fn from(value: RomContent) -> Self {
+        Self {
+            id: value.id,
+            source: value.source,
+            size: value.size,
+        }
+    }
+}
+
+impl From<DiscContent> for DecodedDiscContent {
+    fn from(value: DiscContent) -> Self {
+        Self {
+            id: value.id,
+            source: value.source,
+            title: value.title,
+            disc_number: value.disc_number,
+            consumed_sources: value.consumed_sources,
+        }
+    }
+}
+
+impl From<DecodedRomContent> for RomContent {
+    fn from(value: DecodedRomContent) -> Self {
+        Self {
+            id: value.id,
+            source: value.source,
+            size: value.size,
+        }
+    }
+}
+
+impl From<DecodedDiscContent> for DiscContent {
+    fn from(value: DecodedDiscContent) -> Self {
+        Self {
+            id: value.id,
+            source: value.source,
+            title: value.title,
+            disc_number: value.disc_number,
+            consumed_sources: value.consumed_sources,
+        }
+    }
+}
+
+impl From<Content> for DecodedContent {
+    fn from(value: Content) -> Self {
+        match value {
+            Content::Bytes(v) => Self::Bytes(v),
+            Content::Rom(v) => Self::Rom(v.into()),
+            Content::Disc(v) => Self::Disc(v.into()),
+            Content::Text(v) => Self::Text(v),
+            Content::Game(_) => {
+                panic!("cannot convert normalized game content into DecodedContent")
+            }
+        }
+    }
+}
+
+impl TryFrom<Content> for NormalizedContent {
+    type Error = &'static str;
+
+    fn try_from(value: Content) -> Result<Self, Self::Error> {
+        match value {
+            Content::Bytes(v) => Ok(Self::Bytes(v)),
+            Content::Game(v) => Ok(Self::Game(v)),
+            Content::Text(v) => Ok(Self::Text(v)),
+            Content::Rom(_) | Content::Disc(_) => {
+                Err("pre-normalized content cannot be converted into NormalizedContent")
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,8 +369,20 @@ mod tests {
     }
 
     #[test]
-    fn returns_game_content_kind() {
-        let content = Content::Game(GameContent {
+    fn returns_decoded_content_kind() {
+        let content = DecodedContent::Rom(DecodedRomContent {
+            id: ContentId::new("game"),
+            source: SourceRef::new("src:game"),
+            size: 123,
+        });
+
+        assert_eq!(content.kind(), DecodedContentKind::Rom);
+        assert_eq!(content.id().to_string(), "game");
+    }
+
+    #[test]
+    fn returns_normalized_content_kind() {
+        let content = NormalizedContent::Game(GameContent {
             id: ContentId::new("game"),
             source: SourceRef::new("file:/roms/game.sfc"),
             title: "game".to_string(),
@@ -190,7 +394,7 @@ mod tests {
             consumed_sources: vec![],
         });
 
-        assert_eq!(content.kind(), ContentKind::Game);
+        assert_eq!(content.kind(), NormalizedContentKind::Game);
         assert_eq!(content.id().to_string(), "game");
         assert_eq!(content.source().to_string(), "file:/roms/game.sfc");
     }
@@ -214,25 +418,32 @@ mod tests {
     }
 
     #[test]
-    fn returns_game_consumed_sources() {
-        let content = Content::Game(GameContent {
-            id: ContentId::new("ff7"),
-            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
-            title: "Final Fantasy VII".to_string(),
-            platform: Platform::Ps1,
-            parts: vec![GamePart::Disc(DiscPart {
-                source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
-                disc_number: 1,
-                consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
-            })],
-            consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
-        });
+    fn converts_legacy_rom_content_to_decoded_rom_content() {
+        let decoded = DecodedContent::from(Content::Rom(RomContent {
+            id: ContentId::new("sonic"),
+            source: SourceRef::new("file:/roms/sonic.bin"),
+            size: 1024,
+        }));
 
-        assert_eq!(content.consumed_sources().len(), 1);
-        assert_eq!(
-            content.consumed_sources()[0].to_string(),
-            "cue:/roms/ff7-disc1.bin"
-        );
+        match decoded {
+            DecodedContent::Rom(rom) => {
+                assert_eq!(rom.id.to_string(), "sonic");
+                assert_eq!(rom.source.to_string(), "file:/roms/sonic.bin");
+                assert_eq!(rom.size, 1024);
+            }
+            other => panic!("expected decoded rom content, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_pre_normalized_content_as_normalized_content() {
+        let result = NormalizedContent::try_from(Content::Rom(RomContent {
+            id: ContentId::new("sonic"),
+            source: SourceRef::new("file:/roms/sonic.bin"),
+            size: 1024,
+        }));
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -23,7 +23,16 @@ enum PendingOutput {
     DiscGroup(DiscGroupKey),
 }
 
-pub fn normalize_content(
+/// Transforms decoded content into normalized domain models.
+///
+/// This is the canonical boundary between decoding and presentation.
+///
+/// - Input: `DecodedContent`
+/// - Output: `NormalizedContent`
+///
+/// All grouping, classification, and semantic enrichment happens here.
+/// Downstream stages must not depend on decoder-specific details.
+pub(crate) fn normalize_decoded_content(
     contents: Vec<DecodedContent>,
     options: &NormalizationOptions,
 ) -> Vec<NormalizedContent> {
@@ -256,7 +265,7 @@ mod tests {
 
     #[test]
     fn normalizes_rom_to_game() {
-        let normalized = normalize_content(
+        let normalized = normalize_decoded_content(
             vec![DecodedContent::Rom(DecodedRomContent {
                 id: ContentId::new("smw"),
                 source: SourceRef::new("file:/roms/Super Mario World.sfc"),
@@ -286,7 +295,7 @@ mod tests {
 
     #[test]
     fn groups_discs_into_single_game() {
-        let normalized = normalize_content(
+        let normalized = normalize_decoded_content(
             vec![
                 DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("ps1/ff7-disc2"),
@@ -330,7 +339,7 @@ mod tests {
 
     #[test]
     fn suppresses_roms_consumed_by_discs() {
-        let normalized = normalize_content(
+        let normalized = normalize_decoded_content(
             vec![
                 DecodedContent::Rom(DecodedRomContent {
                     id: ContentId::new("discs/ps1_multi/game_disc1.bin"),
@@ -368,7 +377,7 @@ mod tests {
 
     #[test]
     fn does_not_merge_same_title_from_different_directories() {
-        let normalized = normalize_content(
+        let normalized = normalize_decoded_content(
             vec![
                 DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("ps1_multi/game_disc1.cue"),
@@ -393,7 +402,7 @@ mod tests {
 
     #[test]
     fn derives_rom_game_title_from_source_leaf_name() {
-        let normalized = normalize_content(
+        let normalized = normalize_decoded_content(
             vec![DecodedContent::Rom(DecodedRomContent {
                 id: ContentId::new("roms/snes/Super Mario World.sfc"),
                 source: SourceRef::new("file:/roms/snes/Super Mario World.sfc"),

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core::content::{
-    BytesContent, ContentId, DecodedContent, DecodedDiscContent, DecodedRomContent, DiscPart,
-    GameContent, GamePart, NormalizedContent, Platform, RomPart, TextContent,
+    ContentId, DecodedContent, DecodedDiscContent, DiscPart, GameContent, GamePart,
+    NormalizedContent, Platform, RomPart,
 };
 use crate::core::source::SourceRef;
 
@@ -250,7 +250,7 @@ mod tests {
     use super::*;
     use crate::core::content::{
         ContentId, DecodedContent, DecodedContentKind, DecodedDiscContent, DecodedRomContent,
-        GamePart, NormalizedContent, NormalizedContentKind,
+        GamePart, NormalizedContent, NormalizedContentKind, TextContent,
     };
     use crate::core::source::SourceRef;
 

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::core::content::{
     BytesContent, ContentId, DecodedContent, DecodedDiscContent, DecodedRomContent, DiscPart,
-    GameContent, GamePart, NormalizedContent, Platform, TextContent, RomPart,
+    GameContent, GamePart, NormalizedContent, Platform, RomPart, TextContent,
 };
 use crate::core::source::SourceRef;
 
@@ -39,20 +39,22 @@ pub fn normalize_content(
                     continue;
                 }
 
-                pending.push(PendingOutput::Direct(NormalizedContent::Game(GameContent {
-                    id: rom.id.clone(),
-                    source: rom.source.clone(),
-                    title: leaf_stem_from_source(&rom.source),
-                    platform: options
-                        .platform_hint
-                        .clone()
-                        .unwrap_or_else(|| derive_platform_from_source(&rom.source)),
-                    parts: vec![GamePart::Rom(RomPart {
-                        source: rom.source,
-                        size: rom.size,
-                    })],
-                    consumed_sources: vec![],
-                })));
+                pending.push(PendingOutput::Direct(NormalizedContent::Game(
+                    GameContent {
+                        id: rom.id.clone(),
+                        source: rom.source.clone(),
+                        title: leaf_stem_from_source(&rom.source),
+                        platform: options
+                            .platform_hint
+                            .clone()
+                            .unwrap_or_else(|| derive_platform_from_source(&rom.source)),
+                        parts: vec![GamePart::Rom(RomPart {
+                            source: rom.source,
+                            size: rom.size,
+                        })],
+                        consumed_sources: vec![],
+                    },
+                )));
             }
             DecodedContent::Disc(disc) => {
                 let key = disc_group_key(&disc);

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core::content::{
-    Content, ContentId, DiscContent, DiscPart, GameContent, GamePart, Platform, RomPart,
+    BytesContent, ContentId, DecodedContent, DecodedDiscContent, DecodedRomContent, DiscPart,
+    GameContent, GamePart, NormalizedContent, Platform, TextContent, RomPart,
 };
 use crate::core::source::SourceRef;
 
@@ -18,24 +19,27 @@ pub struct NormalizationOptions {
 
 #[derive(Debug, Clone)]
 enum PendingOutput {
-    Direct(Content),
+    Direct(NormalizedContent),
     DiscGroup(DiscGroupKey),
 }
 
-pub fn normalize_content(contents: Vec<Content>, options: &NormalizationOptions) -> Vec<Content> {
+pub fn normalize_content(
+    contents: Vec<DecodedContent>,
+    options: &NormalizationOptions,
+) -> Vec<NormalizedContent> {
     let consumed_by_discs = consumed_rom_sources(&contents);
 
     let mut pending = Vec::new();
-    let mut disc_groups: HashMap<DiscGroupKey, Vec<DiscContent>> = HashMap::new();
+    let mut disc_groups: HashMap<DiscGroupKey, Vec<DecodedDiscContent>> = HashMap::new();
 
     for content in contents {
         match content {
-            Content::Rom(rom) => {
+            DecodedContent::Rom(rom) => {
                 if consumed_by_discs.contains(&rom.source) {
                     continue;
                 }
 
-                pending.push(PendingOutput::Direct(Content::Game(GameContent {
+                pending.push(PendingOutput::Direct(NormalizedContent::Game(GameContent {
                     id: rom.id.clone(),
                     source: rom.source.clone(),
                     title: leaf_stem_from_source(&rom.source),
@@ -50,7 +54,7 @@ pub fn normalize_content(contents: Vec<Content>, options: &NormalizationOptions)
                     consumed_sources: vec![],
                 })));
             }
-            Content::Disc(disc) => {
+            DecodedContent::Disc(disc) => {
                 let key = disc_group_key(&disc);
 
                 if !disc_groups.contains_key(&key) {
@@ -59,7 +63,12 @@ pub fn normalize_content(contents: Vec<Content>, options: &NormalizationOptions)
 
                 disc_groups.entry(key).or_default().push(disc);
             }
-            other => pending.push(PendingOutput::Direct(other)),
+            DecodedContent::Bytes(bytes) => {
+                pending.push(PendingOutput::Direct(NormalizedContent::Bytes(bytes)));
+            }
+            DecodedContent::Text(text) => {
+                pending.push(PendingOutput::Direct(NormalizedContent::Text(text)));
+            }
         }
     }
 
@@ -70,7 +79,9 @@ pub fn normalize_content(contents: Vec<Content>, options: &NormalizationOptions)
             PendingOutput::Direct(content) => normalized.push(content),
             PendingOutput::DiscGroup(key) => {
                 if let Some(discs) = disc_groups.remove(&key) {
-                    normalized.push(Content::Game(normalize_disc_group(&key, discs, options)));
+                    normalized.push(NormalizedContent::Game(normalize_disc_group(
+                        &key, discs, options,
+                    )));
                 }
             }
         }
@@ -79,11 +90,11 @@ pub fn normalize_content(contents: Vec<Content>, options: &NormalizationOptions)
     normalized
 }
 
-fn consumed_rom_sources(contents: &[Content]) -> HashSet<SourceRef> {
+fn consumed_rom_sources(contents: &[DecodedContent]) -> HashSet<SourceRef> {
     contents
         .iter()
         .filter_map(|content| match content {
-            Content::Disc(disc) => Some(disc),
+            DecodedContent::Disc(disc) => Some(disc),
             _ => None,
         })
         .flat_map(|disc| disc.consumed_sources.iter().cloned())
@@ -156,7 +167,7 @@ fn platform_from_extension(path: &str) -> Platform {
 
 fn normalize_disc_group(
     key: &DiscGroupKey,
-    mut discs: Vec<DiscContent>,
+    mut discs: Vec<DecodedDiscContent>,
     options: &NormalizationOptions,
 ) -> GameContent {
     discs.sort_by(|left, right| {
@@ -198,7 +209,7 @@ fn normalize_disc_group(
     }
 }
 
-fn disc_group_key(content: &DiscContent) -> DiscGroupKey {
+fn disc_group_key(content: &DecodedDiscContent) -> DiscGroupKey {
     DiscGroupKey {
         parent: logical_parent_path(content.id.0.as_ref()),
         title: content.title.clone(),
@@ -235,13 +246,16 @@ fn leaf_stem(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::content::{Content, ContentId, DiscContent, GamePart, RomContent};
+    use crate::core::content::{
+        ContentId, DecodedContent, DecodedContentKind, DecodedDiscContent, DecodedRomContent,
+        GamePart, NormalizedContent, NormalizedContentKind,
+    };
     use crate::core::source::SourceRef;
 
     #[test]
     fn normalizes_rom_to_game() {
         let normalized = normalize_content(
-            vec![Content::Rom(RomContent {
+            vec![DecodedContent::Rom(DecodedRomContent {
                 id: ContentId::new("smw"),
                 source: SourceRef::new("file:/roms/Super Mario World.sfc"),
                 size: 4096,
@@ -252,7 +266,7 @@ mod tests {
         assert_eq!(normalized.len(), 1);
 
         let game = match &normalized[0] {
-            Content::Game(game) => game,
+            NormalizedContent::Game(game) => game,
             other => panic!("expected game, got {other:?}"),
         };
 
@@ -272,14 +286,14 @@ mod tests {
     fn groups_discs_into_single_game() {
         let normalized = normalize_content(
             vec![
-                Content::Disc(DiscContent {
+                DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("ps1/ff7-disc2"),
                     source: SourceRef::new("cue:/roms/ps1/ff7-disc2.cue"),
                     title: "Final Fantasy VII".to_string(),
                     disc_number: 2,
                     consumed_sources: vec![SourceRef::new("cue:/roms/ps1/ff7-disc2.bin")],
                 }),
-                Content::Disc(DiscContent {
+                DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("ps1/ff7-disc1"),
                     source: SourceRef::new("cue:/roms/ps1/ff7-disc1.cue"),
                     title: "Final Fantasy VII".to_string(),
@@ -293,7 +307,7 @@ mod tests {
         assert_eq!(normalized.len(), 1);
 
         let game = match &normalized[0] {
-            Content::Game(game) => game,
+            NormalizedContent::Game(game) => game,
             other => panic!("expected game, got {other:?}"),
         };
 
@@ -316,12 +330,12 @@ mod tests {
     fn suppresses_roms_consumed_by_discs() {
         let normalized = normalize_content(
             vec![
-                Content::Rom(RomContent {
+                DecodedContent::Rom(DecodedRomContent {
                     id: ContentId::new("discs/ps1_multi/game_disc1.bin"),
                     source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.bin"),
                     size: 6,
                 }),
-                Content::Disc(DiscContent {
+                DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("discs/ps1_multi/game_disc1.cue"),
                     source: SourceRef::new("file:/roms/discs/ps1_multi/game_disc1.cue"),
                     title: "game".to_string(),
@@ -337,7 +351,7 @@ mod tests {
         assert_eq!(normalized.len(), 1);
 
         let game = match &normalized[0] {
-            Content::Game(game) => game,
+            NormalizedContent::Game(game) => game,
             other => panic!("expected game, got {other:?}"),
         };
 
@@ -354,14 +368,14 @@ mod tests {
     fn does_not_merge_same_title_from_different_directories() {
         let normalized = normalize_content(
             vec![
-                Content::Disc(DiscContent {
+                DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("ps1_multi/game_disc1.cue"),
                     source: SourceRef::new("file:/roms/ps1_multi/game_disc1.cue"),
                     title: "game".to_string(),
                     disc_number: 1,
                     consumed_sources: vec![SourceRef::new("file:/roms/ps1_multi/game_disc1.bin")],
                 }),
-                Content::Disc(DiscContent {
+                DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("ps1_single/game.cue"),
                     source: SourceRef::new("file:/roms/ps1_single/game.cue"),
                     title: "game".to_string(),
@@ -378,7 +392,7 @@ mod tests {
     #[test]
     fn derives_rom_game_title_from_source_leaf_name() {
         let normalized = normalize_content(
-            vec![Content::Rom(RomContent {
+            vec![DecodedContent::Rom(DecodedRomContent {
                 id: ContentId::new("roms/snes/Super Mario World.sfc"),
                 source: SourceRef::new("file:/roms/snes/Super Mario World.sfc"),
                 size: 4096,
@@ -387,7 +401,7 @@ mod tests {
         );
 
         let game = match &normalized[0] {
-            Content::Game(game) => game,
+            NormalizedContent::Game(game) => game,
             other => panic!("expected game, got {other:?}"),
         };
 
@@ -421,5 +435,27 @@ mod tests {
         let source =
             SourceRef::new("zip:/roms/collection.zip#roms/megadrive/Sonic the Hedgehog.bin");
         assert_eq!(derive_platform_from_source(&source), Platform::Megadrive);
+    }
+
+    #[test]
+    fn returns_expected_decoded_content_kind() {
+        let content = DecodedContent::Rom(DecodedRomContent {
+            id: ContentId::new("sonic"),
+            source: SourceRef::new("file:/roms/sonic.bin"),
+            size: 1024,
+        });
+
+        assert_eq!(content.kind(), DecodedContentKind::Rom);
+    }
+
+    #[test]
+    fn returns_expected_normalized_content_kind() {
+        let content = NormalizedContent::Text(TextContent {
+            id: ContentId::new("readme"),
+            source: SourceRef::new("file:/roms/readme.txt"),
+            size: 10,
+        });
+
+        assert_eq!(content.kind(), NormalizedContentKind::Text);
     }
 }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 use std::path::Path;
 
-use crate::core::content::{Content, DecodedContent, GamePart};
+use crate::core::content::{DecodedContent, GamePart, NormalizedContent};
 use crate::error::RetromountError;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
@@ -75,7 +75,7 @@ pub fn write_inspect_report<W: Write>(
     } else {
         for content in &trace.normalized {
             writeln!(writer, "  - {:?}", content.kind())?;
-            write_content_summary(writer, content)?;
+            write_normalized_content_summary(writer, content)?;
         }
     }
 
@@ -86,29 +86,18 @@ pub fn write_inspect_report<W: Write>(
     Ok(())
 }
 
-fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Result<()> {
+fn write_normalized_content_summary<W: Write>(
+    writer: &mut W,
+    content: &NormalizedContent,
+) -> io::Result<()> {
     match content {
-        Content::Bytes(bytes) => {
+        NormalizedContent::Bytes(bytes) => {
             writeln!(writer, "    Content: Bytes")?;
             writeln!(writer, "      ID: {}", bytes.id)?;
             writeln!(writer, "      Source: {}", bytes.source)?;
             writeln!(writer, "      Size: {}", bytes.size)?;
         }
-        Content::Rom(rom) => {
-            writeln!(writer, "    Content: Rom")?;
-            writeln!(writer, "      ID: {}", rom.id)?;
-            writeln!(writer, "      Source: {}", rom.source)?;
-            writeln!(writer, "      File name: {}", rom.source.file_name())?;
-            writeln!(writer, "      Size: {}", rom.size)?;
-        }
-        Content::Disc(disc) => {
-            writeln!(writer, "    Content: Disc")?;
-            writeln!(writer, "      ID: {}", disc.id)?;
-            writeln!(writer, "      Source: {}", disc.source)?;
-            writeln!(writer, "      Title: {}", disc.title)?;
-            writeln!(writer, "      Disc number: {}", disc.disc_number)?;
-        }
-        Content::Game(game) => {
+        NormalizedContent::Game(game) => {
             writeln!(writer, "    Content: Game")?;
             writeln!(writer, "      ID: {}", game.id)?;
             writeln!(writer, "      Source: {}", game.source)?;
@@ -132,7 +121,7 @@ fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Res
                 }
             }
         }
-        Content::Text(text) => {
+        NormalizedContent::Text(text) => {
             writeln!(writer, "    Content: Text")?;
             writeln!(writer, "      ID: {}", text.id)?;
             writeln!(writer, "      Source: {}", text.source)?;
@@ -190,7 +179,7 @@ fn yes_no(value: bool) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::content::{BytesContent, ContentId, DecodedContent};
+    use crate::core::content::{BytesContent, ContentId, DecodedContent, NormalizedContent};
     use crate::core::source::{SourceObject, SourceRef};
     use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
     use crate::engine::pipeline::TracedObject;
@@ -212,7 +201,7 @@ mod tests {
                     size: 0,
                 })],
             }],
-            normalized: vec![Content::Bytes(BytesContent {
+            normalized: vec![NormalizedContent::Bytes(BytesContent {
                 id: ContentId::new("blob.dat"),
                 source: SourceRef::new("zip:/tmp/library.zip#misc/blob.dat"),
                 size: 0,

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 use std::path::Path;
 
-use crate::core::content::{Content, GamePart};
+use crate::core::content::{Content, DecodedContent, GamePart};
 use crate::error::RetromountError;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
@@ -62,7 +62,7 @@ pub fn write_inspect_report<W: Write>(
                 writeln!(writer, "    Decoded: (none)")?;
             } else {
                 for content in &object.decoded {
-                    write_content_summary(writer, content)?;
+                    write_decoded_content_summary(writer, content)?;
                 }
             }
         }
@@ -89,27 +89,27 @@ pub fn write_inspect_report<W: Write>(
 fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Result<()> {
     match content {
         Content::Bytes(bytes) => {
-            writeln!(writer, "    Decoded: Bytes")?;
+            writeln!(writer, "    Content: Bytes")?;
             writeln!(writer, "      ID: {}", bytes.id)?;
             writeln!(writer, "      Source: {}", bytes.source)?;
             writeln!(writer, "      Size: {}", bytes.size)?;
         }
         Content::Rom(rom) => {
-            writeln!(writer, "    Decoded: Rom")?;
+            writeln!(writer, "    Content: Rom")?;
             writeln!(writer, "      ID: {}", rom.id)?;
             writeln!(writer, "      Source: {}", rom.source)?;
             writeln!(writer, "      File name: {}", rom.source.file_name())?;
             writeln!(writer, "      Size: {}", rom.size)?;
         }
         Content::Disc(disc) => {
-            writeln!(writer, "    Decoded: Disc")?;
+            writeln!(writer, "    Content: Disc")?;
             writeln!(writer, "      ID: {}", disc.id)?;
             writeln!(writer, "      Source: {}", disc.source)?;
             writeln!(writer, "      Title: {}", disc.title)?;
             writeln!(writer, "      Disc number: {}", disc.disc_number)?;
         }
         Content::Game(game) => {
-            writeln!(writer, "    Decoded: Game")?;
+            writeln!(writer, "    Content: Game")?;
             writeln!(writer, "      ID: {}", game.id)?;
             writeln!(writer, "      Source: {}", game.source)?;
             writeln!(writer, "      Title: {}", game.title)?;
@@ -133,6 +133,42 @@ fn write_content_summary<W: Write>(writer: &mut W, content: &Content) -> io::Res
             }
         }
         Content::Text(text) => {
+            writeln!(writer, "    Content: Text")?;
+            writeln!(writer, "      ID: {}", text.id)?;
+            writeln!(writer, "      Source: {}", text.source)?;
+            writeln!(writer, "      Size: {}", text.size)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_decoded_content_summary<W: Write>(
+    writer: &mut W,
+    content: &DecodedContent,
+) -> io::Result<()> {
+    match content {
+        DecodedContent::Bytes(bytes) => {
+            writeln!(writer, "    Decoded: Bytes")?;
+            writeln!(writer, "      ID: {}", bytes.id)?;
+            writeln!(writer, "      Source: {}", bytes.source)?;
+            writeln!(writer, "      Size: {}", bytes.size)?;
+        }
+        DecodedContent::Rom(rom) => {
+            writeln!(writer, "    Decoded: Rom")?;
+            writeln!(writer, "      ID: {}", rom.id)?;
+            writeln!(writer, "      Source: {}", rom.source)?;
+            writeln!(writer, "      File name: {}", rom.source.file_name())?;
+            writeln!(writer, "      Size: {}", rom.size)?;
+        }
+        DecodedContent::Disc(disc) => {
+            writeln!(writer, "    Decoded: Disc")?;
+            writeln!(writer, "      ID: {}", disc.id)?;
+            writeln!(writer, "      Source: {}", disc.source)?;
+            writeln!(writer, "      Title: {}", disc.title)?;
+            writeln!(writer, "      Disc number: {}", disc.disc_number)?;
+        }
+        DecodedContent::Text(text) => {
             writeln!(writer, "    Decoded: Text")?;
             writeln!(writer, "      ID: {}", text.id)?;
             writeln!(writer, "      Source: {}", text.source)?;
@@ -154,7 +190,7 @@ fn yes_no(value: bool) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::content::{BytesContent, ContentId};
+    use crate::core::content::{BytesContent, ContentId, DecodedContent};
     use crate::core::source::{SourceObject, SourceRef};
     use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
     use crate::engine::pipeline::TracedObject;
@@ -170,7 +206,7 @@ mod tests {
                 },
                 identity: InputIdentity::File,
                 supported: true,
-                decoded: vec![Content::Bytes(BytesContent {
+                decoded: vec![DecodedContent::Bytes(BytesContent {
                     id: ContentId::new("blob.dat"),
                     source: SourceRef::new("zip:/tmp/library.zip#misc/blob.dat"),
                     size: 0,

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::io;
 
 use crate::core::content::{DecodedContent, NormalizedContent};
-use crate::core::normalizer::{normalize_content, NormalizationOptions};
+use crate::core::normalizer::{normalize_decoded_content, NormalizationOptions};
 use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;
 use crate::input::decode::InputDecoder;
@@ -88,7 +88,7 @@ pub fn run_pipeline_with_options(
         });
     }
 
-    let normalized = normalize_content(all_decoded_content, normalization_options);
+    let normalized = normalize_decoded_content(all_decoded_content, normalization_options);
     let normalized_presentable_content = suppress_consumed_content(&normalized);
     let presented = presenter.present(&normalized_presentable_content);
 

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::io;
 
-use crate::core::content::{Content, DecodedContent};
+use crate::core::content::{DecodedContent, NormalizedContent};
 use crate::core::normalizer::{normalize_content, NormalizationOptions};
 use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;
@@ -11,10 +11,9 @@ use crate::input::source::InputSource;
 use crate::output::present::OutputPresenter;
 use serde::Serialize;
 
-#[derive(Debug, Clone, Serialize)]
 pub struct PipelineTrace {
     pub objects: Vec<TracedObject>,
-    pub normalized: Vec<Content>,
+    pub normalized: Vec<NormalizedContent>,
     pub presented: VfsDirectory,
 }
 
@@ -88,8 +87,7 @@ pub fn run_pipeline_with_options(
         });
     }
 
-    let legacy_content = decoded_content_to_legacy_content(all_decoded_content);
-    let normalized = normalize_content(legacy_content, normalization_options);
+    let normalized = normalize_content(all_decoded_content, normalization_options);
     let normalized_presentable_content = suppress_consumed_content(&normalized);
     let presented = presenter.present(&normalized_presentable_content);
 
@@ -100,19 +98,7 @@ pub fn run_pipeline_with_options(
     })
 }
 
-fn decoded_content_to_legacy_content(decoded: Vec<DecodedContent>) -> Vec<Content> {
-    decoded
-        .into_iter()
-        .map(|content| match content {
-            DecodedContent::Bytes(bytes) => Content::Bytes(bytes),
-            DecodedContent::Rom(rom) => Content::Rom(rom.into()),
-            DecodedContent::Disc(disc) => Content::Disc(disc.into()),
-            DecodedContent::Text(text) => Content::Text(text),
-        })
-        .collect()
-}
-
-fn suppress_consumed_content(all_content: &[Content]) -> Vec<Content> {
+fn suppress_consumed_content(all_content: &[NormalizedContent]) -> Vec<NormalizedContent> {
     let consumed_sources: HashSet<_> = all_content
         .iter()
         .flat_map(|content| content.consumed_sources().iter().cloned())

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -11,6 +11,7 @@ use crate::input::source::InputSource;
 use crate::output::present::OutputPresenter;
 use serde::Serialize;
 
+#[derive(Debug, Clone, Serialize)]
 pub struct PipelineTrace {
     pub objects: Vec<TracedObject>,
     pub normalized: Vec<NormalizedContent>,
@@ -116,7 +117,7 @@ mod tests {
     use super::*;
     use std::fs;
 
-    use crate::core::content::{ContentKind, DecodedContentKind};
+    use crate::core::content::{DecodedContentKind, NormalizedContentKind};
     use crate::input::basic_decoder::BasicInputDecoder;
     use crate::input::basic_identifier::BasicInputIdentifier;
     use crate::input::directory_source::DirectoryInputSource;
@@ -216,17 +217,17 @@ mod tests {
         assert!(trace.objects[1].supported);
         assert_eq!(trace.objects[1].decoded.len(), 1);
         assert_eq!(trace.objects[1].decoded[0].kind(), DecodedContentKind::Rom);
-        assert_eq!(trace.normalized[1].kind(), ContentKind::Game);
+        assert_eq!(trace.normalized[1].kind(), NormalizedContentKind::Game);
 
         assert_eq!(trace.objects[2].object.name, "readme.txt");
         assert_eq!(trace.objects[2].identity, InputIdentity::Text);
         assert!(trace.objects[2].supported);
         assert_eq!(trace.objects[2].decoded.len(), 1);
         assert_eq!(trace.objects[2].decoded[0].kind(), DecodedContentKind::Text);
-        assert_eq!(trace.normalized[2].kind(), ContentKind::Text);
+        assert_eq!(trace.normalized[2].kind(), NormalizedContentKind::Text);
 
-        assert_eq!(trace.normalized[0].kind(), ContentKind::Bytes);
-        assert_eq!(trace.normalized[1].kind(), ContentKind::Game);
-        assert_eq!(trace.normalized[2].kind(), ContentKind::Text);
+        assert_eq!(trace.normalized[0].kind(), NormalizedContentKind::Bytes);
+        assert_eq!(trace.normalized[1].kind(), NormalizedContentKind::Game);
+        assert_eq!(trace.normalized[2].kind(), NormalizedContentKind::Text);
     }
 }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::io;
 
-use crate::core::content::{Content, ContentKind, DecodedContent, DecodedContentKind};
+use crate::core::content::{Content, DecodedContent};
 use crate::core::normalizer::{normalize_content, NormalizationOptions};
 use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;
@@ -130,7 +130,7 @@ mod tests {
     use super::*;
     use std::fs;
 
-    use crate::core::content::DecodedContentKind;
+    use crate::core::content::{ContentKind, DecodedContentKind};
     use crate::input::basic_decoder::BasicInputDecoder;
     use crate::input::basic_identifier::BasicInputIdentifier;
     use crate::input::directory_source::DirectoryInputSource;

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::io;
 
-use crate::core::content::Content;
+use crate::core::content::{Content, ContentKind, DecodedContent, DecodedContentKind};
 use crate::core::normalizer::{normalize_content, NormalizationOptions};
 use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;
@@ -23,7 +23,7 @@ pub struct TracedObject {
     pub object: SourceObject,
     pub identity: InputIdentity,
     pub supported: bool,
-    pub decoded: Vec<Content>,
+    pub decoded: Vec<DecodedContent>,
 }
 
 pub fn run_pipeline(
@@ -66,7 +66,7 @@ pub fn run_pipeline_with_options(
 ) -> Result<PipelineTrace, io::Error> {
     let objects = source.enumerate()?;
     let mut traced_objects = Vec::new();
-    let mut all_content = Vec::new();
+    let mut all_decoded_content = Vec::new();
 
     for object in objects {
         let identity = identifier.identify(&object)?;
@@ -78,7 +78,7 @@ pub fn run_pipeline_with_options(
             Vec::new()
         };
 
-        all_content.extend(decoded.iter().cloned());
+        all_decoded_content.extend(decoded.iter().cloned());
 
         traced_objects.push(TracedObject {
             object,
@@ -88,7 +88,8 @@ pub fn run_pipeline_with_options(
         });
     }
 
-    let normalized = normalize_content(all_content, normalization_options);
+    let legacy_content = decoded_content_to_legacy_content(all_decoded_content);
+    let normalized = normalize_content(legacy_content, normalization_options);
     let normalized_presentable_content = suppress_consumed_content(&normalized);
     let presented = presenter.present(&normalized_presentable_content);
 
@@ -97,6 +98,18 @@ pub fn run_pipeline_with_options(
         normalized,
         presented,
     })
+}
+
+fn decoded_content_to_legacy_content(decoded: Vec<DecodedContent>) -> Vec<Content> {
+    decoded
+        .into_iter()
+        .map(|content| match content {
+            DecodedContent::Bytes(bytes) => Content::Bytes(bytes),
+            DecodedContent::Rom(rom) => Content::Rom(rom.into()),
+            DecodedContent::Disc(disc) => Content::Disc(disc.into()),
+            DecodedContent::Text(text) => Content::Text(text),
+        })
+        .collect()
 }
 
 fn suppress_consumed_content(all_content: &[Content]) -> Vec<Content> {
@@ -117,7 +130,7 @@ mod tests {
     use super::*;
     use std::fs;
 
-    use crate::core::content::ContentKind;
+    use crate::core::content::DecodedContentKind;
     use crate::input::basic_decoder::BasicInputDecoder;
     use crate::input::basic_identifier::BasicInputIdentifier;
     use crate::input::directory_source::DirectoryInputSource;
@@ -207,20 +220,23 @@ mod tests {
         assert_eq!(trace.objects[0].identity, InputIdentity::File);
         assert!(trace.objects[0].supported);
         assert_eq!(trace.objects[0].decoded.len(), 1);
-        assert_eq!(trace.objects[0].decoded[0].kind(), ContentKind::Bytes);
+        assert_eq!(
+            trace.objects[0].decoded[0].kind(),
+            DecodedContentKind::Bytes
+        );
 
         assert_eq!(trace.objects[1].object.name, "mario.sfc");
         assert_eq!(trace.objects[1].identity, InputIdentity::File);
         assert!(trace.objects[1].supported);
         assert_eq!(trace.objects[1].decoded.len(), 1);
-        assert_eq!(trace.objects[1].decoded[0].kind(), ContentKind::Rom);
+        assert_eq!(trace.objects[1].decoded[0].kind(), DecodedContentKind::Rom);
         assert_eq!(trace.normalized[1].kind(), ContentKind::Game);
 
         assert_eq!(trace.objects[2].object.name, "readme.txt");
         assert_eq!(trace.objects[2].identity, InputIdentity::Text);
         assert!(trace.objects[2].supported);
         assert_eq!(trace.objects[2].decoded.len(), 1);
-        assert_eq!(trace.objects[2].decoded[0].kind(), ContentKind::Text);
+        assert_eq!(trace.objects[2].decoded[0].kind(), DecodedContentKind::Text);
         assert_eq!(trace.normalized[2].kind(), ContentKind::Text);
 
         assert_eq!(trace.normalized[0].kind(), ContentKind::Bytes);

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::core::content::{
-    BytesContent, Content, ContentId, DiscContent, RomContent, TextContent,
+    BytesContent, ContentId, DecodedContent, DecodedDiscContent, DecodedRomContent, TextContent,
 };
 use crate::core::cue::parse_cue;
 use crate::core::reader::Reader;
@@ -37,12 +37,12 @@ impl InputDecoder for BasicInputDecoder {
         &self,
         object: &SourceObject,
         identity: &InputIdentity,
-    ) -> Result<Vec<Content>, io::Error> {
+    ) -> Result<Vec<DecodedContent>, io::Error> {
         let id = ContentId::new(object.name.clone());
         let size = content_size_for(object)?;
 
         let content = match identity {
-            InputIdentity::Text => Content::Text(TextContent {
+            InputIdentity::Text => DecodedContent::Text(TextContent {
                 id: ContentId::new(path_without_extension(&object.name)),
                 source: object.source.clone(),
                 size,
@@ -51,7 +51,7 @@ impl InputDecoder for BasicInputDecoder {
                 let raw_name = file_stem_or_name_from_object(object);
                 let (title, disc_number) = parse_disc_info_from_name(&raw_name);
 
-                Content::Disc(DiscContent {
+                DecodedContent::Disc(DecodedDiscContent {
                     id,
                     source: object.source.clone(),
                     title,
@@ -61,20 +61,20 @@ impl InputDecoder for BasicInputDecoder {
             }
             InputIdentity::File => {
                 if looks_like_rom_name(&object.name) {
-                    Content::Rom(RomContent {
+                    DecodedContent::Rom(DecodedRomContent {
                         id,
                         source: object.source.clone(),
                         size,
                     })
                 } else {
-                    Content::Bytes(BytesContent {
+                    DecodedContent::Bytes(BytesContent {
                         id,
                         source: object.source.clone(),
                         size,
                     })
                 }
             }
-            InputIdentity::Unknown => Content::Bytes(BytesContent {
+            InputIdentity::Unknown => DecodedContent::Bytes(BytesContent {
                 id,
                 source: object.source.clone(),
                 size,
@@ -261,7 +261,7 @@ mod tests {
 
         let content = decoder.decode(&object, &InputIdentity::Text).unwrap();
         assert_eq!(content.len(), 1);
-        assert!(matches!(content[0], Content::Text(_)));
+        assert!(matches!(content[0], DecodedContent::Text(_)));
     }
 
     #[test]
@@ -278,7 +278,7 @@ mod tests {
 
         let content = decoder.decode(&object, &InputIdentity::File).unwrap();
         assert_eq!(content.len(), 1);
-        assert!(matches!(content[0], Content::Rom(_)));
+        assert!(matches!(content[0], DecodedContent::Rom(_)));
     }
 
     #[test]
@@ -309,7 +309,7 @@ mod tests {
         assert_eq!(content.len(), 1);
 
         match &content[0] {
-            Content::Rom(rom) => assert_eq!(rom.size, 7),
+            DecodedContent::Rom(rom) => assert_eq!(rom.size, 7),
             other => panic!("expected Rom content, got {other:?}"),
         }
     }
@@ -341,7 +341,7 @@ FILE "game.bin" BINARY
         assert_eq!(content.len(), 1);
 
         match &content[0] {
-            Content::Disc(disc) => {
+            DecodedContent::Disc(disc) => {
                 assert_eq!(disc.consumed_sources.len(), 1);
                 assert_eq!(
                     disc.consumed_sources[0].to_string(),
@@ -391,7 +391,7 @@ FILE "game.bin" BINARY
         assert_eq!(content.len(), 1);
 
         match &content[0] {
-            Content::Disc(disc) => {
+            DecodedContent::Disc(disc) => {
                 assert_eq!(disc.consumed_sources.len(), 1);
                 assert_eq!(
                     disc.consumed_sources[0].to_string(),
@@ -450,7 +450,7 @@ FILE "game.bin" BINARY
         let content = decoder.decode(&object, &InputIdentity::Text).unwrap();
 
         match &content[0] {
-            Content::Text(text) => assert_eq!(text.id.to_string(), "mixed/notes"),
+            DecodedContent::Text(text) => assert_eq!(text.id.to_string(), "mixed/notes"),
             other => panic!("expected text content, got {other:?}"),
         }
     }
@@ -470,7 +470,7 @@ FILE "game.bin" BINARY
         let content = decoder.decode(&object, &InputIdentity::Text).unwrap();
 
         match &content[0] {
-            Content::Text(text) => assert_eq!(text.id.to_string(), "roms/snes/game"),
+            DecodedContent::Text(text) => assert_eq!(text.id.to_string(), "roms/snes/game"),
             other => panic!("expected text content, got {other:?}"),
         }
     }

--- a/src/input/decode.rs
+++ b/src/input/decode.rs
@@ -1,4 +1,4 @@
-use crate::core::content::Content;
+use crate::core::content::DecodedContent;
 use crate::core::source::SourceObject;
 use crate::input::identify::InputIdentity;
 
@@ -9,5 +9,5 @@ pub trait InputDecoder: Send + Sync {
         &self,
         object: &SourceObject,
         identity: &InputIdentity,
-    ) -> Result<Vec<Content>, std::io::Error>;
+    ) -> Result<Vec<DecodedContent>, std::io::Error>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use log::{debug, info};
 use std::path::PathBuf;
 
-use retromount::core::content::{Content, GamePart, Platform as ContentPlatform};
+use retromount::core::content::{GamePart, NormalizedContent, Platform as ContentPlatform};
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
 use retromount::engine::inspect::run_phase3_inspect;
@@ -102,9 +102,9 @@ fn map_view_platform(platform: &ConfigPlatform) -> ContentPlatform {
     }
 }
 
-fn log_content_summary(content: &Content) {
+fn log_content_summary(content: &NormalizedContent) {
     match content {
-        Content::Game(game) => {
+        NormalizedContent::Game(game) => {
             info!("  Game:");
             info!("    ID: {}", game.id);
             info!("    Title: {}", game.title);

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -1,4 +1,4 @@
-use crate::core::content::{Content, GameContent, GamePart};
+use crate::core::content::{GameContent, GamePart, NormalizedContent};
 use crate::output::encode::{EncodedBacking, EncodedFile, OutputEncoder};
 
 pub struct BasicEncoder;
@@ -8,40 +8,34 @@ impl BasicEncoder {
         Self
     }
 
-    fn file_name_for(&self, content: &Content) -> String {
+    fn file_name_for(&self, content: &NormalizedContent) -> String {
         match content {
-            Content::Bytes(bytes) => format!("{}.bin", bytes.id),
-            Content::Game(game) => match game.parts.as_slice() {
+            NormalizedContent::Bytes(bytes) => format!("{}.bin", bytes.id),
+            NormalizedContent::Game(game) => match game.parts.as_slice() {
                 [part] => self.file_name_for_game_part(game, part),
                 _ => game.title.clone(),
             },
-            Content::Text(text) => normalize_text_name(text.id.0.as_ref()),
-            Content::Rom(_) | Content::Disc(_) => {
-                unreachable!("BasicEncoder should only encode normalized playable content")
-            }
+            NormalizedContent::Text(text) => normalize_text_name(text.id.0.as_ref()),
         }
     }
 
-    fn backing_for(&self, content: &Content) -> EncodedBacking {
+    fn backing_for(&self, content: &NormalizedContent) -> EncodedBacking {
         match content {
-            Content::Bytes(bytes) => EncodedBacking::SourceBacked {
+            NormalizedContent::Bytes(bytes) => EncodedBacking::SourceBacked {
                 size: bytes.size,
                 source: bytes.source.clone(),
             },
-            Content::Game(game) => match game.parts.as_slice() {
+            NormalizedContent::Game(game) => match game.parts.as_slice() {
                 [part] => self.backing_for_game_part(part),
                 _ => EncodedBacking::SourceBacked {
                     size: 0,
                     source: game.source.clone(),
                 },
             },
-            Content::Text(text) => EncodedBacking::SourceBacked {
+            NormalizedContent::Text(text) => EncodedBacking::SourceBacked {
                 size: text.size,
                 source: text.source.clone(),
             },
-            Content::Rom(_) | Content::Disc(_) => {
-                unreachable!("BasicEncoder should only encode normalized playable content")
-            }
         }
     }
 
@@ -90,11 +84,11 @@ fn normalize_text_name(path: &str) -> String {
 }
 
 impl OutputEncoder for BasicEncoder {
-    fn can_encode(&self, _content: &Content) -> bool {
+    fn can_encode(&self, _content: &NormalizedContent) -> bool {
         true
     }
 
-    fn encode(&self, content: &Content) -> Result<EncodedFile, std::io::Error> {
+    fn encode(&self, content: &NormalizedContent) -> Result<EncodedFile, std::io::Error> {
         Ok(EncodedFile {
             name: self.file_name_for(content),
             backing: self.backing_for(content),
@@ -128,15 +122,15 @@ impl OutputEncoder for BasicEncoder {
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, Platform, RomPart,
-        TextContent,
+        BytesContent, ContentId, DiscPart, GameContent, GamePart, NormalizedContent, Platform,
+        RomPart, TextContent,
     };
     use crate::core::source::SourceRef;
 
     #[test]
     fn encodes_bytes_content() {
         let encoder = BasicEncoder::new();
-        let content = Content::Bytes(BytesContent {
+        let content = NormalizedContent::Bytes(BytesContent {
             id: ContentId::new("bios"),
             source: SourceRef::new("file:/roms/bios"),
             size: 512,
@@ -156,7 +150,7 @@ mod tests {
     #[test]
     fn encodes_single_rom_game_content() {
         let encoder = BasicEncoder::new();
-        let content = Content::Game(GameContent {
+        let content = NormalizedContent::Game(GameContent {
             id: ContentId::new("smw"),
             source: SourceRef::new("file:/roms/Super Mario World.sfc"),
             title: "Super Mario World".to_string(),
@@ -182,7 +176,7 @@ mod tests {
     #[test]
     fn encodes_single_disc_game_content() {
         let encoder = BasicEncoder::new();
-        let content = Content::Game(GameContent {
+        let content = NormalizedContent::Game(GameContent {
             id: ContentId::new("mgs"),
             source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
             title: "Metal Gear Solid".to_string(),
@@ -269,7 +263,7 @@ mod tests {
     #[test]
     fn encodes_text_content() {
         let encoder = BasicEncoder::new();
-        let content = Content::Text(TextContent {
+        let content = NormalizedContent::Text(TextContent {
             id: ContentId::new("readme"),
             source: SourceRef::new("file:/roms/readme"),
             size: 128,
@@ -289,7 +283,7 @@ mod tests {
     #[test]
     fn preserves_relative_path_for_text_content() {
         let encoder = BasicEncoder::new();
-        let content = Content::Text(TextContent {
+        let content = NormalizedContent::Text(TextContent {
             id: ContentId::new("mixed/notes"),
             source: SourceRef::new("mixed/notes.txt"),
             size: 10,
@@ -309,7 +303,7 @@ mod tests {
     #[test]
     fn normalizes_text_extension_from_id_path() {
         let encoder = BasicEncoder::new();
-        let content = Content::Text(TextContent {
+        let content = NormalizedContent::Text(TextContent {
             id: ContentId::new("roms/snes/game"),
             source: SourceRef::new("roms/snes/game.nfo"),
             size: 19,

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -20,9 +20,7 @@ impl EncodedFile {
             EncodedBacking::SourceBacked { source, size } => {
                 VfsFile::source_backed(&self.name, *size, source.clone())
             }
-            EncodedBacking::Inline(contents) => {
-                VfsFile::inline(&self.name, contents.clone())
-            }
+            EncodedBacking::Inline(contents) => VfsFile::inline(&self.name, contents.clone()),
         }
     }
 }

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -1,10 +1,10 @@
-use crate::core::content::{Content, GameContent, GamePart};
+use crate::core::content::{GameContent, GamePart, NormalizedContent};
 use crate::core::source::SourceRef;
-use crate::core::vfs::VfsFile;
+use crate::core::vfs::{FileBacking, VfsFile};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EncodedBacking {
-    SourceBacked { size: u64, source: SourceRef },
+    SourceBacked { source: SourceRef, size: u64 },
     Inline(Vec<u8>),
 }
 
@@ -16,26 +16,22 @@ pub struct EncodedFile {
 
 impl EncodedFile {
     pub fn to_vfs_file(&self) -> VfsFile {
-        match &self.backing {
-            EncodedBacking::SourceBacked { size, source } => {
-                VfsFile::source_backed(self.name.clone(), *size, source.clone())
-            }
-            EncodedBacking::Inline(bytes) => VfsFile::inline(self.name.clone(), bytes.clone()),
-        }
-    }
+        let backing = match &self.backing {
+            EncodedBacking::SourceBacked { source, size } => FileBacking::SourceBacked {
+                source: source.clone(),
+                size: *size,
+            },
+            EncodedBacking::Inline(contents) => FileBacking::Inline(contents.clone()),
+        };
 
-    pub fn size(&self) -> u64 {
-        match &self.backing {
-            EncodedBacking::SourceBacked { size, .. } => *size,
-            EncodedBacking::Inline(bytes) => bytes.len() as u64,
-        }
+        VfsFile::with_backing(&self.name, backing)
     }
 }
 
-pub trait OutputEncoder {
-    fn can_encode(&self, content: &Content) -> bool;
+pub trait OutputEncoder: Send + Sync {
+    fn can_encode(&self, content: &NormalizedContent) -> bool;
 
-    fn encode(&self, content: &Content) -> Result<EncodedFile, std::io::Error>;
+    fn encode(&self, content: &NormalizedContent) -> Result<EncodedFile, std::io::Error>;
 
     fn encode_game_part(
         &self,

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -1,6 +1,6 @@
 use crate::core::content::{GameContent, GamePart, NormalizedContent};
 use crate::core::source::SourceRef;
-use crate::core::vfs::{FileBacking, VfsFile};
+use crate::core::vfs::VfsFile;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EncodedBacking {
@@ -16,15 +16,14 @@ pub struct EncodedFile {
 
 impl EncodedFile {
     pub fn to_vfs_file(&self) -> VfsFile {
-        let backing = match &self.backing {
-            EncodedBacking::SourceBacked { source, size } => FileBacking::SourceBacked {
-                source: source.clone(),
-                size: *size,
-            },
-            EncodedBacking::Inline(contents) => FileBacking::Inline(contents.clone()),
-        };
-
-        VfsFile::with_backing(&self.name, backing)
+        match &self.backing {
+            EncodedBacking::SourceBacked { source, size } => {
+                VfsFile::source_backed(&self.name, *size, source.clone())
+            }
+            EncodedBacking::Inline(contents) => {
+                VfsFile::inline(&self.name, contents.clone())
+            }
+        }
     }
 }
 

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -1,4 +1,4 @@
-use crate::core::content::{Content, DiscPart, GameContent, GamePart};
+use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
 use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
@@ -12,7 +12,7 @@ where
 
 #[derive(Debug, Clone)]
 struct PresentedEntry {
-    content: Content,
+    content: NormalizedContent,
     encoded: EncodedFile,
 }
 
@@ -24,7 +24,7 @@ where
         Self { encoder }
     }
 
-    fn encode_entries(&self, content: &[Content]) -> Vec<PresentedEntry> {
+    fn encode_entries(&self, content: &[NormalizedContent]) -> Vec<PresentedEntry> {
         content
             .iter()
             .filter(|item| self.encoder.can_encode(item))
@@ -45,18 +45,15 @@ where
 
         for entry in entries {
             match &entry.content {
-                Content::Game(game) => {
+                NormalizedContent::Game(game) => {
                     self.insert_game_node(&mut root, game, &entry.encoded);
                 }
-                Content::Bytes(_) | Content::Text(_) => {
+                NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
                     self.insert_file_path(
                         &mut root,
                         &entry.encoded.name,
                         entry.encoded.to_vfs_file(),
                     );
-                }
-                Content::Rom(_) | Content::Disc(_) => {
-                    unreachable!("GenericPresenter should only receive normalized playable content")
                 }
             }
         }
@@ -135,7 +132,7 @@ impl<E> OutputPresenter for GenericPresenter<E>
 where
     E: OutputEncoder + Send + Sync,
 {
-    fn present(&self, content: &[Content]) -> VfsDirectory {
+    fn present(&self, content: &[NormalizedContent]) -> VfsDirectory {
         let entries = self.encode_entries(content);
         let children = self.build_root_children(&entries);
 
@@ -199,8 +196,8 @@ fn ensure_directory<'a>(root: &'a mut VfsDirectory, parents: &[String]) -> &'a m
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, Content, ContentId, DiscPart, GameContent, GamePart, Platform, RomPart,
-        TextContent,
+        BytesContent, ContentId, DiscPart, GameContent, GamePart, NormalizedContent, Platform,
+        RomPart, TextContent,
     };
     use crate::core::source::SourceRef;
     use crate::core::vfs::FileBacking;
@@ -211,12 +208,12 @@ mod tests {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![
-            Content::Bytes(BytesContent {
+            NormalizedContent::Bytes(BytesContent {
                 id: ContentId::new("bios"),
                 source: SourceRef::new("bios"),
                 size: 512,
             }),
-            Content::Game(GameContent {
+            NormalizedContent::Game(GameContent {
                 id: ContentId::new("sonic"),
                 source: SourceRef::new("zip:/roms/megadrive.zip#sonic.bin"),
                 title: "Sonic the Hedgehog".to_string(),
@@ -227,7 +224,7 @@ mod tests {
                 })],
                 consumed_sources: vec![],
             }),
-            Content::Game(GameContent {
+            NormalizedContent::Game(GameContent {
                 id: ContentId::new("ff7"),
                 source: SourceRef::new("cue:/roms/ff7.cue"),
                 title: "Final Fantasy VII".to_string(),
@@ -239,7 +236,7 @@ mod tests {
                 })],
                 consumed_sources: vec![SourceRef::new("cue:/roms/ff7.bin")],
             }),
-            Content::Text(TextContent {
+            NormalizedContent::Text(TextContent {
                 id: ContentId::new("manifest"),
                 source: SourceRef::new("file:/roms/manifest"),
                 size: 64,
@@ -256,7 +253,7 @@ mod tests {
     fn presents_single_rom_game_as_file_in_platform_title_directory() {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
-        let content = vec![Content::Game(GameContent {
+        let content = vec![NormalizedContent::Game(GameContent {
             id: ContentId::new("smw"),
             source: SourceRef::new("file:/roms/Super Mario World.sfc"),
             title: "Super Mario World".to_string(),
@@ -291,7 +288,7 @@ mod tests {
     fn presents_multi_disc_game_as_directory_with_playlist_in_library_view() {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
-        let content = vec![Content::Game(GameContent {
+        let content = vec![NormalizedContent::Game(GameContent {
             id: ContentId::new("ff7"),
             source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
             title: "Final Fantasy VII".to_string(),
@@ -359,7 +356,7 @@ mod tests {
         let presenter = GenericPresenter::new(BasicEncoder::new());
 
         let content = vec![
-            Content::Game(GameContent {
+            NormalizedContent::Game(GameContent {
                 id: ContentId::new("crash-bandicoot"),
                 source: SourceRef::new("file:/roms/Crash Bandicoot.bin"),
                 title: "Crash Bandicoot".to_string(),
@@ -370,7 +367,7 @@ mod tests {
                 })],
                 consumed_sources: vec![],
             }),
-            Content::Game(GameContent {
+            NormalizedContent::Game(GameContent {
                 id: ContentId::new("ff7"),
                 source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
                 title: "Final Fantasy VII".to_string(),

--- a/src/output/present.rs
+++ b/src/output/present.rs
@@ -1,6 +1,6 @@
-use crate::core::content::Content;
+use crate::core::content::NormalizedContent;
 use crate::core::vfs::VfsDirectory;
 
 pub trait OutputPresenter: Send + Sync {
-    fn present(&self, content: &[Content]) -> VfsDirectory;
+    fn present(&self, content: &[NormalizedContent]) -> VfsDirectory;
 }


### PR DESCRIPTION
## Summary

This PR merges the completed D-005 work from `feature/d005-decoded-normalized-split` into `feature/architecture-boundary-review`.

Closes #53 (F-005 / D-005)

D-005 introduces an explicit type boundary between decoded content and normalized content, aligning the type system with the pipeline stage boundaries established in earlier review work.

---

## What changed

### Core model split

- Introduced:
  - `DecodedContent` (decode-stage output)
  - `NormalizedContent` (post-normalization semantic model)
- Removed the previous over-broad `Content` abstraction from the pipeline boundary

### Pipeline updates

- `InputDecoder` now returns `Vec<DecodedContent>`
- `normalize_decoded_content()` now:
  - consumes `DecodedContent`
  - produces `NormalizedContent`
- Presenter and Encoder now operate exclusively on `NormalizedContent`

### Boundary enforcement

- Eliminated reliance on convention for stage correctness
- Removed invalid post-normalization states from type system
- Reduced / eliminated `unreachable!()` cases caused by mixed-stage models

### Documentation updates

- Updated:
  - `review-findings.md` (F-005 → Resolved)
  - `decisions.md` (D-005 → Implemented)
  - `boundaries.md` (explicit decode → normalize contract)
  - `README.md` (pipeline and model updates)
- Renamed:
  - `normalize_content` → `normalize_decoded_content`

### Visibility tightening

- Scoped `normalize_decoded_content` to `pub(crate)` as an internal pipeline boundary

---

## Why this matters

This change completes the core architectural layering work started in:

- D-002 (single orchestration model)
- D-003 (presenter vs encoder separation)
- D-004 (presentation-agnostic core model)

D-005 strengthens the remaining weak boundary:

> decode → normalize

By making this boundary explicit in the type system, the pipeline now guarantees:

- clear stage contracts
- no invalid cross-stage states
- simpler presenter/encoder logic
- stronger foundations for plugin/extensibility work

---

## Testing

- `cargo test` passes
- `cargo clippy -- -D warnings` passes
- `cargo fmt --check` passes
- `markdownlint` passes

CI is fully green.

---

## Notes

- No behavioural changes to output are expected — this is a structural/type-level improvement
- This PR is a prerequisite for defining stable plugin boundaries in the next phase

---

## Next steps

- Interface locking and plugin boundary design
- Further tightening of module visibility where appropriate
- Potential presenter/encoder extension points