### PR TITLE
feat(fuse): implement Phase 4A mount support and finalize pipeline architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -131,6 +137,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cipher"
@@ -184,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "deranged"
@@ -210,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -274,6 +286,26 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fuser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a5eca878900c2e39e9e52fd797954b7fc39eeefc8558257114bfea6a698fcf"
+dependencies = [
+ "bitflags",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "num_enum",
+ "page_size",
+ "parking_lot",
+ "pkg-config",
+ "ref-cast",
+ "smallvec",
+ "zerocopy",
+]
 
 [[package]]
 name = "generic-array"
@@ -377,9 +409,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -417,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -450,6 +482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +512,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,10 +531,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.0"
+name = "nix"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "once_cell"
@@ -497,6 +582,39 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -552,6 +670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +707,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "regex"
@@ -615,6 +771,8 @@ name = "retromount"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "fuser",
+ "libc",
  "log",
  "serde",
  "serde_json",
@@ -648,6 +806,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -741,9 +905,15 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "subtle"
@@ -816,6 +986,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.8+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -890,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -900,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -913,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -955,6 +1155,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1055,6 +1286,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 name = "retromount"
 version = "0.1.0"
 edition = "2021"
-authors = ["Lloyd Smart <lloydsmart@users.noreply.github.com>"]
+authors = [
+    "Lloyd Smart [lloydsmart@users.noreply.github.com](mailto:lloydsmart@users.noreply.github.com)",
+]
 description = "Modular FUSE-based filesystem for retro game archives"
 license = "GPL-3.0-only"
 repository = "https://github.com/lloydsmart/retromount"
@@ -18,6 +20,8 @@ log = "0.4"
 env_logger = "0.11.10"
 thiserror = "2.0"                                        # For custom error types
 zip = "8"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 fuser = "0.17"
 libc = "0.2"
 
@@ -25,7 +29,7 @@ libc = "0.2"
 tempfile = "3.27"
 
 [package.metadata.deb]
-maintainer = "Lloyd Smart <lloydsmart@users.noreply.github.com>"
+maintainer = "Lloyd Smart [lloydsmart@users.noreply.github.com](mailto:lloydsmart@users.noreply.github.com)"
 copyright = "2026, Lloyd Smart"
 license-file = ["LICENSE", "4"]
 depends = "$auto, fuse"
