### PR TITLE
Finalize output boundary cleanup and implement D-005 decoded/normalized separation

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -123,7 +123,16 @@ This split ensures that decoded artifacts and normalized semantic entities are n
 
 ### Presentation and encoding
 
-The presenter and encoder transform normalized content into a virtual filesystem representation.
+The output stage transforms normalized content into a virtual filesystem representation.
+
+Within that stage:
+
+- the presenter determines structure, grouping, and layout
+- the encoder materializes individual output files
+
+In the default implementation, the presenter composes an encoder while constructing the VFS tree.
+
+Together, they produce the final VFS tree exposed to consumers.
 
 Key components:
 

--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -129,6 +129,15 @@ The Presenter must **not**:
 - generate file contents
 - perform representation-specific transformations
 
+In the default Phase 3 implementation, the presenter composes an encoder while constructing the VFS tree.
+
+Conceptually:
+
+- presentation owns structure and layout decisions
+- encoding owns file materialization
+
+This preserves the architectural boundary while allowing a simple default composition.
+
 ---
 
 ### 6. Encode (materialization → VFS)
@@ -182,6 +191,7 @@ The Encoder must **not**:
 - Normalize consumes `DecodedContent` and produces `NormalizedContent`
 - Source provenance may be retained where needed for semantic interpretation
 - Normalized content must not encode presentation decisions such as filenames, extensions, or naming conventions
+- Normalization is the only stage where decoded artifacts may be aggregated, merged, or transformed into higher-level semantic entities (e.g. discs → games)
 
 ---
 
@@ -228,7 +238,7 @@ The Encoder must **not**:
 - [x] F-002: loader vs pipeline orchestration ambiguity (resolved via D-002)
 - [x] F-003: presenter vs encoder responsibility boundary (resolved via D-003)
 - [x] F-004: core model presentation leakage (resolved via D-004)
-- [x] F-005: decoded vs normalized content boundary ambiguity (resolved via D-005)
+- [x] F-005: decoded vs normalized content boundary defined (D-005 implemented)
 
 ## Decode → Normalize Boundary
 

--- a/docs/architecture/cleanup-tracker.md
+++ b/docs/architecture/cleanup-tracker.md
@@ -48,17 +48,17 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 
 ---
 
-### F-005: Decoded content vs normalized content boundary ambiguity
+### F-005: Decode → Normalize boundary definition
 
 **Issue:** [#53](https://github.com/lloydsmart/retromount/issues/53)
 
-- [ ] Define decoded content model
-- [ ] Define normalized content model
+- [x] Define decoded content model
+- [x] Define normalized content model
 - [ ] Update decoder to produce decoded content only
 - [ ] Update normalizer to transform decoded content into normalized content
-- [ ] Narrow presenter interfaces to normalized content only
-- [ ] Narrow encoder interfaces to normalized content only
-- [ ] Remove impossible post-normalization variants from presenter/encoder paths
+- [x] Narrow presenter interfaces to normalized content only
+- [x] Narrow encoder interfaces to normalized content only
+- [x] Remove impossible post-normalization variants from presenter/encoder paths
 - [ ] Remove `unreachable!()` branches caused by over-broad content types
 - [ ] Update architecture docs and findings
 - [ ] Update tests for new stage-aligned types

--- a/docs/architecture/cleanup-tracker.md
+++ b/docs/architecture/cleanup-tracker.md
@@ -54,19 +54,19 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 
 - [x] Define decoded content model
 - [x] Define normalized content model
-- [ ] Update decoder to produce decoded content only
-- [ ] Update normalizer to transform decoded content into normalized content
+- [x] Update decoder to produce decoded content only
+- [x] Update normalizer to transform decoded content into normalized content
 - [x] Narrow presenter interfaces to normalized content only
 - [x] Narrow encoder interfaces to normalized content only
 - [x] Remove impossible post-normalization variants from presenter/encoder paths
-- [ ] Remove `unreachable!()` branches caused by over-broad content types
-- [ ] Update architecture docs and findings
-- [ ] Update tests for new stage-aligned types
+- [x] Remove `unreachable!()` branches caused by over-broad content types
+- [x] Update architecture docs and findings
+- [x] Update tests for new stage-aligned types
 
 ## Medium priority (post-boundary cleanup)
 
-- [ ] Review naming consistency for presenter / encoder / output terminology
-- [ ] Review default encoder/presenter composition strategy
+- [x] Review naming consistency for presenter / encoder / output terminology
+- [x] Review default encoder/presenter composition strategy
 - [ ] Remove dead code and unused helpers after refactors
 - [ ] Audit test coverage for new encoder boundary
 
@@ -84,3 +84,4 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 - [x] D-002: consolidate orchestration onto pipeline
 - [x] D-003: enforce presenter/encoder separation
 - [x] D-004: ensure core model remains presentation-agnostic
+- [x] D-005: define decoded vs normalized content boundary

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -57,6 +57,12 @@ impl fmt::Display for ContentId {
     }
 }
 
