### PR TITLE
Fix duplicated relative paths in VFS leaf file names

### DIFF
--- a/src/output/generic_presenter.rs
+++ b/src/output/generic_presenter.rs
@@ -121,8 +121,12 @@ where
         file: crate::core::vfs::VfsFile,
     ) {
         let normalized = normalize_path(path);
-        let (parents, _) = split_parent_dirs(&normalized);
+        let (parents, file_name) = split_parent_dirs(&normalized);
         let directory = ensure_directory(root, &parents);
+
+        let mut file = file;
+        file.name = file_name;
+
         directory.add_child(VfsNode::File(file));
     }
 
@@ -410,5 +414,47 @@ mod tests {
 
         let names: Vec<&str> = ps1.children().iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["Crash Bandicoot", "Final Fantasy VII"]);
+    }
+
+    #[test]
+    fn presents_text_content_with_relative_path_using_leaf_file_name() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![NormalizedContent::Text(TextContent {
+            id: ContentId::new("mixed/notes"),
+            source: SourceRef::new("file:/roms/mixed/notes.txt"),
+            size: 12,
+        })];
+
+        let root = presenter.present(&content);
+
+        let mixed = match root.find_directory("mixed") {
+            Some(dir) => dir,
+            None => panic!("expected mixed directory"),
+        };
+
+        let names: Vec<&str> = mixed.children().iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["notes.txt"]);
+    }
+
+    #[test]
+    fn presents_bytes_content_with_relative_path_using_leaf_file_name() {
+        let presenter = GenericPresenter::new(BasicEncoder::new());
+
+        let content = vec![NormalizedContent::Bytes(BytesContent {
+            id: ContentId::new("zips/gameboy_collection.zip"),
+            source: SourceRef::new("file:/roms/zips/gameboy_collection.zip"),
+            size: 481,
+        })];
+
+        let root = presenter.present(&content);
+
+        let zips = match root.find_directory("zips") {
+            Some(dir) => dir,
+            None => panic!("expected zips directory"),
+        };
+
+        let names: Vec<&str> = zips.children().iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["gameboy_collection.zip.bin"]);
     }
 }


### PR DESCRIPTION
## Merge: bugfix/vfs-leaf-naming → develop

### Summary

This PR fixes a VFS presentation bug where files with relative-path-based encoded names were being inserted into the correct directory, but retained the full relative path as the leaf file name.

This caused duplicated path segments in the final VFS output.

---

### Problem

For some bytes/text outputs, the presenter correctly created parent directories from the encoded path, but then inserted a `VfsFile` whose `name` still contained the full relative path.

Examples of the broken output included:

- `mixed/mixed/notes.txt`
- `roms/snes/roms/snes/game.txt`
- `zips/zips/gameboy_collection.zip.bin`

---

### Fix

- Updated `GenericPresenter::insert_file_path()` to:
  - split the encoded path into parent directories and leaf filename
  - ensure the parent directory hierarchy exists
  - rewrite the inserted `VfsFile` name to the leaf filename before adding it to the VFS tree

This preserves relative-path-driven directory layout while ensuring file nodes use only the basename at the leaf level.

---

### Tests

Added regression tests covering:
- text content with relative-path-derived filenames
- bytes content with relative-path-derived filenames

---

### Result

The final VFS output now correctly renders entries such as:

- `mixed/notes.txt`
- `roms/snes/game.txt`
- `zips/gameboy_collection.zip.bin`

without duplicating parent path segments in the leaf file name.