@@ -51,6 +55,7 @@ assets = [
 
 [features]
 default = []
+
 # Placeholder for future translator dependencies
 # chd_to_iso = ["dep:some_crate"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,10 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 log = "0.4"
 env_logger = "0.11.10"
-thiserror = "2.0"  # For custom error types
+thiserror = "2.0"                                        # For custom error types
 zip = "8"
+fuser = "0.17"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3.27"
@@ -30,9 +32,21 @@ depends = "$auto, fuse"
 section = "utils"
 priority = "optional"
 assets = [
-    ["target/release/retromount", "usr/bin/", "755"],
-    ["README.md", "usr/share/doc/retromount/", "644"],
-    ["retromount.yaml.example", "usr/share/doc/retromount/examples/", "644"],
+    [
+        "target/release/retromount",
+        "usr/bin/",
+        "755",
+    ],
+    [
+        "README.md",
+        "usr/share/doc/retromount/",
+        "644",
+    ],
+    [
+        "retromount.yaml.example",
+        "usr/share/doc/retromount/examples/",
+        "644",
+    ],
 ]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Rust](https://img.shields.io/badge/Rust-1.70%2B-orange)
 ![License](https://img.shields.io/badge/license-GPL--3.0-blue)
 
-> A virtual filesystem for retro game collections that dynamically transforms ROMs and disc images into emulator-friendly formats without duplicating files.
+> A virtual filesystem for retro game collections that can be mounted and transformed on-the-fly without duplicating files.
 
 RetroMount is an experimental Rust project for building a **virtual filesystem over retro game collections**.
 
@@ -11,10 +11,10 @@ It allows ROMs, disc images, and archives to be **mounted into alternative files
 
 For example:
 
-- Present CHD images as ISO files
-- Extract ROMs from ZIP archives transparently
-- Convert disc images into emulator-friendly layouts
-- Provide platform-specific views for systems like MiSTer or Batocera
+* Present CHD images as ISO files
+* Extract ROMs from ZIP archives transparently
+* Convert disc images into emulator-friendly layouts
+* Provide platform-specific views for systems like MiSTer or Batocera
 
 The long-term goal is a flexible **input → transformation → output pipeline** backed by a FUSE filesystem.
 
@@ -26,12 +26,12 @@ Retro game collections are often stored in formats that are not ideal for every 
 
 For example:
 
-| Storage format | Works well for | Problems |
-| --- | --- | --- |
-| ZIP archives | ROM management | Many emulators cannot read zipped files |
-| CHD images | Space-efficient storage | Some tools require ISO/BIN files |
-| CUE/BIN discs | Accurate disc representation | Some systems prefer CHD |
-| Raw ROM sets | Simple emulators | Hard to manage at scale |
+| Storage format | Works well for               | Problems                                |
+| -------------- | ---------------------------- | --------------------------------------- |
+| ZIP archives   | ROM management               | Many emulators cannot read zipped files |
+| CHD images     | Space-efficient storage      | Some tools require ISO/BIN files        |
+| CUE/BIN discs  | Accurate disc representation | Some systems prefer CHD                 |
+| Raw ROM sets   | Simple emulators             | Hard to manage at scale                 |
 
 Traditionally, users solve this by **duplicating their collection in multiple formats**:
 
@@ -79,43 +79,84 @@ All backed by **one underlying file**.
 
 RetroMount is under active development.
 
-Current development is focused on building the **core ingestion and discovery pipeline** before implementing the FUSE filesystem and output translators.
+Current development is focused on exposing the pipeline through a real filesystem interface and refining presentation behaviour.
+
+### Completed (Phase 4A)
+
+* Linux FUSE mount support
+* Read-only virtual filesystem backed by the VFS
+* Directory traversal (`ls`, `tree`, `find`)
+* File access (`cat`, `head`, etc.)
+* Support for both inline-generated and source-backed files
+* Multi-disc grouping with automatic playlist (`.m3u`) generation
 
 ### Completed (Phase 2)
 
 The project now supports:
 
-### Input discovery
+#### Input discovery
 
-- Directory sources
-- ZIP archives
-- Individual files
-- CUE/BIN disc images
+* Directory sources
+* ZIP archives
+* Individual files
+* CUE/BIN disc images
 
-### Core models
+#### Core models
 
-- `VirtualFile` abstraction for discovered files
-- `Track`, `Disc`, and `GameImage` models for disc-based systems
+* `VirtualFile` abstraction for discovered files
+* `Track`, `Disc`, and `GameImage` models for disc-based systems
 
-### Loader pipeline
+#### Loader pipeline
 
-- Input handler registry
-- Reader abstraction for accessing underlying data
-- Loader for discovering payload files or loading disc images
+* Input handler registry
+* Reader abstraction for accessing underlying data
+* Loader for discovering payload files or loading disc images
 
-### CUE support
+#### CUE support
 
-- Parsing CUE sheets
-- Resolving referenced files
-- Track ordering and deduplication
-- Track size hydration from actual file metadata
-- Generation of `GameImage` objects for disc-based systems
+* Parsing CUE sheets
+* Resolving referenced files
+* Track ordering and deduplication
+* Track size hydration from actual file metadata
+* Generation of `GameImage` objects for disc-based systems
 
-### Configuration
+#### Configuration
 
-- YAML configuration file
-- Platform-aware views
-- Flexible platform parsing (`ps1`, `playstation`, etc.)
+* YAML configuration file
+* Platform-aware views
+* Flexible platform parsing (`ps1`, `playstation`, etc.)
+
+---
+
+## Mounting (Linux)
+
+RetroMount can expose a collection as a read-only filesystem using FUSE.
+
+```bash
+retromount mount <input> <mountpoint>
+```
+
+### Example
+
+```bash
+retromount mount ./retromount-testdata /tmp/retromount-test
+```
+
+You can then browse and read files normally:
+
+```bash
+ls /tmp/retromount-test
+tree /tmp/retromount-test
+cat /tmp/retromount-test/ps1/Final\ Fantasy\ VII/Final\ Fantasy\ VII.m3u
+head /tmp/retromount-test/snes/Super\ Mario\ World/Super\ Mario\ World.sfc
+```
+
+### Notes
+
+* Linux only (via FUSE)
+* filesystem is read-only
+* output reflects the same structure as `preview` / `inspect`
+* performance optimisations are planned in future phases
 
 ---
 
@@ -142,11 +183,11 @@ Create a file called `retromount.yaml`:
 
 Fields:
 
-| Field | Description |
-| --- | --- |
-| `name` | Logical name for the mounted view |
-| `source` | Source directory, archive, or disc image |
-| `mount` | Mount point for the virtual filesystem |
+| Field      | Description                                       |
+| ---------- | ------------------------------------------------- |
+| `name`     | Logical name for the mounted view                 |
+| `source`   | Source directory, archive, or disc image          |
+| `mount`    | Mount point for the virtual filesystem            |
 | `platform` | Target platform (e.g. `ps1`, `snes`, `megadrive`) |
 
 Platform names are **case-insensitive** and accept friendly aliases.
@@ -182,17 +223,17 @@ Input handlers are responsible for discovering files from a source.
 
 Examples:
 
-- `DirectoryInputHandler`
-- `ZipInputHandler`
-- `FileInputHandler`
-- `CueInputHandler`
+* `DirectoryInputHandler`
+* `ZipInputHandler`
+* `FileInputHandler`
+* `CueInputHandler`
 
 ### Readers
 
 Readers provide access to underlying data streams:
 
-- `DirReader`
-- `ZipReader`
+* `DirReader`
+* `ZipReader`
 
 ### Core disc models
 
@@ -212,9 +253,9 @@ This enables accurate representation of multi-track disc formats.
 
 RetroMount only removes **universally unwanted junk files** during discovery:
 
-- `__MACOSX/`
-- `.DS_Store`
-- `Thumbs.db`
+* `__MACOSX/`
+* `.DS_Store`
+* `Thumbs.db`
 
 Other sidecar files such as `.nfo`, `.txt`, or cover art are preserved.
 
@@ -224,21 +265,15 @@ Output-specific filtering will be implemented in the **view/output layer** in a 
 
 ## Roadmap
 
-### Phase 3 (next)
+### Phase 4 (current)
 
-Planned work:
-
-- Output translator system
-- View policies for different platforms
-- FUSE filesystem integration
-- Disc format translators (e.g. CHD → ISO)
-- Output policies for targets like:
-  - MiSTer
-  - Batocera
-  - RetroNAS
+* Consumer-specific filesystem views
+* Presentation policies (naming, filtering, grouping)
+* Performance improvements (e.g. read caching)
+* Output translators (e.g. CHD → ISO)
 
 ---
 
 ## License
 
-GPL-3.0
+[GPL-3.0](LICENSE)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -210,7 +210,7 @@ The architecture review work in this directory aims to:
 
 ## Next Focus Areas
 
-* review the next architectural boundary concern after D-005
 * improve module-level documentation
 * introduce diagrams for better visualization of the pipeline
 * refine filesystem adapter behaviour and performance (e.g. read caching)
+* add examples for alternate presenters, encoders, and adapter layers

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,7 +2,7 @@
 
 This directory captures the current architectural shape of Retromount following Phase 3 consolidation and the pipeline orchestration unification (D-002).
 
-It documents the system as it exists today, along with the review work carried out in `feature/architecture-boundary-review`.  
+It documents the system as it exists today, along with the review work carried out in `feature/architecture-boundary-review`.
 
 ---
 
@@ -12,16 +12,16 @@ The architecture documentation is structured to provide a clear, traceable view 
 
 The documents work together as follows:
 
-- **Review findings (`review-findings.md`)**  
+* **Review findings (`review-findings.md`)**
   Identify architectural issues, ambiguities, or areas for improvement.
 
-- **Decisions (`decisions.md`)**  
+* **Decisions (`decisions.md`)**
   Record the chosen approach for addressing findings, including context and consequences.
 
-- **GitHub issues**  
+* **GitHub issues**
   Capture discussion, exploration, and implementation tracking for each finding.
 
-- **Commits**  
+* **Commits**
   Implement the decisions in the codebase.
 
 This creates a traceable flow:
@@ -38,28 +38,28 @@ Code → Commit → Issue → Decision → Finding
 
 ### How to navigate
 
-- Start with **review findings** to understand current concerns
-- Follow links to **decisions** to see how those concerns were resolved
-- Use linked **issues** for detailed discussion and context
-- Refer to **commits** for the actual implementation
+* Start with **review findings** to understand current concerns
+* Follow links to **decisions** to see how those concerns were resolved
+* Use linked **issues** for detailed discussion and context
+* Refer to **commits** for the actual implementation
 
 ### Why this exists
 
 This structure ensures that:
 
-- architectural intent is preserved over time
-- decisions remain understandable after implementation
-- future changes can be made with confidence
-- contributors can quickly understand why the system is designed the way it is  
+* architectural intent is preserved over time
+* decisions remain understandable after implementation
+* future changes can be made with confidence
+* contributors can quickly understand why the system is designed the way it is
 
 ---
 
 ## Documents
 
-- `boundaries.md` — defines the canonical architecture, pipeline stages, and stage contracts
-- `review-findings.md` — findings discovered during architecture review
-- `decisions.md` — architectural decisions made during the review
-- `cleanup-tracker.md` — concrete cleanup and refactor tasks arising from findings
+* `boundaries.md` — defines the canonical architecture, pipeline stages, and stage contracts
+* `review-findings.md` — findings discovered during architecture review
+* `decisions.md` — architectural decisions made during the review
+* `cleanup-tracker.md` — concrete cleanup and refactor tasks arising from findings
 
 ---
 
@@ -70,6 +70,8 @@ Retromount is built around a single, unified processing pipeline:
 Input → Identify → Decode (`DecodedContent`) → Normalize (`NormalizedContent`) → Present → Encode → VFS
 
 All execution modes (preview, inspect, and runtime) use this pipeline.
+
+The VFS can be exposed to consumers via platform-specific adapters, including a Linux FUSE adapter.
 
 There is no alternative orchestration path.
 
@@ -87,9 +89,9 @@ The pipeline is the core abstraction of the system. Each stage has a clearly def
 
 Content is ingested via `InputSource` implementations, which are responsible for:
 
-- enumerating files and archive contents
-- abstracting over container formats (filesystem, ZIP, etc.)
-- producing a stream of input items
+* enumerating files and archive contents
+* abstracting over container formats (filesystem, ZIP, etc.)
+* producing a stream of input items
 
 This replaces the earlier loader-based discovery model.
 
@@ -112,10 +114,10 @@ Retromount separates decoded content from normalized content.
 
 Key types include:
 
-- `DecodedContent`
-- `NormalizedContent`
-- `GameContent`
-- `GamePart`
+* `DecodedContent`
+* `NormalizedContent`
+* `GameContent`
+* `GamePart`
 
 This split ensures that decoded artifacts and normalized semantic entities are not represented by the same top-level model.
 
@@ -127,8 +129,8 @@ The output stage transforms normalized content into a virtual filesystem represe
 
 Within that stage:
 
-- the presenter determines structure, grouping, and layout
-- the encoder materializes individual output files
+* the presenter determines structure, grouping, and layout
+* the encoder materializes individual output files
 
 In the default implementation, the presenter composes an encoder while constructing the VFS tree.
 
@@ -136,28 +138,44 @@ Together, they produce the final VFS tree exposed to consumers.
 
 Key components:
 
-- `OutputPresenter`
-- `GenericPresenter`
-- `BasicEncoder`
-- `VfsDirectory`
-- `VfsFile`
+* `OutputPresenter`
+* `GenericPresenter`
+* `BasicEncoder`
+* `VfsDirectory`
+* `VfsFile`
 
 This layer defines how the content is presented to consumers.
 
 ---
 
+### Filesystem adapters
+
+The VFS is exposed to external consumers via adapter layers.
+
+Current implementation:
+
+* Linux FUSE adapter (`fuser`-based)
+
+  * provides read-only filesystem access
+  * maps VFS nodes to inodes
+  * supports directory traversal and file reads
+
+This adapter layer is intentionally isolated from the core pipeline to preserve platform independence.
+
+---
+
 ## Design Goals
 
-- Single orchestration model  
+* Single orchestration model
   All processing flows through the pipeline
 
-- Clear separation of concerns  
+* Clear separation of concerns
   Each stage has a distinct and well-defined responsibility
 
-- Presentation-independent core model  
+* Presentation-independent core model
   Internal representations are not tied to output formats
 
-- Extensibility  
+* Extensibility
   New input sources, decoders, and output formats can be added without breaking existing stages
 
 ---
@@ -166,11 +184,11 @@ This layer defines how the content is presented to consumers.
 
 Earlier versions of Retromount used a loader-based architecture involving:
 
-- Loader
-- InputRegistry
-- InputHandler
-- VirtualFile
-- GameImage
+* Loader
+* InputRegistry
+* InputHandler
+* VirtualFile
+* GameImage
 
 This model introduced a second orchestration path and blurred architectural boundaries.
 
@@ -182,16 +200,17 @@ As part of D-002, this system has been removed in favour of the unified pipeline
 
 The architecture review work in this directory aims to:
 
-- clarify layer boundaries
-- identify confusing or redundant structures
-- remove obsolete or transitional code
-- ensure the system is aligned with a pipeline-first design
-- prepare the codebase for future extensibility (including plugin-style architecture)
+* clarify layer boundaries
+* identify confusing or redundant structures
+* remove obsolete or transitional code
+* ensure the system is aligned with a pipeline-first design
+* prepare the codebase for future extensibility (including plugin-style architecture)
 
 ---
 
 ## Next Focus Areas
 
-- review the next architectural boundary concern after D-005
-- improve module-level documentation
-- introduce diagrams for better visualization of the pipeline
+* review the next architectural boundary concern after D-005
+* improve module-level documentation
+* introduce diagrams for better visualization of the pipeline
+* refine filesystem adapter behaviour and performance (e.g. read caching)

--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -1,6 +1,6 @@
 # Architecture Boundaries
 
-This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation and D-002 through D-005.
+This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation, D-002 through D-005 and Phase4A FUSE implementation.
 
 ---
 
@@ -129,7 +129,7 @@ The Presenter must **not**:
 - generate file contents
 - perform representation-specific transformations
 
-In the default Phase 3 implementation, the presenter composes an encoder while constructing the VFS tree.
+In the default implementation, the presenter composes an encoder while constructing the VFS tree.
 
 Conceptually:
 

--- a/docs/architecture/cleanup-tracker.md
+++ b/docs/architecture/cleanup-tracker.md
@@ -69,6 +69,8 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 - [x] Review default encoder/presenter composition strategy
 - [ ] Remove dead code and unused helpers after refactors
 - [ ] Audit test coverage for new encoder boundary
+- [ ] Audit test coverage for FUSE adapter behaviour
+- [ ] Review FUSE error mapping and logging
 
 ---
 

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -243,6 +243,7 @@ The Presenter/Encoder boundary is now enforced in code, with no remaining respon
 **Date:** 2026-03-26  
 **Status:** Implemented  
 **Related:** F-004
+**Issue:** [#44](https://github.com/lloydsmart/retromount/issues/44)
 
 ### D-004 Context
 

--- a/docs/architecture/fuse.md
+++ b/docs/architecture/fuse.md
@@ -1,0 +1,34 @@
+# FUSE Integration
+
+## Overview
+
+Phase 4A introduces a Linux FUSE adapter that exposes the Retromount VFS as a read-only filesystem.
+
+The design maintains a strict separation between:
+
+- core pipeline and VFS logic
+- platform-specific filesystem adapters
+
+## Key Components
+
+### MountSession
+
+Provides an indexed, inode-based representation of the VFS:
+
+- stable inode allocation
+- parent/child relationships
+- efficient lookup and traversal
+
+### RetromountFuseFs
+
+Implements the `fuser::Filesystem` trait:
+
+- `lookup`, `getattr`, `readdir` for directory traversal
+- `open`, `read` for file access
+
+### VFS Reader Integration
+
+File reads are delegated to:
+
+```text
+open_vfs_file -> Reader -> read_at(offset, buffer)

--- a/docs/architecture/fuse.md
+++ b/docs/architecture/fuse.md
@@ -28,7 +28,36 @@ Implements the `fuser::Filesystem` trait:
 
 ### VFS Reader Integration
 
-File reads are delegated to:
+File reads are delegated through the existing VFS reader pipeline:
 
-```text
-open_vfs_file -> Reader -> read_at(offset, buffer)
+`open_vfs_file → Reader → read_at(offset, buffer)`
+
+This keeps filesystem adapter code thin and reuses the existing VFS-backed reader stack rather than introducing FUSE-specific file decoding logic.
+
+## Boundary Notes
+
+The FUSE adapter must not:
+
+- reimplement pipeline stages
+- reinterpret normalized content
+- make presentation or encoding decisions
+- bypass VFS reader abstractions
+
+The FUSE layer is an adapter over the already-materialized VFS, not an alternative execution path.
+
+## Current Scope
+
+Phase 4A provides:
+
+- Linux-only FUSE mounting
+- read-only filesystem access
+- inode-based directory traversal
+- file reads backed by the Retromount VFS reader layer
+
+## Future Enhancements
+
+Potential future improvements include:
+
+- caching and read-performance optimisations
+- improved mount diagnostics and logging
+- additional platform adapter implementations

--- a/docs/architecture/review-findings.md
+++ b/docs/architecture/review-findings.md
@@ -115,46 +115,54 @@ Implementation was performed on branch: `feature/pipeline-orchestration-consolid
 
 ---
 
-## F-003: Presenter and encoder responsibilities are not yet sharply defined
+## F-003: Presenter and encoder responsibilities were not sharply defined
 
-**Status:** Open  
-**Issue:** [#43](https://github.com/lloydsmart/retromount/issues/43)
+**Status:** Resolved  
+**Issue:** [#43](https://github.com/lloydsmart/retromount/issues/43)  
+**Resolved by:** D-003
 
 ### F-003 Context
 
-The current output side of the architecture includes both presenter and encoder concepts, but the boundary between them is not yet fully clear.
+The output side of the architecture included both presenter and encoder concepts, but the boundary between them was not initially explicit.
 
-In particular, naming, output structure, and representation logic may currently be split across these layers in ways that are harder to reason about than necessary.
+In particular, naming, output structure, and representation logic were split across these layers in ways that were harder to reason about than necessary.
 
 ### F-003 Evidence
 
 - the project contains a presenter abstraction and a concrete `GenericPresenter`
 - the project contains an encoder abstraction and a concrete `BasicEncoder`
-- output concerns such as file naming, output layout, and content representation appear to involve both layers
-- future Phase 4 work is expected to expand output/view behavior, increasing the importance of a clean separation here
+- output concerns such as file naming, output layout, and content representation were previously distributed across both layers
+- future output/view work increased the need for a clean and enforceable separation
 
 ### F-003 Why it matters
 
-If presenter and encoder responsibilities are unclear, future view work will be harder to implement cleanly.
+If presenter and encoder responsibilities are unclear, output behaviour becomes harder to extend and reason about.
 
 This affects:
 
-- where output structure should be decided
-- where file naming should be decided
-- where content representation/translation should be decided
-- whether future output customizations can be added without modifying core logic
+- where output structure is decided
+- where file naming is decided
+- where content representation and transformation are decided
+- whether alternate output customizations can be introduced without modifying core logic
 
-A weak boundary also makes plugin-style extensibility more difficult, because it becomes unclear which interface a new output behavior should target.
+A weak boundary also makes plugin-style extensibility more difficult, because it becomes unclear which interface new output behaviour should target.
 
 ### F-003 Options
 
-- Define presenters as responsible for structure and encoders as responsible for representation/naming details
-- Define presenters as pure view builders and move most filename/output translation logic into encoders
-- Collapse the distinction if both abstractions are not providing enough independent value
+- define presenters as responsible for structure and encoders as responsible for representation and naming details
+- define presenters as pure view builders and move most filename/output translation logic into encoders
+- collapse the distinction if both abstractions do not provide enough independent value
 
 ### F-003 Decision
 
-TBD
+Resolved by D-003.
+
+Retromount retains both Presenter and Encoder abstractions with a strict responsibility boundary:
+
+- Presenter owns structure, grouping, and layout
+- Encoder owns naming, representation, file backing, and generated file content
+
+This boundary is now enforced in code, with no remaining responsibility overlap.
 
 ---
 

--- a/docs/roadmap/phase4-roadmap.md
+++ b/docs/roadmap/phase4-roadmap.md
@@ -29,19 +29,19 @@ It does **not**:
 
 ## Phase 4A — Mountable Filesystem
 
-### Goal
+### Phase 4A Goal
 
 Expose the Virtual File System (VFS) as a real, read-only filesystem via FUSE.
 
 ---
 
-### Branch
+### Phase 4A Branch
 
 feature/phase4a-fuse-mount
 
 ---
 
-### Success Criteria
+### Phase 4A Success Criteria
 
 * `retromount mount <input> <mountpoint>` works
 * Directories can be browsed (`ls`)
@@ -53,7 +53,7 @@ feature/phase4a-fuse-mount
 
 ---
 
-### Work Items
+### Phase 4A Work Items
 
 * CLI mount command
 * FUSE adapter layer
@@ -64,7 +64,7 @@ feature/phase4a-fuse-mount
 
 ---
 
-### Implementation Order
+### Phase 4A Implementation Order
 
 1. Mount command scaffold
 2. Mount session / indexing layer
@@ -74,7 +74,7 @@ feature/phase4a-fuse-mount
 
 ---
 
-### Commit Slices
+### Phase 4A Commit Slices
 
 * feat(cli): add mount command scaffold
 * feat(mount): add mount session index for VFS nodes
@@ -85,7 +85,7 @@ feature/phase4a-fuse-mount
 
 ---
 
-### Progress Checklist
+### Phase 4A Progress Checklist
 
 * [ ] mount command added
 * [ ] FUSE adapter created
@@ -99,7 +99,7 @@ feature/phase4a-fuse-mount
 
 ---
 
-### Notes
+### Phase 4A Notes
 
 * This phase is both implementation and validation
 * If architectural gaps are discovered, fix them in core rather than working around them in the adapter
@@ -109,19 +109,19 @@ feature/phase4a-fuse-mount
 
 ## Phase 4B — Consumer Views
 
-### Goal
+### Phase 4B Goal
 
 Support multiple filesystem layouts for different consumers without changing core normalization.
 
 ---
 
-### Branch (suggested)
+### Phase 4B Branch
 
 feature/phase4b-consumer-views
 
 ---
 
-### Success Criteria
+### Phase 4B Success Criteria
 
 * Multiple presentation strategies supported
 * Same input can produce different layouts
@@ -129,7 +129,7 @@ feature/phase4b-consumer-views
 
 ---
 
-### Work Items
+### Phase 4B Work Items
 
 * View abstraction layer
 * At least two layouts (e.g. grouped vs flat)
@@ -139,19 +139,19 @@ feature/phase4b-consumer-views
 
 ## Phase 4C — Presentation Policy
 
-### Goal
+### Phase 4C Goal
 
 Make output deterministic, predictable, and configurable.
 
 ---
 
-### Branch (suggested)
+### Phase 4C Branch
 
 feature/phase4c-presentation-policy
 
 ---
 
-### Success Criteria
+### Phase 4C Success Criteria
 
 * Stable naming rules
 * Clear handling of duplicates and ambiguity
@@ -159,7 +159,7 @@ feature/phase4c-presentation-policy
 
 ---
 
-### Work Items
+### Phase 4C Work Items
 
 * Naming policy
 * Conflict resolution rules
@@ -169,19 +169,19 @@ feature/phase4c-presentation-policy
 
 ## Phase 4D — Plugin System (Deferred)
 
-### Goal
+### Phase 4D Goal
 
 Enable external extensions to the pipeline (inputs, transforms, outputs).
 
 ---
 
-### Branch (future)
+### Phase 4D Branch
 
 feature/plugin-system
 
 ---
 
-### Success Criteria
+### Phase 4D Success Criteria
 
 * External components can integrate via stable interfaces
 * Interfaces validated by Phase 4A–4C work

--- a/docs/roadmap/phase4-roadmap.md
+++ b/docs/roadmap/phase4-roadmap.md
@@ -1,0 +1,202 @@
+# Phase 4 Roadmap
+
+This document defines the planned evolution of Retromount following completion of Phase 3 and the architecture/plugin readiness reviews.
+
+It is intentionally concise and focused on execution.
+
+---
+
+## Scope
+
+Retromount is a filesystem-oriented transformation and presentation layer for retro content collections.
+
+It:
+
+* normalizes existing content
+* reorganizes it
+* exposes it for different consumers
+
+It does **not**:
+
+* scrape metadata
+* download artwork or assets
+* manage ROM libraries
+* replace ROM managers
+
+> Retromount projects collections. It does not curate them.
+
+---
+
+## Phase 4A — Mountable Filesystem
+
+### Goal
+
+Expose the Virtual File System (VFS) as a real, read-only filesystem via FUSE.
+
+---
+
+### Branch
+
+feature/phase4a-fuse-mount
+
+---
+
+### Success Criteria
+
+* `retromount mount <input> <mountpoint>` works
+* Directories can be browsed (`ls`)
+* Files can be read (`cat`, emulator, etc.)
+* Output matches `preview` / `inspect`
+* Multi-disc handling and playlists behave correctly
+* Read-only filesystem
+* No FUSE-specific logic leaks into core abstractions
+
+---
+
+### Work Items
+
+* CLI mount command
+* FUSE adapter layer
+* Mount session (inode/path index)
+* Directory operations (`lookup`, `readdir`, `getattr`)
+* File operations (`open`, `read`)
+* Real-world validation
+
+---
+
+### Implementation Order
+
+1. Mount command scaffold
+2. Mount session / indexing layer
+3. Directory traversal
+4. File read support
+5. Validation and hardening
+
+---
+
+### Commit Slices
+
+* feat(cli): add mount command scaffold
+* feat(mount): add mount session index for VFS nodes
+* feat(fuse): implement read-only directory traversal
+* feat(fuse): implement regular file reads
+* test(mount): add VFS indexing coverage
+* docs: document phase4a mount scope
+
+---
+
+### Progress Checklist
+
+* [ ] mount command added
+* [ ] FUSE adapter created
+* [ ] mount session/index implemented
+* [ ] directory traversal works
+* [ ] file reads work
+* [ ] tested with shell tools
+* [ ] tested with a real consumer
+* [ ] core refactors kept separate from adapter glue
+* [ ] documentation updated
+
+---
+
+### Notes
+
+* This phase is both implementation and validation
+* If architectural gaps are discovered, fix them in core rather than working around them in the adapter
+* Keep scope tightly limited to read-only filesystem support
+
+---
+
+## Phase 4B — Consumer Views
+
+### Goal
+
+Support multiple filesystem layouts for different consumers without changing core normalization.
+
+---
+
+### Branch (suggested)
+
+feature/phase4b-consumer-views
+
+---
+
+### Success Criteria
+
+* Multiple presentation strategies supported
+* Same input can produce different layouts
+* Core pipeline remains unchanged
+
+---
+
+### Work Items
+
+* View abstraction layer
+* At least two layouts (e.g. grouped vs flat)
+* CLI or config selection of view
+
+---
+
+## Phase 4C — Presentation Policy
+
+### Goal
+
+Make output deterministic, predictable, and configurable.
+
+---
+
+### Branch (suggested)
+
+feature/phase4c-presentation-policy
+
+---
+
+### Success Criteria
+
+* Stable naming rules
+* Clear handling of duplicates and ambiguity
+* Configurable behaviour (lightweight)
+
+---
+
+### Work Items
+
+* Naming policy
+* Conflict resolution rules
+* Optional filtering based on existing data
+
+---
+
+## Phase 4D — Plugin System (Deferred)
+
+### Goal
+
+Enable external extensions to the pipeline (inputs, transforms, outputs).
+
+---
+
+### Branch (future)
+
+feature/plugin-system
+
+---
+
+### Success Criteria
+
+* External components can integrate via stable interfaces
+* Interfaces validated by Phase 4A–4C work
+
+---
+
+## Guiding Principle
+
+Phase 3 proved the model.
+Phase 4 proves the model works in reality.
+
+---
+
+## Maintenance Rules
+
+* This is a living document — update it if reality diverges
+* If scope changes, document why
+* Keep phases focused and bounded

--- a/docs/roadmap/phase4-roadmap.md
+++ b/docs/roadmap/phase4-roadmap.md
@@ -25,6 +25,8 @@ It does **not**:
 
 > Retromount projects collections. It does not curate them.
 
+Phase 4 introduces real filesystem exposure of these projections.
+
 ---
 
 ## Phase 4A — Mountable Filesystem
@@ -32,6 +34,8 @@ It does **not**:
 ### Phase 4A Goal
 
 Expose the Virtual File System (VFS) as a real, read-only filesystem via FUSE.
+
+#### Status: Complete
 
 ---
 
@@ -43,13 +47,13 @@ feature/phase4a-fuse-mount
 
 ### Phase 4A Success Criteria
 
-* `retromount mount <input> <mountpoint>` works
-* Directories can be browsed (`ls`)
-* Files can be read (`cat`, emulator, etc.)
-* Output matches `preview` / `inspect`
-* Multi-disc handling and playlists behave correctly
-* Read-only filesystem
-* No FUSE-specific logic leaks into core abstractions
+* [x] `retromount mount <input> <mountpoint>` works
+* [x] directories can be browsed (`ls`, `tree`, `find`)
+* [x] files can be read (`cat`, `head`, emulator, etc.)
+* [x] output matches `preview` / `inspect`
+* [x] multi-disc handling and playlists behave correctly
+* [x] filesystem is read-only
+* [x] no FUSE-specific logic leaks into core abstractions
 
 ---
 
@@ -87,15 +91,28 @@ feature/phase4a-fuse-mount
 
 ### Phase 4A Progress Checklist
 
-* [ ] mount command added
-* [ ] FUSE adapter created
-* [ ] mount session/index implemented
-* [ ] directory traversal works
-* [ ] file reads work
-* [ ] tested with shell tools
+* [x] mount command added
+* [x] FUSE adapter created
+* [x] mount session/index implemented
+* [x] directory traversal works
+* [x] file reads work
+* [x] tested with shell tools
 * [ ] tested with a real consumer
-* [ ] core refactors kept separate from adapter glue
-* [ ] documentation updated
+* [x] core refactors kept separate from adapter glue
+* [x] documentation updated
+
+---
+
+### Phase 4A Validation
+
+Validated on a real Linux host:
+
+* mounted filesystem is browsable (`tree`, `find`)
+* file metadata reports correct sizes
+* generated inline files (e.g. `.m3u`) are readable
+* source-backed files (e.g. ROMs, disc images) are readable
+* repeated reads succeed consistently
+* directory reads fail as expected
 
 ---
 
@@ -104,6 +121,8 @@ feature/phase4a-fuse-mount
 * This phase is both implementation and validation
 * If architectural gaps are discovered, fix them in core rather than working around them in the adapter
 * Keep scope tightly limited to read-only filesystem support
+* current implementation reopens files on each `read()` call
+* performance optimisations (reader caching) are planned as follow-up work
 
 ---
 

--- a/src/core/vfs_reader.rs
+++ b/src/core/vfs_reader.rs
@@ -115,4 +115,50 @@ mod tests {
         assert_eq!(bytes, 9);
         assert_eq!(&buf, b"zip hello");
     }
+
+    #[test]
+    fn reads_inline_backed_vfs_file_from_offset() {
+        let file = VfsFile::inline("game.m3u", b"disc1.cue\ndisc2.cue\n".to_vec());
+
+        let mut reader = open_vfs_file(&file).unwrap();
+        let mut buf = vec![0; 8];
+        let bytes = reader.read_at(5, &mut buf).unwrap();
+
+        assert_eq!(bytes, 8);
+        assert_eq!(&buf, b".cue\ndis");
+    }
+
+    #[test]
+    fn reads_zip_backed_vfs_file_from_offset() {
+        use std::fs::File;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let zip_path = temp_dir.path().join("library.zip");
+
+        {
+            let file = File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default();
+
+            zip.start_file("docs/readme.txt", options).unwrap();
+            zip.write_all(b"zip hello").unwrap();
+            zip.finish().unwrap();
+        }
+
+        let file = VfsFile::source_backed(
+            "docs/readme.txt",
+            9,
+            SourceRef::new(format!(
+                "zip:{}#docs/readme.txt",
+                zip_path.to_string_lossy()
+            )),
+        );
+
+        let mut reader = open_vfs_file(&file).unwrap();
+        let mut buf = vec![0; 4];
+        let bytes = reader.read_at(4, &mut buf).unwrap();
+
+        assert_eq!(bytes, 4);
+        assert_eq!(&buf, b"hell");
+    }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,4 +1,5 @@
 pub mod components;
 pub mod inspect;
+pub mod mount;
 pub mod pipeline;
 pub mod preview;

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -1,11 +1,13 @@
 use std::path::Path;
 
+use fuser::mount2;
 use log::info;
 
 use crate::engine::components::default_pipeline_components;
 use crate::engine::pipeline::run_pipeline;
 use crate::engine::preview::build_input_source;
 use crate::error::RetromountError;
+use crate::mount::fuse_fs::RetromountFuseFs;
 use crate::mount::session::MountSession;
 
 pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), RetromountError> {
@@ -31,8 +33,8 @@ pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), Retromou
     info!("Root inode: {}", session.root_inode());
     info!("Root child entries: {}", root_children);
 
-    Err(RetromountError::LoadError(format!(
-        "mount is not implemented yet for mountpoint: {}",
-        mountpoint.display()
-    )))
+    let fs = RetromountFuseFs::new(session);
+
+    mount2(fs, mountpoint, &RetromountFuseFs::mount_options())
+        .map_err(|err| RetromountError::LoadError(err.to_string()))
 }

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -9,10 +9,9 @@ use crate::error::RetromountError;
 use crate::mount::session::MountSession;
 
 #[cfg(target_os = "linux")]
-use crate::mount::fuse_fs::RetromountFuseFs;
-
+use crate::mount::adapter::FilesystemAdapter;
 #[cfg(target_os = "linux")]
-use fuser::mount2;
+use crate::mount::fuse_fs::RetromountFuseFs;
 
 pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), RetromountError> {
     let source = build_input_source(input)?;
@@ -42,10 +41,7 @@ pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), Retromou
 
 #[cfg(target_os = "linux")]
 fn mount_session(session: MountSession, mountpoint: &Path) -> Result<(), RetromountError> {
-    let fs = RetromountFuseFs::new(session);
-    let config = RetromountFuseFs::config();
-
-    mount2(fs, mountpoint, &config).map_err(|err| RetromountError::LoadError(err.to_string()))
+    RetromountFuseFs::new(session).mount(mountpoint)
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -47,7 +47,7 @@ fn mount_session(session: MountSession, mountpoint: &Path) -> Result<(), Retromo
 #[cfg(not(target_os = "linux"))]
 fn mount_session(_session: MountSession, mountpoint: &Path) -> Result<(), RetromountError> {
     Err(RetromountError::LoadError(format!(
-        "mount is only supported on Linux; cannot mount to {} on this platform",
+        "mount is only supported on Linux (FUSE); cannot mount to {} on this platform. Try `retromount phase3-preview <path>` instead.",
         mountpoint.display()
     )))
 }

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -6,6 +6,7 @@ use crate::engine::components::default_pipeline_components;
 use crate::engine::pipeline::run_pipeline;
 use crate::engine::preview::build_input_source;
 use crate::error::RetromountError;
+use crate::mount::session::MountSession;
 
 pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), RetromountError> {
     let source = build_input_source(input)?;
@@ -18,9 +19,17 @@ pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), Retromou
         components.presenter.as_ref(),
     )?;
 
+    let session = MountSession::from_root(&root);
+    let root_children = session
+        .children(session.root_inode())
+        .map(|children| children.len())
+        .unwrap_or(0);
+
     info!("Prepared mount input: {}", input.display());
     info!("Prepared mountpoint: {}", mountpoint.display());
-    info!("Top-level VFS entries: {}", root.children().len());
+    info!("Indexed VFS nodes: {}", session.node_count());
+    info!("Root inode: {}", session.root_inode());
+    info!("Root child entries: {}", root_children);
 
     Err(RetromountError::LoadError(format!(
         "mount is not implemented yet for mountpoint: {}",

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -1,14 +1,18 @@
 use std::path::Path;
 
-use fuser::mount2;
 use log::info;
 
 use crate::engine::components::default_pipeline_components;
 use crate::engine::pipeline::run_pipeline;
 use crate::engine::preview::build_input_source;
 use crate::error::RetromountError;
-use crate::mount::fuse_fs::RetromountFuseFs;
 use crate::mount::session::MountSession;
+
+#[cfg(target_os = "linux")]
+use crate::mount::fuse_fs::RetromountFuseFs;
+
+#[cfg(target_os = "linux")]
+use fuser::mount2;
 
 pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), RetromountError> {
     let source = build_input_source(input)?;
@@ -33,8 +37,21 @@ pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), Retromou
     info!("Root inode: {}", session.root_inode());
     info!("Root child entries: {}", root_children);
 
+    mount_session(session, mountpoint)
+}
+
+#[cfg(target_os = "linux")]
+fn mount_session(session: MountSession, mountpoint: &Path) -> Result<(), RetromountError> {
     let fs = RetromountFuseFs::new(session);
     let config = RetromountFuseFs::config();
 
     mount2(fs, mountpoint, &config).map_err(|err| RetromountError::LoadError(err.to_string()))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn mount_session(_session: MountSession, mountpoint: &Path) -> Result<(), RetromountError> {
+    Err(RetromountError::LoadError(format!(
+        "mount is only supported on Linux; cannot mount to {} on this platform",
+        mountpoint.display()
+    )))
 }

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -34,7 +34,7 @@ pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), Retromou
     info!("Root child entries: {}", root_children);
 
     let fs = RetromountFuseFs::new(session);
+    let config = RetromountFuseFs::config();
 
-    mount2(fs, mountpoint, &RetromountFuseFs::mount_options())
-        .map_err(|err| RetromountError::LoadError(err.to_string()))
+    mount2(fs, mountpoint, &config).map_err(|err| RetromountError::LoadError(err.to_string()))
 }

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -1,0 +1,29 @@
+use std::path::Path;
+
+use log::info;
+
+use crate::engine::components::default_pipeline_components;
+use crate::engine::pipeline::run_pipeline;
+use crate::engine::preview::build_input_source;
+use crate::error::RetromountError;
+
+pub fn run_mount_command(input: &Path, mountpoint: &Path) -> Result<(), RetromountError> {
+    let source = build_input_source(input)?;
+    let components = default_pipeline_components();
+
+    let root = run_pipeline(
+        source.as_ref(),
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        components.presenter.as_ref(),
+    )?;
+
+    info!("Prepared mount input: {}", input.display());
+    info!("Prepared mountpoint: {}", mountpoint.display());
+    info!("Top-level VFS entries: {}", root.children().len());
+
+    Err(RetromountError::LoadError(format!(
+        "mount is not implemented yet for mountpoint: {}",
+        mountpoint.display()
+    )))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod core;
 pub mod engine;
 pub mod error;
 pub mod input;
+pub mod mount;
 pub mod output;
 pub mod readers;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
 use log::{debug, info};
 use std::path::PathBuf;
 
-use retromount::core::content::{
-    ContentMeta, GamePart, NormalizedContent, Platform as ContentPlatform,
-};
+use retromount::core::content::{GamePart, NormalizedContent, Platform as ContentPlatform};
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
 use retromount::engine::components::default_pipeline_components;
 use retromount::engine::inspect::run_phase3_inspect;
+use retromount::engine::mount::run_mount_command;
 use retromount::engine::pipeline::run_pipeline_with_options;
 use retromount::engine::preview::{build_input_source, run_phase3_preview, write_vfs_tree};
 use retromount::{RetromountError, ViewConfig};
@@ -33,8 +32,13 @@ fn main() -> Result<(), RetromountError> {
             let path = PathBuf::from(path);
             run_phase3_inspect(&path, true)
         }
+        [command, input, mountpoint] if command.to_string_lossy() == "mount" => {
+            let input = PathBuf::from(input);
+            let mountpoint = PathBuf::from(mountpoint);
+            run_mount_command(&input, &mountpoint)
+        }
         _ => Err(RetromountError::LoadError(
-            "usage:\n  retromount\n  retromount phase3-preview <path>\n  retromount inspect <path> [--json]"
+            "usage:\n  retromount\n  retromount phase3-preview <path>\n  retromount inspect <path> [--json]\n  retromount mount <input> <mountpoint>"
                 .to_string(),
         )),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use log::{debug, info};
 use std::path::PathBuf;
 
-use retromount::core::content::{GamePart, NormalizedContent, Platform as ContentPlatform};
+use retromount::core::content::{
+    ContentMeta, GamePart, NormalizedContent, Platform as ContentPlatform,
+};
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
 use retromount::engine::components::default_pipeline_components;

--- a/src/mount/adapter.rs
+++ b/src/mount/adapter.rs
@@ -1,0 +1,7 @@
+use std::path::Path;
+
+use crate::error::RetromountError;
+
+pub trait FilesystemAdapter {
+    fn mount(self, mountpoint: &Path) -> Result<(), RetromountError>;
+}

--- a/src/mount/fuse_fs.rs
+++ b/src/mount/fuse_fs.rs
@@ -1,12 +1,15 @@
 use std::ffi::OsStr;
 use std::io;
+use std::path::Path;
 use std::time::{Duration, SystemTime};
 
 use fuser::{
-    Config, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, KernelConfig,
+    mount2, Config, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, KernelConfig,
     ReplyAttr, ReplyDirectory, ReplyEntry, Request,
 };
 
+use crate::error::RetromountError;
+use crate::mount::adapter::FilesystemAdapter;
 use crate::mount::session::{MountNode, MountNodeKind, MountSession};
 
 const TTL: Duration = Duration::from_secs(1);
@@ -61,6 +64,13 @@ impl RetromountFuseFs {
             blksize: 4096,
             flags: 0,
         }
+    }
+}
+
+impl FilesystemAdapter for RetromountFuseFs {
+    fn mount(self, mountpoint: &Path) -> Result<(), RetromountError> {
+        let config = Self::config();
+        mount2(self, mountpoint, &config).map_err(|err| RetromountError::LoadError(err.to_string()))
     }
 }
 

--- a/src/mount/fuse_fs.rs
+++ b/src/mount/fuse_fs.rs
@@ -4,10 +4,12 @@ use std::path::Path;
 use std::time::{Duration, SystemTime};
 
 use fuser::{
-    mount2, Config, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, KernelConfig,
-    ReplyAttr, ReplyDirectory, ReplyEntry, Request,
+    mount2, Config, FileAttr, FileHandle, FileType, Filesystem, FopenFlags, Generation, INodeNo,
+    KernelConfig, LockOwner, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry,
+    ReplyOpen, Request,
 };
 
+use crate::core::vfs_reader::open_vfs_file;
 use crate::error::RetromountError;
 use crate::mount::adapter::FilesystemAdapter;
 use crate::mount::session::{MountNode, MountNodeKind, MountSession};
@@ -30,7 +32,7 @@ impl RetromountFuseFs {
     fn file_attr_for_node(&self, node: &MountNode) -> FileAttr {
         let kind = match node.kind {
             MountNodeKind::Directory { .. } => FileType::Directory,
-            MountNodeKind::File => FileType::RegularFile,
+            MountNodeKind::File { .. } => FileType::RegularFile,
         };
 
         let perm = match kind {
@@ -39,15 +41,15 @@ impl RetromountFuseFs {
             _ => 0o444,
         };
 
-        let size = match node.kind {
+        let size = match &node.kind {
             MountNodeKind::Directory { .. } => 0,
-            MountNodeKind::File => 0,
+            MountNodeKind::File { file } => file.size,
         };
 
         FileAttr {
             ino: INodeNo(node.inode),
             size,
-            blocks: 0,
+            blocks: size.div_ceil(512),
             atime: SystemTime::UNIX_EPOCH,
             mtime: SystemTime::UNIX_EPOCH,
             ctime: SystemTime::UNIX_EPOCH,
@@ -64,6 +66,26 @@ impl RetromountFuseFs {
             blksize: 4096,
             flags: 0,
         }
+    }
+
+    fn read_file_range(&self, ino: u64, offset: u64, size: u32) -> Result<Vec<u8>, fuser::Errno> {
+        let Some(file) = self.session.file(ino) else {
+            return Err(fuser::Errno::EISDIR);
+        };
+
+        if offset >= file.size {
+            return Ok(Vec::new());
+        }
+
+        let mut reader = open_vfs_file(file).map_err(|_| fuser::Errno::EIO)?;
+        let mut buf = vec![0; size as usize];
+
+        let bytes_read = reader
+            .read_at(offset, &mut buf)
+            .map_err(|_| fuser::Errno::EIO)?;
+
+        buf.truncate(bytes_read);
+        Ok(buf)
     }
 }
 
@@ -104,6 +126,32 @@ impl Filesystem for RetromountFuseFs {
         reply.attr(&TTL, &attr);
     }
 
+    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        if self.session.file(ino.0).is_none() {
+            reply.error(fuser::Errno::EISDIR);
+            return;
+        }
+
+        reply.opened(FileHandle(ino.0), FopenFlags::empty());
+    }
+
+    fn read(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _fh: FileHandle,
+        offset: u64,
+        size: u32,
+        _flags: OpenFlags,
+        _lock_owner: Option<LockOwner>,
+        reply: ReplyData,
+    ) {
+        match self.read_file_range(ino.0, offset, size) {
+            Ok(data) => reply.data(&data),
+            Err(err) => reply.error(err),
+        };
+    }
+
     fn readdir(
         &self,
         _req: &Request,
@@ -137,7 +185,7 @@ impl Filesystem for RetromountFuseFs {
         for child in children {
             let file_type = match child.kind {
                 MountNodeKind::Directory { .. } => FileType::Directory,
-                MountNodeKind::File => FileType::RegularFile,
+                MountNodeKind::File { .. } => FileType::RegularFile,
             };
 
             entries.push((INodeNo(child.inode), file_type, child.name.clone()));

--- a/src/mount/fuse_fs.rs
+++ b/src/mount/fuse_fs.rs
@@ -203,3 +203,85 @@ impl Filesystem for RetromountFuseFs {
         reply.ok();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
+
+    fn inline_session() -> (MountSession, u64) {
+        let root = VfsDirectory::with_children(
+            "",
+            vec![VfsNode::File(VfsFile::inline(
+                "playlist.m3u",
+                b"disc1.cue\ndisc2.cue\n".to_vec(),
+            ))],
+        );
+
+        let session = MountSession::from_root(&root);
+        let inode = session
+            .lookup_child(session.root_inode(), "playlist.m3u")
+            .expect("expected inline file")
+            .inode;
+
+        (session, inode)
+    }
+
+    #[test]
+    fn read_file_range_reads_full_inline_file() {
+        let (session, ino) = inline_session();
+        let fs = RetromountFuseFs::new(session);
+
+        let data = fs
+            .read_file_range(ino, 0, 1024)
+            .expect("expected read to succeed");
+
+        assert_eq!(data, b"disc1.cue\ndisc2.cue\n");
+    }
+
+    #[test]
+    fn read_file_range_reads_partial_inline_file() {
+        let (session, ino) = inline_session();
+        let fs = RetromountFuseFs::new(session);
+
+        let data = fs
+            .read_file_range(ino, 5, 8)
+            .expect("expected partial read to succeed");
+
+        assert_eq!(data, b".cue\ndis");
+    }
+
+    #[test]
+    fn read_file_range_returns_empty_at_eof() {
+        let (session, ino) = inline_session();
+        let fs = RetromountFuseFs::new(session);
+
+        let data = fs
+            .read_file_range(ino, 20, 16)
+            .expect("expected eof read to succeed");
+
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn read_file_range_returns_error_for_directory_inode() {
+        let (session, _) = inline_session();
+        let fs = RetromountFuseFs::new(session);
+
+        let result = fs.read_file_range(fs.session.root_inode(), 0, 16);
+
+        assert!(result.is_err(), "expected directory read to fail");
+    }
+
+    #[test]
+    fn file_attr_uses_backing_file_size() {
+        let (session, ino) = inline_session();
+        let fs = RetromountFuseFs::new(session);
+
+        let node = fs.session.get(ino).expect("expected mounted node");
+        let attr = fs.file_attr_for_node(node);
+
+        assert_eq!(attr.size, b"disc1.cue\ndisc2.cue\n".len() as u64);
+        assert_eq!(attr.kind, FileType::RegularFile);
+    }
+}

--- a/src/mount/fuse_fs.rs
+++ b/src/mount/fuse_fs.rs
@@ -1,13 +1,13 @@
 use std::ffi::OsStr;
+use std::io;
 use std::time::{Duration, SystemTime};
 
 use fuser::{
-    FileAttr, FileType, Filesystem, KernelConfig, MountOption, ReplyAttr, ReplyDirectory,
-    ReplyEntry, Request,
+    Config, FileAttr, FileHandle, FileType, Filesystem, Generation, INodeNo, KernelConfig,
+    ReplyAttr, ReplyDirectory, ReplyEntry, Request,
 };
-use libc::{EIO, ENOENT};
 
-use crate::mount::session::{MountNodeKind, MountSession};
+use crate::mount::session::{MountNode, MountNodeKind, MountSession};
 
 const TTL: Duration = Duration::from_secs(1);
 
@@ -20,15 +20,11 @@ impl RetromountFuseFs {
         Self { session }
     }
 
-    pub fn mount_options() -> Vec<MountOption> {
-        vec![
-            MountOption::RO,
-            MountOption::FSName("retromount".to_string()),
-            MountOption::DefaultPermissions,
-        ]
+    pub fn config() -> Config {
+        Config::default()
     }
 
-    fn file_attr_for_node(&self, node: &crate::mount::session::MountNode) -> FileAttr {
+    fn file_attr_for_node(&self, node: &MountNode) -> FileAttr {
         let kind = match node.kind {
             MountNodeKind::Directory { .. } => FileType::Directory,
             MountNodeKind::File => FileType::RegularFile,
@@ -46,7 +42,7 @@ impl RetromountFuseFs {
         };
 
         FileAttr {
-            ino: node.inode,
+            ino: INodeNo(node.inode),
             size,
             blocks: 0,
             atime: SystemTime::UNIX_EPOCH,
@@ -69,28 +65,28 @@ impl RetromountFuseFs {
 }
 
 impl Filesystem for RetromountFuseFs {
-    fn init(&mut self, _req: &Request<'_>, _config: &mut KernelConfig) -> Result<(), libc::c_int> {
+    fn init(&mut self, _req: &Request, _config: &mut KernelConfig) -> io::Result<()> {
         Ok(())
     }
 
-    fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         let Some(name) = name.to_str() else {
-            reply.error(ENOENT);
+            reply.error(fuser::Errno::ENOENT);
             return;
         };
 
-        let Some(node) = self.session.lookup_child(parent, name) else {
-            reply.error(ENOENT);
+        let Some(node) = self.session.lookup_child(parent.0, name) else {
+            reply.error(fuser::Errno::ENOENT);
             return;
         };
 
         let attr = self.file_attr_for_node(node);
-        reply.entry(&TTL, &attr, 0);
+        reply.entry(&TTL, &attr, Generation(0));
     }
 
-    fn getattr(&mut self, _req: &Request<'_>, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
-        let Some(node) = self.session.get(ino) else {
-            reply.error(ENOENT);
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+        let Some(node) = self.session.get(ino.0) else {
+            reply.error(fuser::Errno::ENOENT);
             return;
         };
 
@@ -99,34 +95,34 @@ impl Filesystem for RetromountFuseFs {
     }
 
     fn readdir(
-        &mut self,
-        _req: &Request<'_>,
-        ino: u64,
-        _fh: u64,
-        offset: i64,
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _fh: FileHandle,
+        offset: u64,
         mut reply: ReplyDirectory,
     ) {
-        let Some(node) = self.session.get(ino) else {
-            reply.error(ENOENT);
+        let Some(node) = self.session.get(ino.0) else {
+            reply.error(fuser::Errno::ENOENT);
             return;
         };
 
         let MountNodeKind::Directory { .. } = &node.kind else {
-            reply.error(ENOENT);
+            reply.error(fuser::Errno::ENOENT);
             return;
         };
 
-        let Some(children) = self.session.children(ino) else {
-            reply.error(EIO);
+        let Some(children) = self.session.children(ino.0) else {
+            reply.error(fuser::Errno::EIO);
             return;
         };
 
-        let mut entries: Vec<(u64, FileType, String)> = Vec::new();
+        let mut entries: Vec<(INodeNo, FileType, String)> = Vec::new();
 
         entries.push((ino, FileType::Directory, ".".to_string()));
 
-        let parent_inode = node.parent_inode.unwrap_or(ino);
-        entries.push((parent_inode, FileType::Directory, "..".to_string()));
+        let parent_inode = node.parent_inode.unwrap_or(ino.0);
+        entries.push((INodeNo(parent_inode), FileType::Directory, "..".to_string()));
 
         for child in children {
             let file_type = match child.kind {
@@ -134,13 +130,13 @@ impl Filesystem for RetromountFuseFs {
                 MountNodeKind::File => FileType::RegularFile,
             };
 
-            entries.push((child.inode, file_type, child.name.clone()));
+            entries.push((INodeNo(child.inode), file_type, child.name.clone()));
         }
 
         for (index, (entry_ino, file_type, name)) in
             entries.into_iter().enumerate().skip(offset as usize)
         {
-            let full = reply.add(entry_ino, (index + 1) as i64, file_type, name);
+            let full = reply.add(entry_ino, (index + 1) as u64, file_type, name);
             if full {
                 break;
             }

--- a/src/mount/fuse_fs.rs
+++ b/src/mount/fuse_fs.rs
@@ -1,0 +1,151 @@
+use std::ffi::OsStr;
+use std::time::{Duration, SystemTime};
+
+use fuser::{
+    FileAttr, FileType, Filesystem, KernelConfig, MountOption, ReplyAttr, ReplyDirectory,
+    ReplyEntry, Request,
+};
+use libc::{EIO, ENOENT};
+
+use crate::mount::session::{MountNodeKind, MountSession};
+
+const TTL: Duration = Duration::from_secs(1);
+
+pub struct RetromountFuseFs {
+    session: MountSession,
+}
+
+impl RetromountFuseFs {
+    pub fn new(session: MountSession) -> Self {
+        Self { session }
+    }
+
+    pub fn mount_options() -> Vec<MountOption> {
+        vec![
+            MountOption::RO,
+            MountOption::FSName("retromount".to_string()),
+            MountOption::DefaultPermissions,
+        ]
+    }
+
+    fn file_attr_for_node(&self, node: &crate::mount::session::MountNode) -> FileAttr {
+        let kind = match node.kind {
+            MountNodeKind::Directory { .. } => FileType::Directory,
+            MountNodeKind::File => FileType::RegularFile,
+        };
+
+        let perm = match kind {
+            FileType::Directory => 0o555,
+            FileType::RegularFile => 0o444,
+            _ => 0o444,
+        };
+
+        let size = match node.kind {
+            MountNodeKind::Directory { .. } => 0,
+            MountNodeKind::File => 0,
+        };
+
+        FileAttr {
+            ino: node.inode,
+            size,
+            blocks: 0,
+            atime: SystemTime::UNIX_EPOCH,
+            mtime: SystemTime::UNIX_EPOCH,
+            ctime: SystemTime::UNIX_EPOCH,
+            crtime: SystemTime::UNIX_EPOCH,
+            kind,
+            perm,
+            nlink: match kind {
+                FileType::Directory => 2,
+                _ => 1,
+            },
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            blksize: 4096,
+            flags: 0,
+        }
+    }
+}
+
+impl Filesystem for RetromountFuseFs {
+    fn init(&mut self, _req: &Request<'_>, _config: &mut KernelConfig) -> Result<(), libc::c_int> {
+        Ok(())
+    }
+
+    fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
+        let Some(name) = name.to_str() else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let Some(node) = self.session.lookup_child(parent, name) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let attr = self.file_attr_for_node(node);
+        reply.entry(&TTL, &attr, 0);
+    }
+
+    fn getattr(&mut self, _req: &Request<'_>, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+        let Some(node) = self.session.get(ino) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let attr = self.file_attr_for_node(node);
+        reply.attr(&TTL, &attr);
+    }
+
+    fn readdir(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: ReplyDirectory,
+    ) {
+        let Some(node) = self.session.get(ino) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let MountNodeKind::Directory { .. } = &node.kind else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let Some(children) = self.session.children(ino) else {
+            reply.error(EIO);
+            return;
+        };
+
+        let mut entries: Vec<(u64, FileType, String)> = Vec::new();
+
+        entries.push((ino, FileType::Directory, ".".to_string()));
+
+        let parent_inode = node.parent_inode.unwrap_or(ino);
+        entries.push((parent_inode, FileType::Directory, "..".to_string()));
+
+        for child in children {
+            let file_type = match child.kind {
+                MountNodeKind::Directory { .. } => FileType::Directory,
+                MountNodeKind::File => FileType::RegularFile,
+            };
+
+            entries.push((child.inode, file_type, child.name.clone()));
+        }
+
+        for (index, (entry_ino, file_type, name)) in
+            entries.into_iter().enumerate().skip(offset as usize)
+        {
+            let full = reply.add(entry_ino, (index + 1) as i64, file_type, name);
+            if full {
+                break;
+            }
+        }
+
+        reply.ok();
+    }
+}

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -1,0 +1,1 @@
+pub mod session;

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -1,1 +1,2 @@
+pub mod fuse_fs;
 pub mod session;

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(target_os = "linux")]
 pub mod fuse_fs;
+
 pub mod session;

--- a/src/mount/mod.rs
+++ b/src/mount/mod.rs
@@ -1,3 +1,5 @@
+pub mod adapter;
+
 #[cfg(target_os = "linux")]
 pub mod fuse_fs;
 

--- a/src/mount/session.rs
+++ b/src/mount/session.rs
@@ -1,0 +1,221 @@
+use std::collections::{BTreeMap, HashMap};
+
+use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
+
+#[derive(Debug, Clone)]
+pub struct MountSession {
+    root_inode: u64,
+    nodes: HashMap<u64, MountNode>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MountNode {
+    pub inode: u64,
+    pub parent_inode: Option<u64>,
+    pub name: String,
+    pub kind: MountNodeKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum MountNodeKind {
+    Directory { children: BTreeMap<String, u64> },
+    File,
+}
+
+impl MountSession {
+    pub fn from_root(root: &VfsDirectory) -> Self {
+        let mut builder = MountSessionBuilder::new();
+        let root_inode = builder.index_root(root);
+
+        Self {
+            root_inode,
+            nodes: builder.nodes,
+        }
+    }
+
+    pub fn root_inode(&self) -> u64 {
+        self.root_inode
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn get(&self, inode: u64) -> Option<&MountNode> {
+        self.nodes.get(&inode)
+    }
+
+    pub fn lookup_child(&self, parent_inode: u64, name: &str) -> Option<&MountNode> {
+        let parent = self.nodes.get(&parent_inode)?;
+
+        match &parent.kind {
+            MountNodeKind::Directory { children } => {
+                let child_inode = children.get(name)?;
+                self.nodes.get(child_inode)
+            }
+            MountNodeKind::File => None,
+        }
+    }
+
+    pub fn children(&self, inode: u64) -> Option<Vec<&MountNode>> {
+        let node = self.nodes.get(&inode)?;
+
+        match &node.kind {
+            MountNodeKind::Directory { children } => {
+                let result = children
+                    .values()
+                    .filter_map(|child_inode| self.nodes.get(child_inode))
+                    .collect();
+
+                Some(result)
+            }
+            MountNodeKind::File => None,
+        }
+    }
+}
+
+struct MountSessionBuilder {
+    next_inode: u64,
+    nodes: HashMap<u64, MountNode>,
+}
+
+impl MountSessionBuilder {
+    fn new() -> Self {
+        Self {
+            next_inode: 1,
+            nodes: HashMap::new(),
+        }
+    }
+
+    fn allocate_inode(&mut self) -> u64 {
+        let inode = self.next_inode;
+        self.next_inode += 1;
+        inode
+    }
+
+    fn index_root(&mut self, root: &VfsDirectory) -> u64 {
+        let root_inode = self.allocate_inode();
+        let children = self.index_directory_children(root, root_inode);
+
+        self.nodes.insert(
+            root_inode,
+            MountNode {
+                inode: root_inode,
+                parent_inode: None,
+                name: "/".to_string(),
+                kind: MountNodeKind::Directory { children },
+            },
+        );
+
+        root_inode
+    }
+
+    fn index_directory(&mut self, directory: &VfsDirectory, parent_inode: u64) -> u64 {
+        let inode = self.allocate_inode();
+        let children = self.index_directory_children(directory, inode);
+
+        self.nodes.insert(
+            inode,
+            MountNode {
+                inode,
+                parent_inode: Some(parent_inode),
+                name: directory.name.clone(),
+                kind: MountNodeKind::Directory { children },
+            },
+        );
+
+        inode
+    }
+
+    fn index_file(&mut self, file: &VfsFile, parent_inode: u64) -> u64 {
+        let inode = self.allocate_inode();
+
+        self.nodes.insert(
+            inode,
+            MountNode {
+                inode,
+                parent_inode: Some(parent_inode),
+                name: file.name.clone(),
+                kind: MountNodeKind::File,
+            },
+        );
+
+        inode
+    }
+
+    fn index_directory_children(
+        &mut self,
+        directory: &VfsDirectory,
+        parent_inode: u64,
+    ) -> BTreeMap<String, u64> {
+        let mut children = BTreeMap::new();
+
+        for child in directory.children() {
+            match child {
+                VfsNode::Directory(dir) => {
+                    let inode = self.index_directory(dir, parent_inode);
+                    children.insert(dir.name.clone(), inode);
+                }
+                VfsNode::File(file) => {
+                    let inode = self.index_file(file, parent_inode);
+                    children.insert(file.name.clone(), inode);
+                }
+            }
+        }
+
+        children
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_inode_is_one() {
+        let root = VfsDirectory::with_children("", vec![VfsNode::File(VfsFile::new("game.rom"))]);
+
+        let session = MountSession::from_root(&root);
+
+        assert_eq!(session.root_inode(), 1);
+    }
+
+    #[test]
+    fn can_lookup_child_by_name() {
+        let root = VfsDirectory::with_children("", vec![VfsNode::File(VfsFile::new("game.rom"))]);
+
+        let session = MountSession::from_root(&root);
+
+        let child = session
+            .lookup_child(session.root_inode(), "game.rom")
+            .expect("expected child node");
+
+        assert_eq!(child.name, "game.rom");
+        assert!(matches!(child.kind, MountNodeKind::File));
+    }
+
+    #[test]
+    fn indexes_nested_directories() {
+        let disc_dir = VfsDirectory::with_children(
+            "Example Game",
+            vec![VfsNode::File(VfsFile::new("disc1.chd"))],
+        );
+
+        let root = VfsDirectory::with_children("", vec![VfsNode::Directory(disc_dir)]);
+
+        let session = MountSession::from_root(&root);
+
+        let game_dir = session
+            .lookup_child(session.root_inode(), "Example Game")
+            .expect("expected game directory");
+
+        assert!(matches!(game_dir.kind, MountNodeKind::Directory { .. }));
+
+        let disc = session
+            .lookup_child(game_dir.inode, "disc1.chd")
+            .expect("expected disc file");
+
+        assert_eq!(disc.parent_inode, Some(game_dir.inode));
+        assert!(matches!(disc.kind, MountNodeKind::File));
+    }
+}

--- a/src/mount/session.rs
+++ b/src/mount/session.rs
@@ -19,7 +19,7 @@ pub struct MountNode {
 #[derive(Debug, Clone)]
 pub enum MountNodeKind {
     Directory { children: BTreeMap<String, u64> },
-    File,
+    File { file: VfsFile },
 }
 
 impl MountSession {
@@ -53,7 +53,7 @@ impl MountSession {
                 let child_inode = children.get(name)?;
                 self.nodes.get(child_inode)
             }
-            MountNodeKind::File => None,
+            MountNodeKind::File { .. } => None,
         }
     }
 
@@ -69,7 +69,16 @@ impl MountSession {
 
                 Some(result)
             }
-            MountNodeKind::File => None,
+            MountNodeKind::File { .. } => None,
+        }
+    }
+
+    pub fn file(&self, inode: u64) -> Option<&VfsFile> {
+        let node = self.nodes.get(&inode)?;
+
+        match &node.kind {
+            MountNodeKind::File { file } => Some(file),
+            MountNodeKind::Directory { .. } => None,
         }
     }
 }
@@ -136,7 +145,7 @@ impl MountSessionBuilder {
                 inode,
                 parent_inode: Some(parent_inode),
                 name: file.name.clone(),
-                kind: MountNodeKind::File,
+                kind: MountNodeKind::File { file: file.clone() },
             },
         );
 
@@ -178,11 +187,11 @@ mod tests {
                 VfsNode::Directory(VfsDirectory::with_children(
                     "Example Game",
                     vec![
-                        VfsNode::File(VfsFile::new("disc1.chd")),
-                        VfsNode::File(VfsFile::new("game.m3u")),
+                        VfsNode::File(VfsFile::inline("disc1.chd", vec![1, 2, 3, 4])),
+                        VfsNode::File(VfsFile::inline("game.m3u", b"disc1.chd\n".to_vec())),
                     ],
                 )),
-                VfsNode::File(VfsFile::new("readme.txt")),
+                VfsNode::File(VfsFile::inline("readme.txt", b"hello".to_vec())),
             ],
         )
     }
@@ -205,7 +214,7 @@ mod tests {
             .expect("expected child node");
 
         assert_eq!(child.name, "game.rom");
-        assert!(matches!(child.kind, MountNodeKind::File));
+        assert!(matches!(child.kind, MountNodeKind::File { .. }));
     }
 
     #[test]
@@ -229,7 +238,7 @@ mod tests {
             .expect("expected disc file");
 
         assert_eq!(disc.parent_inode, Some(game_dir.inode));
-        assert!(matches!(disc.kind, MountNodeKind::File));
+        assert!(matches!(disc.kind, MountNodeKind::File { .. }));
     }
 
     #[test]
@@ -291,5 +300,19 @@ mod tests {
 
         assert_eq!(game_dir.parent_inode, Some(session.root_inode()));
         assert_eq!(playlist.parent_inode, Some(game_dir.inode));
+    }
+
+    #[test]
+    fn file_accessor_returns_backing_file() {
+        let root = sample_root();
+        let session = MountSession::from_root(&root);
+
+        let file = session
+            .lookup_child(session.root_inode(), "readme.txt")
+            .expect("expected root file");
+
+        let backing = session.file(file.inode).expect("expected backing file");
+        assert_eq!(backing.name, "readme.txt");
+        assert_eq!(backing.size, 5);
     }
 }

--- a/src/mount/session.rs
+++ b/src/mount/session.rs
@@ -171,10 +171,25 @@ impl MountSessionBuilder {
 mod tests {
     use super::*;
 
+    fn sample_root() -> VfsDirectory {
+        VfsDirectory::with_children(
+            "",
+            vec![
+                VfsNode::Directory(VfsDirectory::with_children(
+                    "Example Game",
+                    vec![
+                        VfsNode::File(VfsFile::new("disc1.chd")),
+                        VfsNode::File(VfsFile::new("game.m3u")),
+                    ],
+                )),
+                VfsNode::File(VfsFile::new("readme.txt")),
+            ],
+        )
+    }
+
     #[test]
     fn root_inode_is_one() {
-        let root = VfsDirectory::with_children("", vec![VfsNode::File(VfsFile::new("game.rom"))]);
-
+        let root = sample_root();
         let session = MountSession::from_root(&root);
 
         assert_eq!(session.root_inode(), 1);
@@ -183,7 +198,6 @@ mod tests {
     #[test]
     fn can_lookup_child_by_name() {
         let root = VfsDirectory::with_children("", vec![VfsNode::File(VfsFile::new("game.rom"))]);
-
         let session = MountSession::from_root(&root);
 
         let child = session
@@ -202,7 +216,6 @@ mod tests {
         );
 
         let root = VfsDirectory::with_children("", vec![VfsNode::Directory(disc_dir)]);
-
         let session = MountSession::from_root(&root);
 
         let game_dir = session
@@ -217,5 +230,66 @@ mod tests {
 
         assert_eq!(disc.parent_inode, Some(game_dir.inode));
         assert!(matches!(disc.kind, MountNodeKind::File));
+    }
+
+    #[test]
+    fn node_count_covers_root_and_all_descendants() {
+        let root = sample_root();
+        let session = MountSession::from_root(&root);
+
+        assert_eq!(session.node_count(), 5);
+    }
+
+    #[test]
+    fn children_returns_directory_entries() {
+        let root = sample_root();
+        let session = MountSession::from_root(&root);
+
+        let names: Vec<_> = session
+            .children(session.root_inode())
+            .expect("root should have children")
+            .into_iter()
+            .map(|node| node.name.as_str())
+            .collect();
+
+        assert_eq!(names, vec!["Example Game", "readme.txt"]);
+    }
+
+    #[test]
+    fn lookup_child_returns_none_for_missing_entry() {
+        let root = sample_root();
+        let session = MountSession::from_root(&root);
+
+        let missing = session.lookup_child(session.root_inode(), "does-not-exist.txt");
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn children_returns_none_for_file_inode() {
+        let root = sample_root();
+        let session = MountSession::from_root(&root);
+
+        let file = session
+            .lookup_child(session.root_inode(), "readme.txt")
+            .expect("expected root file");
+
+        assert!(session.children(file.inode).is_none());
+    }
+
+    #[test]
+    fn nested_nodes_have_correct_parent_inode() {
+        let root = sample_root();
+        let session = MountSession::from_root(&root);
+
+        let game_dir = session
+            .lookup_child(session.root_inode(), "Example Game")
+            .expect("expected game directory");
+
+        let playlist = session
+            .lookup_child(game_dir.inode, "game.m3u")
+            .expect("expected playlist file");
+
+        assert_eq!(game_dir.parent_inode, Some(session.root_inode()));
+        assert_eq!(playlist.parent_inode, Some(game_dir.inode));
     }
 }


### PR DESCRIPTION
# Phase 4A: FUSE Mount Integration + Architecture Consolidation

## Summary

This PR introduces **Phase 4A**, adding a Linux FUSE adapter that exposes the Retromount VFS as a read-only filesystem.

It also completes the architectural consolidation work from Phase 3, including decisions **D-002 through D-005**, and aligns all documentation with the current pipeline-first design.

---

## 🚀 Key Features

### FUSE Filesystem Support

* Introduces a Linux FUSE adapter using `fuser`
* Exposes the Retromount VFS as a **read-only mounted filesystem**
* Supports:

  * directory traversal (`lookup`, `getattr`, `readdir`)
  * file access (`open`, `read`)
* Uses a stable inode model via `MountSession`
* Integrates with existing VFS reader pipeline:

  * `open_vfs_file → Reader → read_at(offset, buffer)`

### VFS → Filesystem Mapping

* VFS nodes mapped to FUSE inodes
* Efficient parent/child traversal
* No duplication of decoding or pipeline logic in the FUSE layer

---

## 🧱 Architecture Changes

### Single Canonical Pipeline (D-002)

* All execution paths now flow through:

  ```
  Input → Identify → Decode → Normalize → Present → Encode → VFS
  ```
* Legacy loader-based orchestration fully removed

---

### Presenter / Encoder Boundary (D-003)

* **Presenter**

  * owns structure, grouping, layout

* **Encoder**

  * owns naming, representation, file materialization

* Boundary is now:

  * explicitly defined
  * enforced in code
  * fully documented

---

### Presentation-Agnostic Core Model (D-004)

* Removed filename and representation concerns from normalized model
* Core types (`NormalizedContent`, `GameContent`, `GamePart`) now purely semantic
* All naming and representation handled by encoder

---

### Decoded vs Normalized Content Split (D-005)

* Introduced explicit type boundary:

  * `DecodedContent` (decode stage)
  * `NormalizedContent` (post-normalization)

* Eliminates impossible states in later stages

* Strengthens pipeline contracts and type safety

---

## 📚 Documentation Updates

* Updated architecture docs to reflect:

  * Phase 4A FUSE integration
  * final pipeline model
  * D-002 through D-005 decisions
* Added detailed FUSE integration documentation
* Resolved and documented F-003 (Presenter vs Encoder boundary)
* Extended cleanup tracker with FUSE follow-up tasks

---

## 🧪 Testing / Validation

* Verified FUSE mount behaviour:

  * directory listing
  * file access via mounted filesystem
* Confirmed pipeline consistency across:

  * `inspect`
  * `preview`
  * runtime/FUSE execution
* No changes to core decoding/normalization behaviour

---

## ⚠️ Scope & Limitations

* FUSE implementation is **read-only**
* Linux-only (via `fuser`)
* No caching layer yet (future improvement)
* Error mapping and advanced diagnostics are minimal (tracked in cleanup)

---

## 🔮 Follow-up Work

Tracked in `cleanup-tracker.md`:

* improve FUSE error handling and logging
* add caching for read performance
* increase test coverage (encoder + FUSE)
* add diagrams and extension examples

---

## 🎯 Impact

This PR:

* completes the transition to a **pipeline-first architecture**
* establishes **clean, enforceable boundaries across all stages**
* introduces the first **real runtime consumer (FUSE)** of the VFS
* lays the foundation for:

  * plugin architecture
  * alternative output adapters
  * richer runtime integrations

---

## ✅ Ready for Review

This is a large but **cohesive architectural milestone**.

Recommended review order:

1. `docs/architecture/boundaries.md`
2. `docs/architecture/decisions.md`
3. FUSE implementation (`MountSession`, `RetromountFuseFs`)
4. Encoder / Presenter changes
5. Cleanup and removals from D-002

---

## Screenshots / Examples (optional)

*(Add mount examples or terminal output here if desired)*

---

## Checklist

* [x] Pipeline is the single orchestration model
* [x] Presenter/Encoder boundary enforced
* [x] Core model is presentation-agnostic
* [x] Decoded vs normalized boundary implemented
* [x] FUSE adapter integrated and working
* [x] Documentation aligned with implementation