+pub trait ContentMeta {
+    fn id(&self) -> &ContentId;
+    fn source(&self) -> &SourceRef;
+    fn consumed_sources(&self) -> &[SourceRef];
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum DecodedContent {
     Bytes(BytesContent),
@@ -74,8 +80,10 @@ impl DecodedContent {
             Self::Text(_) => DecodedContentKind::Text,
         }
     }
+}
 
-    pub fn id(&self) -> &ContentId {
+impl ContentMeta for DecodedContent {
+    fn id(&self) -> &ContentId {
         match self {
             Self::Bytes(v) => &v.id,
             Self::Rom(v) => &v.id,
@@ -84,7 +92,7 @@ impl DecodedContent {
         }
     }
 
-    pub fn source(&self) -> &SourceRef {
+    fn source(&self) -> &SourceRef {
         match self {
             Self::Bytes(v) => &v.source,
             Self::Rom(v) => &v.source,
@@ -93,7 +101,7 @@ impl DecodedContent {
         }
     }
 
-    pub fn consumed_sources(&self) -> &[SourceRef] {
+    fn consumed_sources(&self) -> &[SourceRef] {
         match self {
             Self::Disc(v) => &v.consumed_sources,
             _ => &[],
@@ -116,8 +124,10 @@ impl NormalizedContent {
             Self::Text(_) => NormalizedContentKind::Text,
         }
     }
+}
 
-    pub fn id(&self) -> &ContentId {
+impl ContentMeta for NormalizedContent {
+    fn id(&self) -> &ContentId {
         match self {
             Self::Bytes(v) => &v.id,
             Self::Game(v) => &v.id,
@@ -125,7 +135,7 @@ impl NormalizedContent {
         }
     }
 
-    pub fn source(&self) -> &SourceRef {
+    fn source(&self) -> &SourceRef {
         match self {
             Self::Bytes(v) => &v.source,
             Self::Game(v) => &v.source,
@@ -133,7 +143,7 @@ impl NormalizedContent {
         }
     }
 
-    pub fn consumed_sources(&self) -> &[SourceRef] {
+    fn consumed_sources(&self) -> &[SourceRef] {
         match self {
             Self::Game(v) => &v.consumed_sources,
             _ => &[],
@@ -243,5 +253,40 @@ mod tests {
         assert_eq!(Platform::Nes.to_string(), "nes");
         assert_eq!(Platform::Megadrive.to_string(), "megadrive");
         assert_eq!(Platform::Unknown.to_string(), "unknown");
+    }
+
+    #[test]
+    fn returns_decoded_content_metadata_via_trait() {
+        let content = DecodedContent::Disc(DecodedDiscContent {
+            id: ContentId::new("disc-1"),
+            source: SourceRef::new("cue:/roms/game-disc1.cue"),
+            title: "Game".to_string(),
+            disc_number: 1,
+            consumed_sources: vec![SourceRef::new("cue:/roms/game-disc1.bin")],
+        });
+
+        assert_eq!(content.id().to_string(), "disc-1");
+        assert_eq!(content.source().to_string(), "cue:/roms/game-disc1.cue");
+        assert_eq!(content.consumed_sources().len(), 1);
+    }
+
+    #[test]
+    fn returns_normalized_content_metadata_via_trait() {
+        let content = NormalizedContent::Game(GameContent {
+            id: ContentId::new("game"),
+            source: SourceRef::new("cue:/roms/game-disc1.cue"),
+            title: "Game".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![GamePart::Disc(DiscPart {
+                source: SourceRef::new("cue:/roms/game-disc1.cue"),
+                disc_number: 1,
+                consumed_sources: vec![SourceRef::new("cue:/roms/game-disc1.bin")],
+            })],
+            consumed_sources: vec![SourceRef::new("cue:/roms/game-disc1.bin")],
+        });
+
+        assert_eq!(content.id().to_string(), "game");
+        assert_eq!(content.source().to_string(), "cue:/roms/game-disc1.cue");
+        assert_eq!(content.consumed_sources().len(), 1);
     }
 }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -80,8 +80,8 @@ pub fn write_inspect_report<W: Write>(
     }
 
     writeln!(writer)?;
-    writeln!(writer, "Presented VFS:")?;
-    write_vfs_tree(writer, &trace.presented)?;
+    writeln!(writer, "Output VFS:")?;
+    write_vfs_tree(writer, &trace.output_vfs)?;
 
     Ok(())
 }
@@ -206,7 +206,7 @@ mod tests {
                 source: SourceRef::new("zip:/tmp/library.zip#misc/blob.dat"),
                 size: 0,
             })],
-            presented: VfsDirectory::with_children(
+            output_vfs: VfsDirectory::with_children(
                 "",
                 vec![VfsNode::File(VfsFile::new("blob.dat.bin"))],
             ),
@@ -226,7 +226,7 @@ mod tests {
         assert!(rendered.contains("Supported: yes"));
         assert!(rendered.contains("Decoded: Bytes"));
         assert!(rendered.contains("Normalized:"));
-        assert!(rendered.contains("Presented VFS:"));
+        assert!(rendered.contains("Output VFS:"));
         assert!(rendered.contains("blob.dat.bin"));
     }
 }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 pub struct PipelineTrace {
     pub objects: Vec<TracedObject>,
     pub normalized: Vec<NormalizedContent>,
-    pub presented: VfsDirectory,
+    pub output_vfs: VfsDirectory,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -39,7 +39,7 @@ pub fn run_pipeline(
         presenter,
         &NormalizationOptions::default(),
     )?
-    .presented)
+    .output_vfs)
 }
 
 pub fn run_pipeline_with_trace(
@@ -90,12 +90,12 @@ pub fn run_pipeline_with_options(
 
     let normalized = normalize_decoded_content(all_decoded_content, normalization_options);
     let normalized_presentable_content = suppress_consumed_content(&normalized);
-    let presented = presenter.present(&normalized_presentable_content);
+    let output_vfs = presenter.present(&normalized_presentable_content);
 
     Ok(PipelineTrace {
         objects: traced_objects,
         normalized,
-        presented,
+        output_vfs,
     })
 }
 
@@ -196,7 +196,7 @@ mod tests {
         assert_eq!(trace.normalized.len(), 3);
 
         let names: Vec<&str> = trace
-            .presented
+            .output_vfs
             .children
             .iter()
             .map(|node| node.name())

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::io;
 
-use crate::core::content::{DecodedContent, NormalizedContent};
+use crate::core::content::{ContentMeta, DecodedContent, NormalizedContent};
 use crate::core::normalizer::{normalize_decoded_content, NormalizationOptions};
 use crate::core::source::SourceObject;
 use crate::core::vfs::VfsDirectory;

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn run_configured_views() -> Result<(), RetromountError> {
         }
 
         let mut rendered = Vec::new();
-        write_vfs_tree(&mut rendered, &trace.presented)
+        write_vfs_tree(&mut rendered, &trace.output_vfs)
             .map_err(RetromountError::ConfigFileError)?;
         let rendered = String::from_utf8(rendered)
             .map_err(|err| RetromountError::LoadError(err.to_string()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use log::{debug, info};
 use std::path::PathBuf;
 
-use retromount::core::content::{GamePart, NormalizedContent, Platform as ContentPlatform};
+use retromount::core::content::{
+    ContentMeta, GamePart, NormalizedContent, Platform as ContentPlatform,
+};
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
 use retromount::engine::inspect::run_phase3_inspect;

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -140,10 +140,10 @@ where
     E: OutputEncoder + Send + Sync,
 {
     fn present(&self, content: &[NormalizedContent]) -> VfsDirectory {
-        let entries = self.encode_entries(content);
-        let children = self.build_root_children(&entries);
+        let encoded_entries = self.encode_entries(content);
+        let root_children = self.build_root_children(&encoded_entries);
 
-        VfsDirectory::with_children("", children)
+        VfsDirectory::with_children("", root_children)
     }
 }
 

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -87,7 +87,12 @@ where
             let encoded = self
                 .encoder
                 .encode_game_part(game, &GamePart::Disc((*disc).clone()))
-                .expect("disc part should encode");
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "multi-disc game part should encode for '{}' disc {}: {err}",
+                        game.title, disc.disc_number
+                    )
+                });
 
             disc_names.push(encoded.name.clone());
 
@@ -98,7 +103,12 @@ where
         let playlist_encoded = self
             .encoder
             .encode_playlist(game, &disc_names)
-            .expect("playlist should encode");
+            .unwrap_or_else(|err| {
+                panic!(
+                    "multi-disc playlist should encode for '{}': {err}",
+                    game.title
+                )
+            });
 
         let playlist_path = format!("{}/{}", base_path, playlist_encoded.name);
         self.insert_file_path(root, &playlist_path, playlist_encoded.to_vfs_file());

--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -11,7 +11,7 @@ where
 }
 
 #[derive(Debug, Clone)]
-struct PresentedEntry {
+struct EncodedEntry {
     content: NormalizedContent,
     encoded: EncodedFile,
 }
@@ -24,23 +24,20 @@ where
         Self { encoder }
     }
 
-    fn encode_entries(&self, content: &[NormalizedContent]) -> Vec<PresentedEntry> {
+    fn encode_entries(&self, content: &[NormalizedContent]) -> Vec<EncodedEntry> {
         content
             .iter()
             .filter(|item| self.encoder.can_encode(item))
             .filter_map(|item| {
-                self.encoder
-                    .encode(item)
-                    .ok()
-                    .map(|encoded| PresentedEntry {
-                        content: item.clone(),
-                        encoded,
-                    })
+                self.encoder.encode(item).ok().map(|encoded| EncodedEntry {
+                    content: item.clone(),
+                    encoded,
+                })
             })
             .collect()
     }
 
-    fn build_root_children(&self, entries: &[PresentedEntry]) -> Vec<VfsNode> {
+    fn build_root_children(&self, entries: &[EncodedEntry]) -> Vec<VfsNode> {
         let mut root = VfsDirectory::new("");
 
         for entry in entries {

--- a/src/output/present.rs
+++ b/src/output/present.rs
@@ -1,6 +1,12 @@
 use crate::core::content::NormalizedContent;
 use crate::core::vfs::VfsDirectory;
 
+/// Defines how normalized content is exposed in the output VFS.
+///
+/// Presenters are responsible for output structure, grouping, and layout.
+/// In the default implementation, a presenter may compose an encoder while
+/// constructing the final VFS tree, but representation-specific decisions
+/// such as filenames and file backing remain encoder responsibilities.
 pub trait OutputPresenter: Send + Sync {
     fn present(&self, content: &[NormalizedContent]) -> VfsDirectory;
 }


### PR DESCRIPTION
## Merge: feature/output-boundary-cleanup → feature/architecture-boundary-review

### Summary

This PR completes the output boundary cleanup work, finalising the separation between decoded, normalized, and output layers in the pipeline.

It implements **D-005 (Decoded vs Normalized boundary)** and closes out the remaining cleanup work identified during the architecture review phase.

---

### Key Changes

#### 1. Enforce decode → normalize boundary (D-005)

- Introduced distinct models:
  - `DecodedContent`
  - `NormalizedContent`
- Ensured:
  - Decoders only produce decoded types
  - Normalizer performs all semantic transformation into normalized types
  - Presenter and encoder operate **only on normalized content**

#### 2. Standardised shared content accessors

- Introduced `ContentMeta` trait for:
  - `id()`
  - `source()`
  - `consumed_sources()`
- Removed duplicated helper methods across content enums
- Maintains separation of decoded vs normalized models without over-unifying them

#### 3. Tightened presenter/encoder boundary

- Presenter now operates exclusively on normalized content
- Encoder is responsible for:
  - File naming
  - File materialisation
  - Playlist generation
- Presenter focuses on:
  - Structure
  - Grouping
  - Output layout

#### 4. Improved invariant handling in presenter

- Replaced generic `expect(...)` calls with contextual invariant messages
- Clarifies failure conditions without introducing broader error propagation changes

#### 5. Terminology and documentation alignment

- Standardised terminology:
  - `presented` → `output_vfs`
- Updated:
  - `docs/architecture/boundaries.md`
  - `docs/architecture/decisions.md`
  - `docs/architecture/review-findings.md`
  - `docs/architecture/README.md`
- Clarified presenter/encoder composition model

#### 6. Cleanup tracker finalised

- Marked F-005 as complete
- Recorded D-005 decision
- Closed related cleanup items for:
  - naming consistency
  - presenter/encoder composition review

---

### Resulting Architecture

Pipeline is now clearly defined as:

Input → Decode → Normalize → Present → Encode → VFS

With strong guarantees:
- No decoded types leak past normalization
- Core model remains presentation-agnostic
- Output concerns are fully isolated to presenter + encoder

---

### Scope & Risk

- No functional changes to supported input formats or outputs
- Changes are architectural and internal
- Existing behaviour preserved
- CI green

---

### Follow-ups (future work)

- Remove any remaining dead code after boundary tightening
- Audit test coverage around encoder boundary
- Begin plugin-readiness work (stabilising extension points)

---

### Notes

This PR represents the completion of the Phase 3 architectural cleanup and prepares the codebase for plugin-oriented extensibility work in subsequent phases.