### PR TITLE
Feature/phase4c policy foundations

### DIFF
--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -1,6 +1,6 @@
 # Architecture Boundaries
 
-This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation, D-002 through D-005 and Phase4A FUSE implementation.
+This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation, D-002 through D-005, Phase 4A FUSE implementation, and Phase 4C policy introduction.
 
 ---
 
@@ -29,15 +29,15 @@ Implemented in: `src/input`
 
 Responsible for:
 
-- enumerating content from sources (directories, archives, files)
-- abstracting over container formats
-- producing a stream of input items for processing
+* enumerating content from sources (directories, archives, files)
+* abstracting over container formats
+* producing a stream of input items for processing
 
 Key components:
 
-- `InputSource`
-- `DirectoryInputSource`
-- `ZipInputSource`
+* `InputSource`
+* `DirectoryInputSource`
+* `ZipInputSource`
 
 This stage answers:
 
@@ -49,13 +49,13 @@ This stage answers:
 
 Responsible for:
 
-- determining what each input item might represent
-- selecting an appropriate decoding strategy
+* determining what each input item might represent
+* selecting an appropriate decoding strategy
 
 Key components:
 
-- `InputIdentifier`
-- `BasicInputIdentifier`
+* `InputIdentifier`
+* `BasicInputIdentifier`
 
 This stage answers:
 
@@ -67,13 +67,13 @@ This stage answers:
 
 Responsible for:
 
-- parsing input into structured representations
-- interpreting formats (ROMs, CUE/BIN, etc.)
+* parsing input into structured representations
+* interpreting formats (ROMs, CUE/BIN, etc.)
 
 Key components:
 
-- `InputDecoder`
-- `BasicInputDecoder`
+* `InputDecoder`
+* `BasicInputDecoder`
 
 This stage answers:
 
@@ -87,15 +87,15 @@ Implemented in: `src/core`
 
 Responsible for:
 
-- producing normalized, presentation-agnostic representations of content
-- modelling games, discs, and other semantic entities
+* producing normalized, presentation-agnostic representations of content
+* modelling games, discs, and other semantic entities
 
 Key types:
 
-- `DecodedContent`
-- `NormalizedContent`
-- `GameContent`
-- `GamePart`
+* `DecodedContent`
+* `NormalizedContent`
+* `GameContent`
+* `GamePart`
 
 This stage answers:
 
@@ -107,16 +107,16 @@ This stage answers:
 
 Responsible for:
 
-- defining output structure (directories and hierarchy)
-- grouping related content (e.g. multi-disc games)
-- determining layout decisions (e.g. root vs nested placement)
-- deciding when compound artifacts are required (e.g. playlists)
-- constructing the logical VFS tree
+* defining output structure (directories and hierarchy)
+* grouping related content (e.g. multi-disc games)
+* determining layout decisions (e.g. root vs nested placement)
+* deciding when compound artifacts are required (e.g. playlists)
+* constructing the logical VFS tree
 
 Key components:
 
-- `OutputPresenter`
-- `GenericPresenter`
+* `OutputPresenter`
+* `GenericPresenter`
 
 This stage answers:
 
@@ -124,19 +124,21 @@ This stage answers:
 
 The Presenter must **not**:
 
-- generate filenames or extensions
-- determine file backing (inline vs source-backed)
-- generate file contents
-- perform representation-specific transformations
+* generate filenames or extensions
+* determine file backing (inline vs source-backed)
+* generate file contents
+* perform representation-specific transformations
+* expand logical content into concrete file sets
 
-In the default implementation, the presenter composes an encoder while constructing the VFS tree.
+Presenters operate on logical content and define **placement only**.
+
+Expansion of logical content into one or more output artifacts (e.g. multi-disc outputs, playlists) is an output-layer concern and occurs outside of presentation structure decisions.
 
 Conceptually:
 
-- presentation owns structure and layout decisions
-- encoding owns file materialization
-
-This preserves the architectural boundary while allowing a simple default composition.
+* presentation owns structure and layout decisions
+* expansion determines what output artifacts exist
+* encoding owns file materialization
 
 ---
 
@@ -144,17 +146,17 @@ This preserves the architectural boundary while allowing a simple default compos
 
 Responsible for:
 
-- generating filenames and extensions
-- mapping content to file representations
-- determining file backing (inline vs source-backed)
-- generating file contents (e.g. playlists)
-- applying representation-specific transformations
+* generating filenames and extensions
+* mapping content to file representations
+* determining file backing (inline vs source-backed)
+* generating file contents (e.g. playlists)
+* applying representation-specific transformations
 
 Key components:
 
-- `OutputEncoder`
-- `BasicEncoder`
-- `VfsFile`
+* `OutputEncoder`
+* `BasicEncoder`
+* `VfsFile`
 
 This stage answers:
 
@@ -162,9 +164,31 @@ This stage answers:
 
 The Encoder must **not**:
 
-- define directory structure or layout
-- group content into collections
-- make global presentation decisions
+* define directory structure or layout
+* group content into collections
+* make global presentation decisions
+
+Encoders may produce one or more output files for a logical item, but do not control where those files are placed.
+
+---
+
+## Policy Layer (Phase 4C)
+
+Phase 4C introduces policy as a cross-cutting concern influencing naming, formatting, and conflict handling.
+
+Policy:
+
+* does not define structure
+* does not mutate normalized content
+* does not replace presenter or encoder responsibilities
+
+Policy is applied at **output boundaries**, particularly:
+
+* filename derivation
+* formatting/sanitization
+* conflict resolution between sibling entries
+
+Conflict resolution is applied when inserting entries into a namespace, not by the core VFS itself.
 
 ---
 
@@ -172,73 +196,87 @@ The Encoder must **not**:
 
 ### Input → Identify
 
-- Input produces raw content items
-- No semantic interpretation occurs here
-- Must not depend on content type assumptions
+* Input produces raw content items
+* No semantic interpretation occurs here
+* Must not depend on content type assumptions
 
 ---
 
 ### Identify → Decode
 
-- Identify suggests possible content type(s)
-- Decode performs actual parsing and validation
+* Identify suggests possible content type(s)
+* Decode performs actual parsing and validation
 
 ---
 
 ### Decode → Normalize
 
-- Decode produces `DecodedContent`
-- Normalize consumes `DecodedContent` and produces `NormalizedContent`
-- Source provenance may be retained where needed for semantic interpretation
-- Normalized content must not encode presentation decisions such as filenames, extensions, or naming conventions
-- Normalization is the only stage where decoded artifacts may be aggregated, merged, or transformed into higher-level semantic entities (e.g. discs → games)
+* Decode produces `DecodedContent`
+* Normalize consumes `DecodedContent` and produces `NormalizedContent`
+* Source provenance may be retained where needed for semantic interpretation
+* Normalized content must not encode presentation decisions such as filenames, extensions, or naming conventions
+* Normalization is the only stage where decoded artifacts may be aggregated, merged, or transformed into higher-level semantic entities (e.g. discs → games)
 
 ---
 
 ### Normalized Model → Presenter
 
-- Presenter consumes `NormalizedContent`
-- Must not re-interpret raw inputs
-- Must not depend on decoder-specific details
+* Presenter consumes `NormalizedContent`
+* Must not re-interpret raw inputs
+* Must not depend on decoder-specific details
+* Must not derive representation-level artifacts
 
 ---
 
 ### Presenter → Encoder
 
-- Presenter defines structure and grouping
-- Encoder defines representation of each item
-- Presenter must not implement representation logic
-- Encoder must not influence structure
+* Presenter defines structure and grouping
+* Encoder defines representation of each item
+* Expansion determines the set of output artifacts
+* Policy determines naming and conflict behaviour
+
+Responsibilities remain strictly separated:
+
+* Presenter must not implement representation logic
+* Encoder must not influence structure
+* Policy must not define structure or representation
 
 ---
 
 ## Design Principles
 
-- **Single orchestration model**  
+* **Single orchestration model**
   All processing flows through the pipeline
 
-- **Strict separation of concerns**
-  - Input handles enumeration
-  - Identify/Decode handle interpretation
-  - Core model represents semantics
-  - Presenter defines structure
-  - Encoder defines representation
+* **Strict separation of concerns**
 
-- **Presentation independence**
+  * Input handles enumeration
+  * Identify/Decode handle interpretation
+  * Core model represents semantics
+  * Presenter defines structure
+  * Encoder defines representation
+  * Policy defines naming and conflict behaviour
+
+* **Presentation independence**
   The core model must not encode output-specific assumptions
 
-- **Extensibility**
+* **Policy isolation**
+  Naming, formatting, and conflict handling must not leak into core model or VFS primitives
+
+* **Extensibility**
   Each stage should be replaceable or extensible without affecting others
 
 ---
 
 ## Known Boundary Concerns
 
-- [x] F-001: input vs inputs naming ambiguity (resolved via `builtin_inputs` rename)
-- [x] F-002: loader vs pipeline orchestration ambiguity (resolved via D-002)
-- [x] F-003: presenter vs encoder responsibility boundary (resolved via D-003)
-- [x] F-004: core model presentation leakage (resolved via D-004)
-- [x] F-005: decoded vs normalized content boundary defined (D-005 implemented)
+* [x] F-001: input vs inputs naming ambiguity (resolved via `builtin_inputs` rename)
+* [x] F-002: loader vs pipeline orchestration ambiguity (resolved via D-002)
+* [x] F-003: presenter vs encoder responsibility boundary (resolved via D-003)
+* [x] F-004: core model presentation leakage (resolved via D-004)
+* [x] F-005: decoded vs normalized content boundary defined (D-005 implemented)
+
+---
 
 ## Decode → Normalize Boundary
 
@@ -271,10 +309,10 @@ pub enum NormalizedContent {
 
 ### Pipeline contracts
 
-- decoder → `Vec<DecodedContent>`
-- normalizer → `Vec<NormalizedContent>`
-- presenter → consumes `NormalizedContent`
-- encoder → consumes `NormalizedContent`
+* decoder → `Vec<DecodedContent>`
+* normalizer → `Vec<NormalizedContent>`
+* presenter → consumes `NormalizedContent`
+* encoder → consumes `NormalizedContent`
 
 Pre-normalized artifacts such as ROMs and discs are not visible beyond the normalization stage.
 
@@ -282,6 +320,6 @@ Pre-normalized artifacts such as ROMs and discs are not visible beyond the norma
 
 This boundary ensures:
 
-- explicit stage contracts
-- elimination of impossible post-normalization states
-- clearer plugin and extension boundaries
+* explicit stage contracts
+* elimination of impossible post-normalization states
+* clearer plugin and extension boundaries

--- a/docs/roadmap/phase4c-policy.md
+++ b/docs/roadmap/phase4c-policy.md
@@ -20,10 +20,10 @@ Specifically:
 
 Phase 4C introduces:
 
-- explicit policy support in runtime and pipeline execution
-- policy abstractions for naming, formatting, and conflict resolution
-- default policy implementations that preserve current behaviour
-- the ability to vary naming and related rules independently of presenter and encoder selection
+* explicit policy support in runtime and pipeline execution
+* policy abstractions for naming, formatting, and conflict resolution
+* default policy implementations that preserve current behaviour
+* the ability to vary naming and related rules independently of presenter and encoder selection
 
 ---
 
@@ -31,12 +31,12 @@ Phase 4C introduces:
 
 Phase 4C explicitly does **not** include:
 
-- plugin loading or external extension mechanisms (Phase 4D)
-- metadata enrichment or scraping
-- redesign of the normalized core model
-- changes to the presenter/encoder architectural boundary
-- broad deduplication strategy redesign unless it falls naturally out of policy insertion points
-- user-facing configuration formats beyond what is needed to establish the internal architecture
+* plugin loading or external extension mechanisms (Phase 4D)
+* metadata enrichment or scraping
+* redesign of the normalized core model
+* changes to the presenter/encoder architectural boundary
+* broad deduplication strategy redesign unless it falls naturally out of policy insertion points
+* user-facing configuration formats beyond what is needed to establish the internal architecture
 
 ---
 
@@ -46,10 +46,10 @@ Phase 4B established that presentation structure should be owned by presenters, 
 
 However, a further concern remains:
 
-- how names are derived
-- how names are normalized or sanitized
-- how collisions are resolved
-- how future compatibility profiles can alter these rules without changing structure or encoding behaviour
+* how names are derived
+* how names are normalized or sanitized
+* how collisions are resolved
+* how future compatibility profiles can alter these rules without changing structure or encoding behaviour
 
 Without a dedicated policy layer, these concerns would leak into presenter and encoder implementations, making them harder to reuse, harder to swap, and harder to evolve.
 
@@ -69,34 +69,64 @@ Retromount’s canonical pipeline remains:
 6. Encode
 7. Materialize via VFS / mount adapter
 
-Phase 4C adds policy as a cross-cutting rules layer that influences presentation and encoding without owning either concern.
+Phase 4C introduces policy as a cross-cutting rules layer that influences output behaviour without owning structure or representation.
 
 Conceptually:
 
 ```text
 Normalized -> Presenter -> Encoder -> VFS
-        ^            ^
+        ^            ^         ^
+        |            |         |
+        |         Policy   Policy
         |            |
-      Policy influences naming, formatting, and conflict behaviour
+        +------------+
 ```
 
-Policy must not:
+Policy influences:
 
-- define structure directly
-- mutate normalized content
-- replace presenter responsibilities
-- replace encoder responsibilities
+* naming
+* formatting
+* conflict handling
+
+But must not:
+
+* define structure directly
+* mutate normalized content
+* replace presenter responsibilities
+* replace encoder responsibilities
+
+---
+
+## Implementation Outcome
+
+The initial Phase 4C implementation establishes policy as a cross-cutting concern while preserving strict architectural boundaries.
+
+In particular:
+
+* naming, formatting, and conflict behaviour are defined through policy abstractions
+* logical content is expanded into output artifacts before layout-specific presentation
+* presenters operate only on expanded output intent and do not inspect `GamePart` or `DiscPart`
+* presenters do not invoke encoding decisions (e.g. disc encoding or playlist generation)
+* conflict handling is applied at namespace insertion points via output-layer name allocation
+* core VFS structures remain unchanged and do not depend on policy
+
+This results in a clear separation:
+
+* **expansion determines what files exist**
+* **presentation determines where files are placed**
+* **encoding determines how files are represented**
+* **policy determines how files are named and how conflicts are resolved**
 
 ---
 
 ## Success Criteria
 
-- policy abstractions exist for naming, formatting, and conflict handling
-- default policy implementations preserve existing Phase 4B behaviour
-- policy is threaded through runtime and pipeline execution
-- at least one naming decision currently embedded in presenter or encoder logic is moved into policy
-- the same normalized input and presenter can produce different output names under different policy implementations
-- existing presenter and encoder boundaries remain intact
+* policy abstractions exist for naming, formatting, and conflict handling
+* default policy implementations preserve existing Phase 4B behaviour
+* policy is threaded through runtime and pipeline execution
+* at least one naming decision currently embedded in presenter or encoder logic is moved into policy
+* the same normalized input and presenter can produce different output names under different policy implementations
+* existing presenter and encoder boundaries remain intact
 
 ---
 
@@ -108,34 +138,42 @@ Phase 4C establishes policy as the home for rules such as:
 
 Examples:
 
-- game names
-- part names
-- playlist names
-- platform label formatting where applicable
+* game names
+* part names
+* playlist names
+* platform label formatting where applicable
 
 Examples of variation:
 
-- `Final Fantasy VII (Disc 1).cue`
-- `Final Fantasy VII - CD1.cue`
-- `FF7_Disc1.cue`
+* `Final Fantasy VII (Disc 1).cue`
+* `Final Fantasy VII - CD1.cue`
+* `FF7_Disc1.cue`
 
 ### Formatting
 
 Examples:
 
-- whitespace normalization
-- invalid character handling
-- filesystem-safe transformations
-- case normalization where required
+* whitespace normalization
+* invalid character handling
+* filesystem-safe transformations
+* case normalization where required
 
 ### Conflict Handling
 
 Examples:
 
-- append numeric suffixes
-- preserve first entry
-- error on collision
-- future strategies for stricter compatibility profiles
+* append numeric suffixes
+* preserve first entry
+* error on collision
+* future strategies for stricter compatibility profiles
+
+Conflict handling is applied at namespace boundaries when inserting entries into a directory.
+
+This is an output-layer concern and must not:
+
+* alter presentation structure
+* be implemented directly inside presenters
+* be embedded in core VFS structures
 
 ---
 
@@ -143,31 +181,45 @@ Examples:
 
 Phase 4C depends on keeping responsibilities clear.
 
+### Expansion owns
+
+* determining how many output artifacts a logical item produces
+* multi-disc expansion
+* playlist generation
+* other logical-to-artifact transformations
+
 ### Presenter owns
 
-- what logical entries exist
-- grouping and layout decisions
-- directory structure
-- whether artifacts such as playlists are part of the presentation
+* grouping and layout decisions
+* directory structure
+* placement of output artifacts
+
+Presenters must not:
+
+* inspect `GamePart` or `DiscPart` to determine expansion
+* decide how many files a logical item produces
+* invoke encoding behaviour to create additional artifacts
 
 ### Encoder owns
 
-- how logical entries are materialized
-- output representation
-- inline file generation
-- file backing choice
+* how output artifacts are materialized
+* file representation
+* inline file generation
+* file backing choice
 
 ### Policy owns
 
-- naming rules
-- formatting rules
-- conflict-resolution rules
+* naming rules
+* formatting rules
+* conflict-resolution rules
 
 A presenter may decide that a playlist exists.
 
+Expansion determines that it produces a file.
+
 A policy decides what it should be called.
 
-An encoder decides how that playlist becomes a file and what content it contains.
+An encoder decides how that file is represented and what content it contains.
 
 ---
 
@@ -177,12 +229,14 @@ An encoder decides how that playlist becomes a file and what content it contains
 
 Add internal abstractions for:
 
-- `NamingPolicy`
-- `FormattingPolicy`
-- `ConflictPolicy`
-- `PolicySet`
+* `NamingPolicy`
+* `FormattingPolicy`
+* `ConflictPolicy`
+* `PolicySet`
 
-This step should define the architecture only and should not change visible behaviour.
+This step defines the architecture without changing visible behaviour.
+
+---
 
 ### Step 2 — Add default policy implementations
 
@@ -190,22 +244,28 @@ Create default policies that mirror the current naming and formatting behaviour 
 
 This provides a safe compatibility baseline.
 
+---
+
 ### Step 3 — Thread policy through runtime and pipeline
 
 Ensure that the execution path can supply policy to the components that need it.
 
-Policy should be available to presenter and encoder code paths through explicit runtime context rather than hidden global state.
+Policy should be available through explicit runtime context rather than hidden global state.
+
+---
 
 ### Step 4 — Move naming decisions into policy
 
 Identify existing hard-coded naming logic and migrate it into `NamingPolicy`.
 
-Initial targets should include:
+Initial targets include:
 
-- file names
-- part names
-- playlist names
-- other obvious naming hotspots currently embedded in presenter or encoder implementations
+* file names
+* part names
+* playlist names
+* other naming hotspots currently embedded in presenter or encoder implementations
+
+---
 
 ### Step 5 — Apply formatting policy separately
 
@@ -213,17 +273,21 @@ Introduce formatting as a distinct concern from naming.
 
 This allows a raw logical name to be derived first, then normalized for output constraints.
 
+---
+
 ### Step 6 — Introduce conflict handling at namespace boundaries
 
 Apply conflict resolution where sibling names are inserted into the same logical namespace.
 
 This must remain a naming-resolution concern and must not alter presentation structure.
 
+---
+
 ### Step 7 — Prove swappability
 
 Add at least one alternate policy implementation that changes output naming without requiring presenter or encoder changes.
 
-This is the proof that policy is a real abstraction rather than a relocation of helper functions.
+This proves that policy is a true abstraction rather than a relocation of helper functions.
 
 ---
 
@@ -233,10 +297,10 @@ The first implementation slice should be intentionally conservative.
 
 It should include:
 
-- policy traits and `PolicySet`
-- default implementations
-- runtime and pipeline wiring
-- tests proving default behaviour matches the current system
+* policy traits and `PolicySet`
+* default implementations
+* runtime and pipeline wiring
+* tests proving default behaviour matches the current system
 
 It should not yet attempt broad naming refactors beyond what is needed to establish the abstraction.
 
@@ -250,18 +314,18 @@ Phase 4C should include:
 
 For default policy behaviour, including:
 
-- game naming
-- part naming
-- playlist naming
-- formatting behaviour
-- conflict resolution behaviour
+* game naming
+* part naming
+* playlist naming
+* formatting behaviour
+* conflict resolution behaviour
 
 ### Integration tests
 
 To verify that:
 
-- default policy preserves existing output
-- alternate policy changes naming without changing structure
+* default policy preserves existing output
+* alternate policy changes naming without changing structure
 
 ### Regression coverage
 
@@ -275,10 +339,10 @@ Phase 4C lays the groundwork for later extensibility.
 
 In particular, it enables future support for:
 
-- multiple naming styles
-- compatibility profiles for specific consumers
-- profile-based composition of presenter, encoder, and policy
-- plugin-based policy implementations in later phases
+* multiple naming styles
+* compatibility profiles for specific consumers
+* profile-based composition of presenter, encoder, and policy
+* plugin-based policy implementations in later phases
 
 This is especially important for long-term ideas where the same underlying data may need to conform to different external naming conventions without changing the core pipeline.
 
@@ -286,4 +350,9 @@ This is especially important for long-term ideas where the same underlying data 
 
 ## Exit Condition
 
-Phase 4C is complete when policy is a first-class architectural concept in the codebase, default behaviour is preserved, and naming-related rules can vary independently of presenter and encoder implementations.
+Phase 4C is complete when:
+
+* policy is a first-class architectural concept in the codebase
+* default behaviour is preserved
+* naming-related rules can vary independently of presenter and encoder implementations
+* expansion, presentation, encoding, and policy responsibilities remain clearly separated

--- a/docs/roadmap/phase4c-policy.md
+++ b/docs/roadmap/phase4c-policy.md
@@ -1,0 +1,289 @@
+# Phase 4C — Policy Layer
+
+This document defines the implementation plan and scope for Phase 4C.
+
+Phase 4C builds on the Phase 4B presenter model and introduces a formal policy layer to control naming, formatting, and conflict behaviour without collapsing existing architectural boundaries.
+
+---
+
+## Goal
+
+Introduce a dedicated policy layer that governs naming and related behavioural rules across presenters and encoders.
+
+Specifically:
+
+> The same normalized content and presentation structure can be rendered using different naming, formatting, and conflict-handling rules via interchangeable policy implementations.
+
+---
+
+## Scope
+
+Phase 4C introduces:
+
+- explicit policy support in runtime and pipeline execution
+- policy abstractions for naming, formatting, and conflict resolution
+- default policy implementations that preserve current behaviour
+- the ability to vary naming and related rules independently of presenter and encoder selection
+
+---
+
+## Non-Goals
+
+Phase 4C explicitly does **not** include:
+
+- plugin loading or external extension mechanisms (Phase 4D)
+- metadata enrichment or scraping
+- redesign of the normalized core model
+- changes to the presenter/encoder architectural boundary
+- broad deduplication strategy redesign unless it falls naturally out of policy insertion points
+- user-facing configuration formats beyond what is needed to establish the internal architecture
+
+---
+
+## Why This Phase Exists
+
+Phase 4B established that presentation structure should be owned by presenters, while file materialization should be owned by encoders.
+
+However, a further concern remains:
+
+- how names are derived
+- how names are normalized or sanitized
+- how collisions are resolved
+- how future compatibility profiles can alter these rules without changing structure or encoding behaviour
+
+Without a dedicated policy layer, these concerns would leak into presenter and encoder implementations, making them harder to reuse, harder to swap, and harder to evolve.
+
+Phase 4C exists to give these rules a proper home.
+
+---
+
+## Architectural Position
+
+Retromount’s canonical pipeline remains:
+
+1. Input
+2. Identify
+3. Decode
+4. Normalize
+5. Present
+6. Encode
+7. Materialize via VFS / mount adapter
+
+Phase 4C adds policy as a cross-cutting rules layer that influences presentation and encoding without owning either concern.
+
+Conceptually:
+
+```text
+Normalized -> Presenter -> Encoder -> VFS
+        ^            ^
+        |            |
+      Policy influences naming, formatting, and conflict behaviour
+```
+
+Policy must not:
+
+- define structure directly
+- mutate normalized content
+- replace presenter responsibilities
+- replace encoder responsibilities
+
+---
+
+## Success Criteria
+
+- policy abstractions exist for naming, formatting, and conflict handling
+- default policy implementations preserve existing Phase 4B behaviour
+- policy is threaded through runtime and pipeline execution
+- at least one naming decision currently embedded in presenter or encoder logic is moved into policy
+- the same normalized input and presenter can produce different output names under different policy implementations
+- existing presenter and encoder boundaries remain intact
+
+---
+
+## Policy Responsibilities
+
+Phase 4C establishes policy as the home for rules such as:
+
+### Naming
+
+Examples:
+
+- game names
+- part names
+- playlist names
+- platform label formatting where applicable
+
+Examples of variation:
+
+- `Final Fantasy VII (Disc 1).cue`
+- `Final Fantasy VII - CD1.cue`
+- `FF7_Disc1.cue`
+
+### Formatting
+
+Examples:
+
+- whitespace normalization
+- invalid character handling
+- filesystem-safe transformations
+- case normalization where required
+
+### Conflict Handling
+
+Examples:
+
+- append numeric suffixes
+- preserve first entry
+- error on collision
+- future strategies for stricter compatibility profiles
+
+---
+
+## Boundary Rules
+
+Phase 4C depends on keeping responsibilities clear.
+
+### Presenter owns
+
+- what logical entries exist
+- grouping and layout decisions
+- directory structure
+- whether artifacts such as playlists are part of the presentation
+
+### Encoder owns
+
+- how logical entries are materialized
+- output representation
+- inline file generation
+- file backing choice
+
+### Policy owns
+
+- naming rules
+- formatting rules
+- conflict-resolution rules
+
+A presenter may decide that a playlist exists.
+
+A policy decides what it should be called.
+
+An encoder decides how that playlist becomes a file and what content it contains.
+
+---
+
+## Proposed Implementation Plan
+
+### Step 1 — Introduce policy abstractions
+
+Add internal abstractions for:
+
+- `NamingPolicy`
+- `FormattingPolicy`
+- `ConflictPolicy`
+- `PolicySet`
+
+This step should define the architecture only and should not change visible behaviour.
+
+### Step 2 — Add default policy implementations
+
+Create default policies that mirror the current naming and formatting behaviour already embedded in the system.
+
+This provides a safe compatibility baseline.
+
+### Step 3 — Thread policy through runtime and pipeline
+
+Ensure that the execution path can supply policy to the components that need it.
+
+Policy should be available to presenter and encoder code paths through explicit runtime context rather than hidden global state.
+
+### Step 4 — Move naming decisions into policy
+
+Identify existing hard-coded naming logic and migrate it into `NamingPolicy`.
+
+Initial targets should include:
+
+- file names
+- part names
+- playlist names
+- other obvious naming hotspots currently embedded in presenter or encoder implementations
+
+### Step 5 — Apply formatting policy separately
+
+Introduce formatting as a distinct concern from naming.
+
+This allows a raw logical name to be derived first, then normalized for output constraints.
+
+### Step 6 — Introduce conflict handling at namespace boundaries
+
+Apply conflict resolution where sibling names are inserted into the same logical namespace.
+
+This must remain a naming-resolution concern and must not alter presentation structure.
+
+### Step 7 — Prove swappability
+
+Add at least one alternate policy implementation that changes output naming without requiring presenter or encoder changes.
+
+This is the proof that policy is a real abstraction rather than a relocation of helper functions.
+
+---
+
+## Recommended First Slice
+
+The first implementation slice should be intentionally conservative.
+
+It should include:
+
+- policy traits and `PolicySet`
+- default implementations
+- runtime and pipeline wiring
+- tests proving default behaviour matches the current system
+
+It should not yet attempt broad naming refactors beyond what is needed to establish the abstraction.
+
+---
+
+## Testing Expectations
+
+Phase 4C should include:
+
+### Unit tests
+
+For default policy behaviour, including:
+
+- game naming
+- part naming
+- playlist naming
+- formatting behaviour
+- conflict resolution behaviour
+
+### Integration tests
+
+To verify that:
+
+- default policy preserves existing output
+- alternate policy changes naming without changing structure
+
+### Regression coverage
+
+Existing preview, inspect, and mount-oriented behaviour should continue to behave as expected under the default policy set.
+
+---
+
+## Future Relevance
+
+Phase 4C lays the groundwork for later extensibility.
+
+In particular, it enables future support for:
+
+- multiple naming styles
+- compatibility profiles for specific consumers
+- profile-based composition of presenter, encoder, and policy
+- plugin-based policy implementations in later phases
+
+This is especially important for long-term ideas where the same underlying data may need to conform to different external naming conventions without changing the core pipeline.
+
+---
+
+## Exit Condition
+
+Phase 4C is complete when policy is a first-class architectural concept in the codebase, default behaviour is preserved, and naming-related rules can vary independently of presenter and encoder implementations.

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -5,6 +5,7 @@ use crate::input::identify::InputIdentifier;
 use crate::output::flat_presenter::FlatPresenter;
 use crate::output::grouped_presenter::GroupedPresenter;
 use crate::output::present::{OutputPresenter, PresenterKind};
+use crate::policy::PolicySet;
 
 /// The concrete pipeline components used to run Retromount.
 ///
@@ -15,6 +16,7 @@ pub struct PipelineComponents {
     pub identifier: Box<dyn InputIdentifier>,
     pub decoder: Box<dyn InputDecoder>,
     pub presenter: Box<dyn OutputPresenter>,
+    pub policy: PolicySet,
 }
 
 pub fn default_pipeline_components() -> PipelineComponents {
@@ -31,5 +33,6 @@ pub fn pipeline_components_for_presenter(kind: PresenterKind) -> PipelineCompone
         identifier: Box::new(BasicInputIdentifier::new()),
         decoder: Box::new(BasicInputDecoder::new()),
         presenter,
+        policy: PolicySet::default(),
     }
 }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -22,6 +22,7 @@ pub fn run_phase3_inspect(
         components.identifier.as_ref(),
         components.decoder.as_ref(),
         components.presenter.as_ref(),
+        &components.policy,
     )?;
 
     if json {

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -27,6 +27,7 @@ pub fn run_mount_command(
         components.identifier.as_ref(),
         components.decoder.as_ref(),
         components.presenter.as_ref(),
+        &components.policy,
     )?;
 
     let session = MountSession::from_root(&root);

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -129,6 +129,65 @@ mod tests {
     use crate::input::directory_source::DirectoryInputSource;
     use crate::output::flat_presenter::FlatPresenter;
     use crate::output::grouped_presenter::GroupedPresenter;
+    use crate::policy::{ConflictPolicy, FormattingPolicy, NamingPolicy, PolicySet};
+
+    struct AlternateNamingPolicy;
+
+    impl NamingPolicy for AlternateNamingPolicy {
+        fn game_name(&self, game: &crate::core::content::GameContent) -> String {
+            format!("{} [ALT]", game.title)
+        }
+
+        fn part_name(
+            &self,
+            game: &crate::core::content::GameContent,
+            part: &crate::core::content::GamePart,
+        ) -> String {
+            match part {
+                crate::core::content::GamePart::Rom(rom) => {
+                    format!("ALT-{}", rom.source.file_name())
+                }
+                crate::core::content::GamePart::Disc(disc) => {
+                    format!("{} - CD{}.cue", game.title, disc.disc_number)
+                }
+            }
+        }
+
+        fn playlist_name(&self, game: &crate::core::content::GameContent) -> String {
+            format!("{} - Playlist.m3u", game.title)
+        }
+
+        fn platform_name(&self, platform: &crate::core::content::Platform) -> String {
+            match platform {
+                crate::core::content::Platform::Ps1 => "PlayStation".to_string(),
+                _ => platform.to_string(),
+            }
+        }
+    }
+
+    struct PassthroughFormattingPolicy;
+
+    impl FormattingPolicy for PassthroughFormattingPolicy {
+        fn format_name(&self, raw: &str) -> String {
+            raw.to_string()
+        }
+    }
+
+    struct PreserveConflictPolicy;
+
+    impl ConflictPolicy for PreserveConflictPolicy {
+        fn resolve_name_conflict(&self, proposed: &str, _existing: &[String]) -> String {
+            proposed.to_string()
+        }
+    }
+
+    fn alternate_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(AlternateNamingPolicy),
+            Box::new(PassthroughFormattingPolicy),
+            Box::new(PreserveConflictPolicy),
+        )
+    }
 
     #[test]
     fn runs_end_to_end_directory_pipeline() {
@@ -274,5 +333,88 @@ mod tests {
         assert!(flat_root.find_directory("snes").is_none());
         assert!(flat_root.find_directory("ps1").is_none());
         assert!(flat_root.find_file("Super Mario World.sfc").is_some());
+    }
+
+    #[test]
+    fn pipeline_can_apply_alternate_policy_without_changing_structure() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        fs::write(
+            temp_dir.path().join("Final Fantasy VII (Disc 1).cue"),
+            br#"FILE "Final Fantasy VII (Disc 1).bin" BINARY
+  TRACK 01 MODE2/2352
+    INDEX 01 00:00:00
+"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("Final Fantasy VII (Disc 1).bin"),
+            b"disc1",
+        )
+        .unwrap();
+
+        fs::write(
+            temp_dir.path().join("Final Fantasy VII (Disc 2).cue"),
+            br#"FILE "Final Fantasy VII (Disc 2).bin" BINARY
+  TRACK 01 MODE2/2352
+    INDEX 01 00:00:00
+"#,
+        )
+        .unwrap();
+        fs::write(
+            temp_dir.path().join("Final Fantasy VII (Disc 2).bin"),
+            b"disc2",
+        )
+        .unwrap();
+
+        let source = DirectoryInputSource::new(temp_dir.path());
+        let identifier = BasicInputIdentifier::new();
+        let decoder = BasicInputDecoder::new();
+        let presenter = GroupedPresenter::new();
+
+        let default_policy = PolicySet::default();
+        let alt_policy = alternate_policy();
+
+        let default_root =
+            run_pipeline(&source, &identifier, &decoder, &presenter, &default_policy).unwrap();
+        let alt_root =
+            run_pipeline(&source, &identifier, &decoder, &presenter, &alt_policy).unwrap();
+
+        let default_platform = default_root.find_directory("unknown").unwrap();
+        let default_game = default_platform
+            .find_directory("Final Fantasy VII")
+            .unwrap();
+
+        let alt_platform = alt_root.find_directory("unknown").unwrap();
+        let alt_game = alt_platform
+            .find_directory("Final Fantasy VII [ALT]")
+            .unwrap();
+
+        let default_names: Vec<&str> = default_game
+            .children()
+            .iter()
+            .map(|node| node.name())
+            .collect();
+        let alt_names: Vec<&str> = alt_game.children().iter().map(|node| node.name()).collect();
+
+        assert_eq!(
+            default_names,
+            vec![
+                "Final Fantasy VII (Disc 1).cue",
+                "Final Fantasy VII (Disc 2).cue",
+                "Final Fantasy VII.m3u",
+            ]
+        );
+        assert_eq!(
+            alt_names,
+            vec![
+                "Final Fantasy VII - CD1.cue",
+                "Final Fantasy VII - CD2.cue",
+                "Final Fantasy VII - Playlist.m3u",
+            ]
+        );
+
+        assert_eq!(default_root.children().len(), 1);
+        assert_eq!(alt_root.children().len(), 1);
     }
 }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -9,6 +9,7 @@ use crate::input::decode::InputDecoder;
 use crate::input::identify::{InputIdentifier, InputIdentity};
 use crate::input::source::InputSource;
 use crate::output::present::OutputPresenter;
+use crate::policy::PolicySet;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
@@ -31,12 +32,14 @@ pub fn run_pipeline(
     identifier: &dyn InputIdentifier,
     decoder: &dyn InputDecoder,
     presenter: &dyn OutputPresenter,
+    policy: &PolicySet,
 ) -> Result<VfsDirectory, io::Error> {
     Ok(run_pipeline_with_options(
         source,
         identifier,
         decoder,
         presenter,
+        policy,
         &NormalizationOptions::default(),
     )?
     .output_vfs)
@@ -47,12 +50,14 @@ pub fn run_pipeline_with_trace(
     identifier: &dyn InputIdentifier,
     decoder: &dyn InputDecoder,
     presenter: &dyn OutputPresenter,
+    policy: &PolicySet,
 ) -> Result<PipelineTrace, io::Error> {
     run_pipeline_with_options(
         source,
         identifier,
         decoder,
         presenter,
+        policy,
         &NormalizationOptions::default(),
     )
 }
@@ -62,6 +67,7 @@ pub fn run_pipeline_with_options(
     identifier: &dyn InputIdentifier,
     decoder: &dyn InputDecoder,
     presenter: &dyn OutputPresenter,
+    policy: &PolicySet,
     normalization_options: &NormalizationOptions,
 ) -> Result<PipelineTrace, io::Error> {
     let objects = source.enumerate()?;
@@ -90,7 +96,7 @@ pub fn run_pipeline_with_options(
 
     let normalized = normalize_decoded_content(all_decoded_content, normalization_options);
     let normalized_presentable_content = suppress_consumed_content(&normalized);
-    let output_vfs = presenter.present(&normalized_presentable_content);
+    let output_vfs = presenter.present(&normalized_presentable_content, policy);
 
     Ok(PipelineTrace {
         objects: traced_objects,
@@ -136,7 +142,8 @@ mod tests {
         let decoder = BasicInputDecoder::new();
         let presenter = GroupedPresenter::new();
 
-        let root = run_pipeline(&source, &identifier, &decoder, &presenter).unwrap();
+        let policy = PolicySet::default();
+        let root = run_pipeline(&source, &identifier, &decoder, &presenter, &policy).unwrap();
 
         let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["snes", "blob.dat.bin", "readme.txt"]);
@@ -171,8 +178,8 @@ mod tests {
         let identifier = BasicInputIdentifier::new();
         let decoder = BasicInputDecoder::new();
         let presenter = GroupedPresenter::new();
-
-        let root = run_pipeline(&source, &identifier, &decoder, &presenter).unwrap();
+        let policy = PolicySet::default();
+        let root = run_pipeline(&source, &identifier, &decoder, &presenter, &policy).unwrap();
 
         let names: Vec<&str> = root.children.iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["unknown", "blob.dat.bin", "readme.txt"]);
@@ -190,7 +197,9 @@ mod tests {
         let decoder = BasicInputDecoder::new();
         let presenter = GroupedPresenter::new();
 
-        let trace = run_pipeline_with_trace(&source, &identifier, &decoder, &presenter).unwrap();
+        let policy = PolicySet::default();
+        let trace =
+            run_pipeline_with_trace(&source, &identifier, &decoder, &presenter, &policy).unwrap();
 
         assert_eq!(trace.objects.len(), 3);
         assert_eq!(trace.normalized.len(), 3);
@@ -249,8 +258,9 @@ mod tests {
         let grouped = GroupedPresenter::new();
         let flat = FlatPresenter::new();
 
-        let grouped_root = run_pipeline(&source, &identifier, &decoder, &grouped).unwrap();
-        let flat_root = run_pipeline(&source, &identifier, &decoder, &flat).unwrap();
+        let policy = PolicySet::default();
+        let grouped_root = run_pipeline(&source, &identifier, &decoder, &grouped, &policy).unwrap();
+        let flat_root = run_pipeline(&source, &identifier, &decoder, &flat, &policy).unwrap();
 
         assert!(grouped_root.find_directory("snes").is_some());
         assert!(grouped_root.find_directory("ps1").is_none());

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -416,5 +416,9 @@ mod tests {
 
         assert_eq!(default_root.children().len(), 1);
         assert_eq!(alt_root.children().len(), 1);
+        assert_eq!(default_game.children().len(), 3);
+        assert_eq!(alt_game.children().len(), 3);
+        assert_eq!(default_game.children().len(), 3);
+        assert_eq!(alt_game.children().len(), 3);
     }
 }

--- a/src/engine/preview.rs
+++ b/src/engine/preview.rs
@@ -19,6 +19,7 @@ pub fn run_phase3_preview(path: &Path) -> Result<(), RetromountError> {
         components.identifier.as_ref(),
         components.decoder.as_ref(),
         components.presenter.as_ref(),
+        &components.policy,
     )?;
 
     let stdout = io::stdout();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod input;
 pub mod mount;
 pub mod output;
+pub mod policy;
 pub mod readers;
 
 pub use error::RetromountError;

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ fn run_configured_views() -> Result<(), RetromountError> {
             components.identifier.as_ref(),
             components.decoder.as_ref(),
             components.presenter.as_ref(),
+            &components.policy,
             &NormalizationOptions {
                 platform_hint: Some(map_view_platform(&view.platform)),
             },

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -1,5 +1,6 @@
 use crate::core::content::{GameContent, GamePart, NormalizedContent};
 use crate::output::encode::{EncodedBacking, EncodedFile, OutputEncoder};
+use crate::policy::PolicySet;
 
 pub struct BasicEncoder;
 
@@ -8,15 +9,17 @@ impl BasicEncoder {
         Self
     }
 
-    fn file_name_for(&self, content: &NormalizedContent) -> String {
-        match content {
+    fn file_name_for(&self, content: &NormalizedContent, policy: &PolicySet) -> String {
+        let raw = match content {
             NormalizedContent::Bytes(bytes) => format!("{}.bin", bytes.id),
             NormalizedContent::Game(game) => match game.parts.as_slice() {
-                [part] => self.file_name_for_game_part(game, part),
-                _ => game.title.clone(),
+                [part] => policy.naming().part_name(game, part),
+                _ => policy.naming().game_name(game),
             },
             NormalizedContent::Text(text) => normalize_text_name(text.id.0.as_ref()),
-        }
+        };
+
+        policy.format_name(&raw)
     }
 
     fn backing_for(&self, content: &NormalizedContent) -> EncodedBacking {
@@ -39,11 +42,14 @@ impl BasicEncoder {
         }
     }
 
-    fn file_name_for_game_part(&self, game: &GameContent, part: &GamePart) -> String {
-        match part {
-            GamePart::Rom(rom) => rom.source.file_name(),
-            GamePart::Disc(disc) => format!("{} (Disc {}).cue", game.title, disc.disc_number),
-        }
+    fn file_name_for_game_part(
+        &self,
+        game: &GameContent,
+        part: &GamePart,
+        policy: &PolicySet,
+    ) -> String {
+        let raw = policy.naming().part_name(game, part);
+        policy.format_name(&raw)
     }
 
     fn backing_for_game_part(&self, part: &GamePart) -> EncodedBacking {
@@ -59,8 +65,9 @@ impl BasicEncoder {
         }
     }
 
-    fn playlist_name_for(&self, game: &GameContent) -> String {
-        format!("{}.m3u", game.title)
+    fn playlist_name_for(&self, game: &GameContent, policy: &PolicySet) -> String {
+        let raw = policy.naming().playlist_name(game);
+        policy.format_name(&raw)
     }
 
     fn playlist_backing(&self, entries: &[String]) -> EncodedBacking {
@@ -88,9 +95,13 @@ impl OutputEncoder for BasicEncoder {
         true
     }
 
-    fn encode(&self, content: &NormalizedContent) -> Result<EncodedFile, std::io::Error> {
+    fn encode(
+        &self,
+        content: &NormalizedContent,
+        policy: &PolicySet,
+    ) -> Result<EncodedFile, std::io::Error> {
         Ok(EncodedFile {
-            name: self.file_name_for(content),
+            name: self.file_name_for(content, policy),
             backing: self.backing_for(content),
         })
     }
@@ -99,9 +110,10 @@ impl OutputEncoder for BasicEncoder {
         &self,
         game: &GameContent,
         part: &GamePart,
+        policy: &PolicySet,
     ) -> Result<EncodedFile, std::io::Error> {
         Ok(EncodedFile {
-            name: self.file_name_for_game_part(game, part),
+            name: self.file_name_for_game_part(game, part, policy),
             backing: self.backing_for_game_part(part),
         })
     }
@@ -110,9 +122,10 @@ impl OutputEncoder for BasicEncoder {
         &self,
         game: &GameContent,
         entries: &[String],
+        policy: &PolicySet,
     ) -> Result<EncodedFile, std::io::Error> {
         Ok(EncodedFile {
-            name: self.playlist_name_for(game),
+            name: self.playlist_name_for(game, policy),
             backing: self.playlist_backing(entries),
         })
     }
@@ -130,13 +143,14 @@ mod tests {
     #[test]
     fn encodes_bytes_content() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
         let content = NormalizedContent::Bytes(BytesContent {
             id: ContentId::new("bios"),
             source: SourceRef::new("file:/roms/bios"),
             size: 512,
         });
 
-        let encoded = encoder.encode(&content).unwrap();
+        let encoded = encoder.encode(&content, &policy).unwrap();
         assert_eq!(encoded.name, "bios.bin");
         assert_eq!(
             encoded.backing,
@@ -150,6 +164,7 @@ mod tests {
     #[test]
     fn encodes_single_rom_game_content() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
         let content = NormalizedContent::Game(GameContent {
             id: ContentId::new("smw"),
             source: SourceRef::new("file:/roms/Super Mario World.sfc"),
@@ -162,7 +177,7 @@ mod tests {
             consumed_sources: vec![],
         });
 
-        let encoded = encoder.encode(&content).unwrap();
+        let encoded = encoder.encode(&content, &policy).unwrap();
         assert_eq!(encoded.name, "Super Mario World.sfc");
         assert_eq!(
             encoded.backing,
@@ -176,6 +191,7 @@ mod tests {
     #[test]
     fn encodes_single_disc_game_content() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
         let content = NormalizedContent::Game(GameContent {
             id: ContentId::new("mgs"),
             source: SourceRef::new("cue:/roms/mgs-disc1.cue"),
@@ -189,7 +205,7 @@ mod tests {
             consumed_sources: vec![SourceRef::new("cue:/roms/mgs-disc1.bin")],
         });
 
-        let encoded = encoder.encode(&content).unwrap();
+        let encoded = encoder.encode(&content, &policy).unwrap();
         assert_eq!(encoded.name, "Metal Gear Solid (Disc 1).cue");
         assert_eq!(
             encoded.backing,
@@ -203,6 +219,7 @@ mod tests {
     #[test]
     fn encodes_disc_part() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
         let game = GameContent {
             id: ContentId::new("ff7"),
             source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
@@ -218,7 +235,7 @@ mod tests {
             consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
         });
 
-        let encoded = encoder.encode_game_part(&game, &part).unwrap();
+        let encoded = encoder.encode_game_part(&game, &part, &policy).unwrap();
         assert_eq!(encoded.name, "Final Fantasy VII (Disc 2).cue");
         assert_eq!(
             encoded.backing,
@@ -232,6 +249,7 @@ mod tests {
     #[test]
     fn encodes_playlist() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
         let game = GameContent {
             id: ContentId::new("ff7"),
             source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
@@ -248,6 +266,7 @@ mod tests {
                     "Final Fantasy VII (Disc 1).cue".to_string(),
                     "Final Fantasy VII (Disc 2).cue".to_string(),
                 ],
+                &policy,
             )
             .unwrap();
 
@@ -263,13 +282,14 @@ mod tests {
     #[test]
     fn encodes_text_content() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
         let content = NormalizedContent::Text(TextContent {
             id: ContentId::new("readme"),
             source: SourceRef::new("file:/roms/readme"),
             size: 128,
         });
 
-        let encoded = encoder.encode(&content).unwrap();
+        let encoded = encoder.encode(&content, &policy).unwrap();
         assert_eq!(encoded.name, "readme.txt");
         assert_eq!(
             encoded.backing,
@@ -283,13 +303,14 @@ mod tests {
     #[test]
     fn preserves_relative_path_for_text_content() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
         let content = NormalizedContent::Text(TextContent {
             id: ContentId::new("mixed/notes"),
             source: SourceRef::new("mixed/notes.txt"),
             size: 10,
         });
 
-        let encoded = encoder.encode(&content).unwrap();
+        let encoded = encoder.encode(&content, &policy).unwrap();
         assert_eq!(encoded.name, "mixed/notes.txt");
         assert_eq!(
             encoded.backing,
@@ -303,13 +324,14 @@ mod tests {
     #[test]
     fn normalizes_text_extension_from_id_path() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
         let content = NormalizedContent::Text(TextContent {
             id: ContentId::new("roms/snes/game"),
             source: SourceRef::new("roms/snes/game.nfo"),
             size: 19,
         });
 
-        let encoded = encoder.encode(&content).unwrap();
+        let encoded = encoder.encode(&content, &policy).unwrap();
         assert_eq!(encoded.name, "roms/snes/game.txt");
         assert_eq!(
             encoded.backing,
@@ -323,6 +345,7 @@ mod tests {
     #[test]
     fn derives_rom_file_name_from_zip_member_source() {
         let encoder = BasicEncoder::new();
+        let policy = PolicySet::default();
 
         let game = GameContent {
             id: ContentId::new("sonic"),
@@ -338,8 +361,9 @@ mod tests {
                 &game,
                 &GamePart::Rom(RomPart {
                     source: SourceRef::new("zip:/roms/megadrive.zip#Sonic the Hedgehog.bin"),
-                    size: 1024,
+                    size: 2048,
                 }),
+                &policy,
             )
             .unwrap();
 

--- a/src/output/basic_encoder.rs
+++ b/src/output/basic_encoder.rs
@@ -139,6 +139,106 @@ mod tests {
         RomPart, TextContent,
     };
     use crate::core::source::SourceRef;
+    use crate::policy::{ConflictPolicy, FormattingPolicy, NamingPolicy};
+
+    struct DefaultLikeNamingPolicy;
+
+    impl NamingPolicy for DefaultLikeNamingPolicy {
+        fn game_name(&self, game: &GameContent) -> String {
+            game.title.clone()
+        }
+
+        fn part_name(&self, game: &GameContent, part: &GamePart) -> String {
+            match part {
+                GamePart::Rom(rom) => rom.source.file_name(),
+                GamePart::Disc(disc) => format!("{} (Disc {}).cue", game.title, disc.disc_number),
+            }
+        }
+
+        fn playlist_name(&self, game: &GameContent) -> String {
+            format!("{}.m3u", game.title)
+        }
+
+        fn platform_name(&self, platform: &Platform) -> String {
+            platform.to_string()
+        }
+    }
+
+    struct LowercaseFormattingPolicy;
+
+    impl FormattingPolicy for LowercaseFormattingPolicy {
+        fn format_name(&self, raw: &str) -> String {
+            raw.to_lowercase()
+        }
+    }
+
+    struct PreserveConflictPolicy;
+
+    impl ConflictPolicy for PreserveConflictPolicy {
+        fn resolve_name_conflict(&self, proposed: &str, _existing: &[String]) -> String {
+            proposed.to_string()
+        }
+    }
+
+    fn lowercase_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(DefaultLikeNamingPolicy),
+            Box::new(LowercaseFormattingPolicy),
+            Box::new(PreserveConflictPolicy),
+        )
+    }
+
+    #[test]
+    fn applies_formatting_policy_to_encoded_disc_names() {
+        let encoder = BasicEncoder::new();
+        let policy = lowercase_policy();
+
+        let game = GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![],
+            consumed_sources: vec![],
+        };
+
+        let part = GamePart::Disc(DiscPart {
+            source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+            disc_number: 2,
+            consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+        });
+
+        let encoded = encoder.encode_game_part(&game, &part, &policy).unwrap();
+        assert_eq!(encoded.name, "final fantasy vii (disc 2).cue");
+    }
+
+    #[test]
+    fn applies_formatting_policy_to_encoded_playlist_names() {
+        let encoder = BasicEncoder::new();
+        let policy = lowercase_policy();
+
+        let game = GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![],
+            consumed_sources: vec![],
+        };
+
+        let encoded = encoder
+            .encode_playlist(
+                &game,
+                &[
+                    "final fantasy vii (disc 1).cue".to_string(),
+                    "final fantasy vii (disc 2).cue".to_string(),
+                ],
+                &policy,
+            )
+            .unwrap();
+
+        assert_eq!(encoded.name, "final fantasy vii.m3u");
+    }
 
     #[test]
     fn encodes_bytes_content() {

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -1,6 +1,7 @@
 use crate::core::content::{GameContent, GamePart, NormalizedContent};
 use crate::core::source::SourceRef;
 use crate::core::vfs::VfsFile;
+use crate::policy::PolicySet;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EncodedBacking {
@@ -28,17 +29,23 @@ impl EncodedFile {
 pub trait OutputEncoder: Send + Sync {
     fn can_encode(&self, content: &NormalizedContent) -> bool;
 
-    fn encode(&self, content: &NormalizedContent) -> Result<EncodedFile, std::io::Error>;
+    fn encode(
+        &self,
+        content: &NormalizedContent,
+        policy: &PolicySet,
+    ) -> Result<EncodedFile, std::io::Error>;
 
     fn encode_game_part(
         &self,
         game: &GameContent,
         part: &GamePart,
+        policy: &PolicySet,
     ) -> Result<EncodedFile, std::io::Error>;
 
     fn encode_playlist(
         &self,
         game: &GameContent,
         entries: &[String],
+        policy: &PolicySet,
     ) -> Result<EncodedFile, std::io::Error>;
 }

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -10,9 +10,14 @@ pub struct FlatPresenter {
 }
 
 #[derive(Debug, Clone)]
-struct EncodedEntry {
-    content: NormalizedContent,
-    encoded: EncodedFile,
+enum PresentedEntry {
+    Game(PresentedGame),
+    File(EncodedFile),
+}
+
+#[derive(Debug, Clone)]
+struct PresentedGame {
+    game: GameContent,
 }
 
 impl FlatPresenter {
@@ -22,36 +27,41 @@ impl FlatPresenter {
         }
     }
 
-    fn encode_entries(
+    fn build_presented_entries(
         &self,
         content: &[NormalizedContent],
         policy: &PolicySet,
-    ) -> Vec<EncodedEntry> {
+    ) -> Vec<PresentedEntry> {
         content
             .iter()
-            .filter(|item| self.encoder.can_encode(item))
-            .filter_map(|item| {
-                self.encoder
-                    .encode(item, policy)
-                    .ok()
-                    .map(|encoded| EncodedEntry {
-                        content: item.clone(),
-                        encoded,
-                    })
+            .filter_map(|item| match item {
+                NormalizedContent::Game(game) => {
+                    Some(PresentedEntry::Game(PresentedGame { game: game.clone() }))
+                }
+                NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
+                    if !self.encoder.can_encode(item) {
+                        return None;
+                    }
+
+                    self.encoder
+                        .encode(item, policy)
+                        .ok()
+                        .map(PresentedEntry::File)
+                }
             })
             .collect()
     }
 
-    fn build_root_children(&self, entries: &[EncodedEntry], policy: &PolicySet) -> Vec<VfsNode> {
+    fn build_root_children(&self, entries: &[PresentedEntry], policy: &PolicySet) -> Vec<VfsNode> {
         let mut root = VfsDirectory::new("");
 
         for entry in entries {
-            match &entry.content {
-                NormalizedContent::Game(game) => {
-                    self.insert_game_node(&mut root, game, &entry.encoded, policy);
+            match entry {
+                PresentedEntry::Game(presented) => {
+                    self.insert_game_node(&mut root, &presented.game, policy);
                 }
-                NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
-                    let mut file = entry.encoded.to_vfs_file();
+                PresentedEntry::File(encoded) => {
+                    let mut file = encoded.to_vfs_file();
 
                     if let Some(name) = file.name.rsplit('/').next() {
                         file.name = name.to_string();
@@ -68,7 +78,6 @@ impl FlatPresenter {
                         .resolve_name_conflict(&file.name, &existing);
 
                     file.name = resolved_name;
-
                     root.add_child(VfsNode::File(file));
                 }
             }
@@ -77,17 +86,16 @@ impl FlatPresenter {
         root.children().to_vec()
     }
 
-    fn insert_game_node(
-        &self,
-        root: &mut VfsDirectory,
-        game: &GameContent,
-        encoded: &EncodedFile,
-        policy: &PolicySet,
-    ) {
+    fn insert_game_node(&self, root: &mut VfsDirectory, game: &GameContent, policy: &PolicySet) {
         if self.is_multi_disc_game(game) {
             self.insert_multi_disc_game(root, game, policy);
         } else {
-            let mut file = encoded.to_vfs_file();
+            let mut encoded = self
+                .encoder
+                .encode(&NormalizedContent::Game(game.clone()), policy)
+                .unwrap_or_else(|err| {
+                    panic!("single game should encode for '{}': {err}", game.title)
+                });
 
             let existing: Vec<String> = root
                 .children()
@@ -97,11 +105,10 @@ impl FlatPresenter {
 
             let resolved_name = policy
                 .conflict()
-                .resolve_name_conflict(&file.name, &existing);
+                .resolve_name_conflict(&encoded.name, &existing);
 
-            file.name = resolved_name;
-
-            root.add_child(VfsNode::File(file));
+            encoded.name = resolved_name;
+            root.add_child(VfsNode::File(encoded.to_vfs_file()));
         }
     }
 
@@ -172,7 +179,6 @@ impl FlatPresenter {
             .resolve_name_conflict(&playlist_encoded.name, &existing);
 
         playlist_encoded.name = resolved_name;
-
         root.add_child(VfsNode::File(playlist_encoded.to_vfs_file()));
     }
 
@@ -193,8 +199,8 @@ impl Default for FlatPresenter {
 
 impl OutputPresenter for FlatPresenter {
     fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory {
-        let encoded_entries = self.encode_entries(content, policy);
-        let root_children = self.build_root_children(&encoded_entries, policy);
+        let presented_entries = self.build_presented_entries(content, policy);
+        let root_children = self.build_root_children(&presented_entries, policy);
 
         VfsDirectory::with_children("", root_children)
     }

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -3,6 +3,7 @@ use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
+use crate::policy::PolicySet;
 
 pub struct FlatPresenter {
     encoder: BasicEncoder,
@@ -21,26 +22,33 @@ impl FlatPresenter {
         }
     }
 
-    fn encode_entries(&self, content: &[NormalizedContent]) -> Vec<EncodedEntry> {
+    fn encode_entries(
+        &self,
+        content: &[NormalizedContent],
+        policy: &PolicySet,
+    ) -> Vec<EncodedEntry> {
         content
             .iter()
             .filter(|item| self.encoder.can_encode(item))
             .filter_map(|item| {
-                self.encoder.encode(item).ok().map(|encoded| EncodedEntry {
-                    content: item.clone(),
-                    encoded,
-                })
+                self.encoder
+                    .encode(item, policy)
+                    .ok()
+                    .map(|encoded| EncodedEntry {
+                        content: item.clone(),
+                        encoded,
+                    })
             })
             .collect()
     }
 
-    fn build_root_children(&self, entries: &[EncodedEntry]) -> Vec<VfsNode> {
+    fn build_root_children(&self, entries: &[EncodedEntry], policy: &PolicySet) -> Vec<VfsNode> {
         let mut root = VfsDirectory::new("");
 
         for entry in entries {
             match &entry.content {
                 NormalizedContent::Game(game) => {
-                    self.insert_game_node(&mut root, game, &entry.encoded);
+                    self.insert_game_node(&mut root, game, &entry.encoded, policy);
                 }
                 NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
                     let mut file = entry.encoded.to_vfs_file();
@@ -58,15 +66,26 @@ impl FlatPresenter {
         root.children().to_vec()
     }
 
-    fn insert_game_node(&self, root: &mut VfsDirectory, game: &GameContent, encoded: &EncodedFile) {
+    fn insert_game_node(
+        &self,
+        root: &mut VfsDirectory,
+        game: &GameContent,
+        encoded: &EncodedFile,
+        policy: &PolicySet,
+    ) {
         if self.is_multi_disc_game(game) {
-            self.insert_multi_disc_game(root, game);
+            self.insert_multi_disc_game(root, game, policy);
         } else {
             root.add_child(VfsNode::File(encoded.to_vfs_file()));
         }
     }
 
-    fn insert_multi_disc_game(&self, root: &mut VfsDirectory, game: &GameContent) {
+    fn insert_multi_disc_game(
+        &self,
+        root: &mut VfsDirectory,
+        game: &GameContent,
+        policy: &PolicySet,
+    ) {
         let mut disc_parts: Vec<&DiscPart> = game
             .parts
             .iter()
@@ -83,7 +102,7 @@ impl FlatPresenter {
         for disc in &disc_parts {
             let encoded = self
                 .encoder
-                .encode_game_part(game, &GamePart::Disc((*disc).clone()))
+                .encode_game_part(game, &GamePart::Disc((*disc).clone()), policy)
                 .unwrap_or_else(|err| {
                     panic!(
                         "multi-disc game part should encode for '{}' disc {}: {err}",
@@ -97,7 +116,7 @@ impl FlatPresenter {
 
         let playlist_encoded = self
             .encoder
-            .encode_playlist(game, &disc_names)
+            .encode_playlist(game, &disc_names, policy)
             .unwrap_or_else(|err| {
                 panic!(
                     "multi-disc playlist should encode for '{}': {err}",
@@ -124,9 +143,9 @@ impl Default for FlatPresenter {
 }
 
 impl OutputPresenter for FlatPresenter {
-    fn present(&self, content: &[NormalizedContent]) -> VfsDirectory {
-        let encoded_entries = self.encode_entries(content);
-        let root_children = self.build_root_children(&encoded_entries);
+    fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory {
+        let encoded_entries = self.encode_entries(content, policy);
+        let root_children = self.build_root_children(&encoded_entries, policy);
 
         VfsDirectory::with_children("", root_children)
     }
@@ -144,6 +163,7 @@ mod tests {
     #[test]
     fn presents_mixed_content_at_root() {
         let presenter = FlatPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![
             NormalizedContent::Bytes(BytesContent {
@@ -191,7 +211,7 @@ mod tests {
             }),
         ];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
         assert_eq!(
@@ -210,6 +230,7 @@ mod tests {
     #[test]
     fn presents_single_rom_game_as_root_file() {
         let presenter = FlatPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Game(GameContent {
             id: ContentId::new("smw"),
@@ -223,7 +244,7 @@ mod tests {
             consumed_sources: vec![],
         })];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["Super Mario World.sfc"]);
@@ -232,6 +253,7 @@ mod tests {
     #[test]
     fn presents_multi_disc_game_as_root_files_with_playlist() {
         let presenter = FlatPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Game(GameContent {
             id: ContentId::new("ff7"),
@@ -256,7 +278,7 @@ mod tests {
             ],
         })];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         let child_names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
         assert_eq!(
@@ -287,6 +309,7 @@ mod tests {
     #[test]
     fn flattens_non_game_content_to_leaf_file_names() {
         let presenter = FlatPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![
             NormalizedContent::Bytes(BytesContent {
@@ -306,9 +329,9 @@ mod tests {
             }),
         ];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
-        assert_eq!(names, vec!["cover.jpg.bin", "nested.zip.bin", "notes.txt",]);
+        assert_eq!(names, vec!["cover.jpg.bin", "nested.zip.bin", "notes.txt"]);
     }
 }

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -53,10 +53,21 @@ impl FlatPresenter {
                 NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
                     let mut file = entry.encoded.to_vfs_file();
 
-                    // strip any path components → keep only leaf name
                     if let Some(name) = file.name.rsplit('/').next() {
                         file.name = name.to_string();
                     }
+
+                    let existing: Vec<String> = root
+                        .children()
+                        .iter()
+                        .map(|node| node.name().to_string())
+                        .collect();
+
+                    let resolved_name = policy
+                        .conflict()
+                        .resolve_name_conflict(&file.name, &existing);
+
+                    file.name = resolved_name;
 
                     root.add_child(VfsNode::File(file));
                 }
@@ -76,7 +87,21 @@ impl FlatPresenter {
         if self.is_multi_disc_game(game) {
             self.insert_multi_disc_game(root, game, policy);
         } else {
-            root.add_child(VfsNode::File(encoded.to_vfs_file()));
+            let mut file = encoded.to_vfs_file();
+
+            let existing: Vec<String> = root
+                .children()
+                .iter()
+                .map(|node| node.name().to_string())
+                .collect();
+
+            let resolved_name = policy
+                .conflict()
+                .resolve_name_conflict(&file.name, &existing);
+
+            file.name = resolved_name;
+
+            root.add_child(VfsNode::File(file));
         }
     }
 
@@ -100,7 +125,7 @@ impl FlatPresenter {
         let mut disc_names = Vec::new();
 
         for disc in &disc_parts {
-            let encoded = self
+            let mut encoded = self
                 .encoder
                 .encode_game_part(game, &GamePart::Disc((*disc).clone()), policy)
                 .unwrap_or_else(|err| {
@@ -110,11 +135,23 @@ impl FlatPresenter {
                     )
                 });
 
-            disc_names.push(encoded.name.clone());
+            let existing: Vec<String> = root
+                .children()
+                .iter()
+                .map(|node| node.name().to_string())
+                .collect();
+
+            let resolved_name = policy
+                .conflict()
+                .resolve_name_conflict(&encoded.name, &existing);
+
+            encoded.name = resolved_name.clone();
+            disc_names.push(resolved_name);
+
             root.add_child(VfsNode::File(encoded.to_vfs_file()));
         }
 
-        let playlist_encoded = self
+        let mut playlist_encoded = self
             .encoder
             .encode_playlist(game, &disc_names, policy)
             .unwrap_or_else(|err| {
@@ -123,6 +160,18 @@ impl FlatPresenter {
                     game.title
                 )
             });
+
+        let existing: Vec<String> = root
+            .children()
+            .iter()
+            .map(|node| node.name().to_string())
+            .collect();
+
+        let resolved_name = policy
+            .conflict()
+            .resolve_name_conflict(&playlist_encoded.name, &existing);
+
+        playlist_encoded.name = resolved_name;
 
         root.add_child(VfsNode::File(playlist_encoded.to_vfs_file()));
     }
@@ -159,6 +208,65 @@ mod tests {
     };
     use crate::core::source::SourceRef;
     use crate::core::vfs::FileBacking;
+    use crate::policy::{ConflictPolicy, FormattingPolicy, NamingPolicy, PolicySet};
+
+    struct DefaultLikeNamingPolicy;
+
+    impl NamingPolicy for DefaultLikeNamingPolicy {
+        fn game_name(&self, game: &GameContent) -> String {
+            game.title.clone()
+        }
+
+        fn part_name(&self, game: &GameContent, part: &GamePart) -> String {
+            match part {
+                GamePart::Rom(rom) => rom.source.file_name(),
+                GamePart::Disc(disc) => format!("{} (Disc {}).cue", game.title, disc.disc_number),
+            }
+        }
+
+        fn playlist_name(&self, game: &GameContent) -> String {
+            format!("{}.m3u", game.title)
+        }
+
+        fn platform_name(&self, platform: &Platform) -> String {
+            platform.to_string()
+        }
+    }
+
+    struct PassthroughFormattingPolicy;
+
+    impl FormattingPolicy for PassthroughFormattingPolicy {
+        fn format_name(&self, raw: &str) -> String {
+            raw.to_string()
+        }
+    }
+
+    struct SuffixConflictPolicy;
+
+    impl ConflictPolicy for SuffixConflictPolicy {
+        fn resolve_name_conflict(&self, proposed: &str, existing: &[String]) -> String {
+            if !existing.iter().any(|name| name == proposed) {
+                return proposed.to_string();
+            }
+
+            let mut i = 1;
+            loop {
+                let candidate = format!("{proposed} ({i})");
+                if !existing.iter().any(|name| name == &candidate) {
+                    return candidate;
+                }
+                i += 1;
+            }
+        }
+    }
+
+    fn suffix_conflict_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(DefaultLikeNamingPolicy),
+            Box::new(PassthroughFormattingPolicy),
+            Box::new(SuffixConflictPolicy),
+        )
+    }
 
     #[test]
     fn presents_mixed_content_at_root() {
@@ -333,5 +441,29 @@ mod tests {
 
         let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["cover.jpg.bin", "nested.zip.bin", "notes.txt"]);
+    }
+
+    #[test]
+    fn conflict_policy_can_disambiguate_flat_sibling_file_names() {
+        let presenter = FlatPresenter::new();
+        let policy = suffix_conflict_policy();
+
+        let content = vec![
+            NormalizedContent::Bytes(BytesContent {
+                id: ContentId::new("docs/readme"),
+                source: SourceRef::new("file:/roms/docs/readme"),
+                size: 10,
+            }),
+            NormalizedContent::Bytes(BytesContent {
+                id: ContentId::new("other/readme"),
+                source: SourceRef::new("file:/roms/other/readme"),
+                size: 11,
+            }),
+        ];
+
+        let root = presenter.present(&content, &policy);
+
+        let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["readme.bin", "readme.bin (1)"]);
     }
 }

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -1,9 +1,9 @@
 use crate::core::content::NormalizedContent;
 use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
+use crate::output::name_allocator::allocate_file_name;
 use crate::output::present::OutputPresenter;
 use crate::output::presented::{build_presented_entries, PresentedEntry, PresentedGame};
-use crate::output::presenter_utils::resolve_name;
 use crate::policy::PolicySet;
 
 pub struct FlatPresenter {
@@ -32,13 +32,7 @@ impl FlatPresenter {
                         file.name = name.to_string();
                     }
 
-                    let existing: Vec<String> = root
-                        .children()
-                        .iter()
-                        .map(|node| node.name().to_string())
-                        .collect();
-
-                    file.name = resolve_name(&file.name, &existing, policy);
+                    file.name = allocate_file_name(&root, &file.name, policy);
                     root.add_child(VfsNode::File(file));
                 }
             }
@@ -55,14 +49,7 @@ impl FlatPresenter {
     ) {
         for encoded in &presented.files {
             let mut encoded = encoded.clone();
-
-            let existing: Vec<String> = root
-                .children()
-                .iter()
-                .map(|node| node.name().to_string())
-                .collect();
-
-            encoded.name = resolve_name(&encoded.name, &existing, policy);
+            encoded.name = allocate_file_name(&root, &encoded.name, policy);
             root.add_child(VfsNode::File(encoded.to_vfs_file()));
         }
     }
@@ -90,7 +77,6 @@ mod tests {
         BytesContent, ContentId, DiscPart, GameContent, GamePart, Platform, RomPart, TextContent,
     };
     use crate::core::source::SourceRef;
-    use crate::core::vfs::FileBacking;
     use crate::policy::{ConflictPolicy, FormattingPolicy, NamingPolicy, PolicySet};
 
     struct DefaultLikeNamingPolicy;

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -335,4 +335,102 @@ mod tests {
         let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["readme.bin", "readme.bin (1)"]);
     }
+
+    #[test]
+    fn conflict_policy_can_disambiguate_game_file_and_non_game_file_at_root() {
+        let presenter = FlatPresenter::new();
+        let policy = suffix_conflict_policy();
+
+        let content = vec![
+            NormalizedContent::Bytes(BytesContent {
+                id: ContentId::new("other/readme"),
+                source: SourceRef::new("file:/roms/other/readme"),
+                size: 10,
+            }),
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("readme-game"),
+                source: SourceRef::new("file:/roms/readme.bin"),
+                title: "readme".to_string(),
+                platform: Platform::Megadrive,
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("file:/roms/readme.bin"),
+                    size: 1024,
+                })],
+                consumed_sources: vec![],
+            }),
+        ];
+
+        let root = presenter.present(&content, &policy);
+
+        let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["readme.bin", "readme.bin (1)"]);
+    }
+
+    #[test]
+    fn conflict_policy_can_disambiguate_playlist_between_duplicate_multi_disc_games() {
+        let presenter = FlatPresenter::new();
+        let policy = suffix_conflict_policy();
+
+        let content = vec![
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("ff7-a"),
+                source: SourceRef::new("cue:/roms/ff7-a-disc1.cue"),
+                title: "Final Fantasy VII".to_string(),
+                platform: Platform::Ps1,
+                parts: vec![
+                    GamePart::Disc(DiscPart {
+                        source: SourceRef::new("cue:/roms/ff7-a-disc2.cue"),
+                        disc_number: 2,
+                        consumed_sources: vec![SourceRef::new("cue:/roms/ff7-a-disc2.bin")],
+                    }),
+                    GamePart::Disc(DiscPart {
+                        source: SourceRef::new("cue:/roms/ff7-a-disc1.cue"),
+                        disc_number: 1,
+                        consumed_sources: vec![SourceRef::new("cue:/roms/ff7-a-disc1.bin")],
+                    }),
+                ],
+                consumed_sources: vec![
+                    SourceRef::new("cue:/roms/ff7-a-disc2.bin"),
+                    SourceRef::new("cue:/roms/ff7-a-disc1.bin"),
+                ],
+            }),
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("ff7-b"),
+                source: SourceRef::new("cue:/roms/ff7-b-disc1.cue"),
+                title: "Final Fantasy VII".to_string(),
+                platform: Platform::Ps1,
+                parts: vec![
+                    GamePart::Disc(DiscPart {
+                        source: SourceRef::new("cue:/roms/ff7-b-disc2.cue"),
+                        disc_number: 2,
+                        consumed_sources: vec![SourceRef::new("cue:/roms/ff7-b-disc2.bin")],
+                    }),
+                    GamePart::Disc(DiscPart {
+                        source: SourceRef::new("cue:/roms/ff7-b-disc1.cue"),
+                        disc_number: 1,
+                        consumed_sources: vec![SourceRef::new("cue:/roms/ff7-b-disc1.bin")],
+                    }),
+                ],
+                consumed_sources: vec![
+                    SourceRef::new("cue:/roms/ff7-b-disc2.bin"),
+                    SourceRef::new("cue:/roms/ff7-b-disc1.bin"),
+                ],
+            }),
+        ];
+
+        let root = presenter.present(&content, &policy);
+
+        let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "Final Fantasy VII (Disc 1).cue",
+                "Final Fantasy VII (Disc 1).cue (1)",
+                "Final Fantasy VII (Disc 2).cue",
+                "Final Fantasy VII (Disc 2).cue (1)",
+                "Final Fantasy VII.m3u",
+                "Final Fantasy VII.m3u (1)",
+            ]
+        );
+    }
 }

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -49,7 +49,7 @@ impl FlatPresenter {
     ) {
         for encoded in &presented.files {
             let mut encoded = encoded.clone();
-            encoded.name = allocate_file_name(&root, &encoded.name, policy);
+            encoded.name = allocate_file_name(root, &encoded.name, policy);
             root.add_child(VfsNode::File(encoded.to_vfs_file()));
         }
     }

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -1,9 +1,11 @@
-use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
+use crate::core::content::{GameContent, NormalizedContent};
 use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
-use crate::output::encode::OutputEncoder;
 use crate::output::present::OutputPresenter;
 use crate::output::presented::{build_presented_entries, PresentedEntry};
+use crate::output::presenter_utils::{
+    encode_disc, encode_game, encode_playlist, is_multi_disc_game, resolve_name, sorted_disc_parts,
+};
 use crate::policy::PolicySet;
 
 pub struct FlatPresenter {
@@ -38,11 +40,7 @@ impl FlatPresenter {
                         .map(|node| node.name().to_string())
                         .collect();
 
-                    let resolved_name = policy
-                        .conflict()
-                        .resolve_name_conflict(&file.name, &existing);
-
-                    file.name = resolved_name;
+                    file.name = resolve_name(&file.name, &existing, policy);
                     root.add_child(VfsNode::File(file));
                 }
             }
@@ -52,15 +50,10 @@ impl FlatPresenter {
     }
 
     fn insert_game_node(&self, root: &mut VfsDirectory, game: &GameContent, policy: &PolicySet) {
-        if self.is_multi_disc_game(game) {
+        if is_multi_disc_game(game) {
             self.insert_multi_disc_game(root, game, policy);
         } else {
-            let mut encoded = self
-                .encoder
-                .encode(&NormalizedContent::Game(game.clone()), policy)
-                .unwrap_or_else(|err| {
-                    panic!("single game should encode for '{}': {err}", game.title)
-                });
+            let mut encoded = encode_game(&self.encoder, game, policy);
 
             let existing: Vec<String> = root
                 .children()
@@ -68,11 +61,7 @@ impl FlatPresenter {
                 .map(|node| node.name().to_string())
                 .collect();
 
-            let resolved_name = policy
-                .conflict()
-                .resolve_name_conflict(&encoded.name, &existing);
-
-            encoded.name = resolved_name;
+            encoded.name = resolve_name(&encoded.name, &existing, policy);
             root.add_child(VfsNode::File(encoded.to_vfs_file()));
         }
     }
@@ -83,29 +72,11 @@ impl FlatPresenter {
         game: &GameContent,
         policy: &PolicySet,
     ) {
-        let mut disc_parts: Vec<&DiscPart> = game
-            .parts
-            .iter()
-            .filter_map(|part| match part {
-                GamePart::Disc(disc) => Some(disc),
-                _ => None,
-            })
-            .collect();
-
-        disc_parts.sort_by(|left, right| left.disc_number.cmp(&right.disc_number));
-
+        let disc_parts = sorted_disc_parts(game);
         let mut disc_names = Vec::new();
 
-        for disc in &disc_parts {
-            let mut encoded = self
-                .encoder
-                .encode_game_part(game, &GamePart::Disc((*disc).clone()), policy)
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "multi-disc game part should encode for '{}' disc {}: {err}",
-                        game.title, disc.disc_number
-                    )
-                });
+        for disc in disc_parts {
+            let mut encoded = encode_disc(&self.encoder, game, disc, policy);
 
             let existing: Vec<String> = root
                 .children()
@@ -113,25 +84,14 @@ impl FlatPresenter {
                 .map(|node| node.name().to_string())
                 .collect();
 
-            let resolved_name = policy
-                .conflict()
-                .resolve_name_conflict(&encoded.name, &existing);
-
+            let resolved_name = resolve_name(&encoded.name, &existing, policy);
             encoded.name = resolved_name.clone();
             disc_names.push(resolved_name);
 
             root.add_child(VfsNode::File(encoded.to_vfs_file()));
         }
 
-        let mut playlist_encoded = self
-            .encoder
-            .encode_playlist(game, &disc_names, policy)
-            .unwrap_or_else(|err| {
-                panic!(
-                    "multi-disc playlist should encode for '{}': {err}",
-                    game.title
-                )
-            });
+        let mut playlist_encoded = encode_playlist(&self.encoder, game, &disc_names, policy);
 
         let existing: Vec<String> = root
             .children()
@@ -139,20 +99,8 @@ impl FlatPresenter {
             .map(|node| node.name().to_string())
             .collect();
 
-        let resolved_name = policy
-            .conflict()
-            .resolve_name_conflict(&playlist_encoded.name, &existing);
-
-        playlist_encoded.name = resolved_name;
+        playlist_encoded.name = resolve_name(&playlist_encoded.name, &existing, policy);
         root.add_child(VfsNode::File(playlist_encoded.to_vfs_file()));
-    }
-
-    fn is_multi_disc_game(&self, game: &GameContent) -> bool {
-        game.parts.len() > 1
-            && game
-                .parts
-                .iter()
-                .all(|part| matches!(part, GamePart::Disc(_)))
     }
 }
 

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -1,11 +1,9 @@
-use crate::core::content::{GameContent, NormalizedContent};
+use crate::core::content::NormalizedContent;
 use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
 use crate::output::present::OutputPresenter;
-use crate::output::presented::{build_presented_entries, PresentedEntry};
-use crate::output::presenter_utils::{
-    encode_disc, encode_game, encode_playlist, is_multi_disc_game, resolve_name, sorted_disc_parts,
-};
+use crate::output::presented::{build_presented_entries, PresentedEntry, PresentedGame};
+use crate::output::presenter_utils::resolve_name;
 use crate::policy::PolicySet;
 
 pub struct FlatPresenter {
@@ -25,7 +23,7 @@ impl FlatPresenter {
         for entry in entries {
             match entry {
                 PresentedEntry::Game(presented) => {
-                    self.insert_game_node(&mut root, &presented.game, policy);
+                    self.insert_game_files(&mut root, presented, policy);
                 }
                 PresentedEntry::File(encoded) => {
                     let mut file = encoded.to_vfs_file();
@@ -49,11 +47,14 @@ impl FlatPresenter {
         root.children().to_vec()
     }
 
-    fn insert_game_node(&self, root: &mut VfsDirectory, game: &GameContent, policy: &PolicySet) {
-        if is_multi_disc_game(game) {
-            self.insert_multi_disc_game(root, game, policy);
-        } else {
-            let mut encoded = encode_game(&self.encoder, game, policy);
+    fn insert_game_files(
+        &self,
+        root: &mut VfsDirectory,
+        presented: &PresentedGame,
+        policy: &PolicySet,
+    ) {
+        for encoded in &presented.files {
+            let mut encoded = encoded.clone();
 
             let existing: Vec<String> = root
                 .children()
@@ -64,43 +65,6 @@ impl FlatPresenter {
             encoded.name = resolve_name(&encoded.name, &existing, policy);
             root.add_child(VfsNode::File(encoded.to_vfs_file()));
         }
-    }
-
-    fn insert_multi_disc_game(
-        &self,
-        root: &mut VfsDirectory,
-        game: &GameContent,
-        policy: &PolicySet,
-    ) {
-        let disc_parts = sorted_disc_parts(game);
-        let mut disc_names = Vec::new();
-
-        for disc in disc_parts {
-            let mut encoded = encode_disc(&self.encoder, game, disc, policy);
-
-            let existing: Vec<String> = root
-                .children()
-                .iter()
-                .map(|node| node.name().to_string())
-                .collect();
-
-            let resolved_name = resolve_name(&encoded.name, &existing, policy);
-            encoded.name = resolved_name.clone();
-            disc_names.push(resolved_name);
-
-            root.add_child(VfsNode::File(encoded.to_vfs_file()));
-        }
-
-        let mut playlist_encoded = encode_playlist(&self.encoder, game, &disc_names, policy);
-
-        let existing: Vec<String> = root
-            .children()
-            .iter()
-            .map(|node| node.name().to_string())
-            .collect();
-
-        playlist_encoded.name = resolve_name(&playlist_encoded.name, &existing, policy);
-        root.add_child(VfsNode::File(playlist_encoded.to_vfs_file()));
     }
 }
 
@@ -323,7 +287,7 @@ mod tests {
         };
 
         match &playlist.backing {
-            FileBacking::Inline(contents) => {
+            crate::core::vfs::FileBacking::Inline(contents) => {
                 assert_eq!(
                     contents,
                     b"Final Fantasy VII (Disc 1).cue\nFinal Fantasy VII (Disc 2).cue\n"

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -1,23 +1,13 @@
 use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
 use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
-use crate::output::encode::{EncodedFile, OutputEncoder};
+use crate::output::encode::OutputEncoder;
 use crate::output::present::OutputPresenter;
+use crate::output::presented::{build_presented_entries, PresentedEntry};
 use crate::policy::PolicySet;
 
 pub struct FlatPresenter {
     encoder: BasicEncoder,
-}
-
-#[derive(Debug, Clone)]
-enum PresentedEntry {
-    Game(PresentedGame),
-    File(EncodedFile),
-}
-
-#[derive(Debug, Clone)]
-struct PresentedGame {
-    game: GameContent,
 }
 
 impl FlatPresenter {
@@ -25,31 +15,6 @@ impl FlatPresenter {
         Self {
             encoder: BasicEncoder::new(),
         }
-    }
-
-    fn build_presented_entries(
-        &self,
-        content: &[NormalizedContent],
-        policy: &PolicySet,
-    ) -> Vec<PresentedEntry> {
-        content
-            .iter()
-            .filter_map(|item| match item {
-                NormalizedContent::Game(game) => {
-                    Some(PresentedEntry::Game(PresentedGame { game: game.clone() }))
-                }
-                NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
-                    if !self.encoder.can_encode(item) {
-                        return None;
-                    }
-
-                    self.encoder
-                        .encode(item, policy)
-                        .ok()
-                        .map(PresentedEntry::File)
-                }
-            })
-            .collect()
     }
 
     fn build_root_children(&self, entries: &[PresentedEntry], policy: &PolicySet) -> Vec<VfsNode> {
@@ -199,7 +164,7 @@ impl Default for FlatPresenter {
 
 impl OutputPresenter for FlatPresenter {
     fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory {
-        let presented_entries = self.build_presented_entries(content, policy);
+        let presented_entries = build_presented_entries(content, &self.encoder, policy);
         let root_children = self.build_root_children(&presented_entries, policy);
 
         VfsDirectory::with_children("", root_children)

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -1,9 +1,11 @@
-use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
+use crate::core::content::{GameContent, NormalizedContent};
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
-use crate::output::encode::OutputEncoder;
 use crate::output::present::OutputPresenter;
 use crate::output::presented::{build_presented_entries, PresentedEntry};
+use crate::output::presenter_utils::{
+    encode_disc, encode_game, encode_playlist, is_multi_disc_game, resolve_name, sorted_disc_parts,
+};
 use crate::policy::PolicySet;
 
 pub struct GroupedPresenter {
@@ -44,16 +46,10 @@ impl GroupedPresenter {
             policy.format_name(&game_name)
         );
 
-        if self.is_multi_disc_game(game) {
+        if is_multi_disc_game(game) {
             self.insert_multi_disc_game(root, game, &base_path, policy);
         } else {
-            let encoded = self
-                .encoder
-                .encode(&NormalizedContent::Game(game.clone()), policy)
-                .unwrap_or_else(|err| {
-                    panic!("single game should encode for '{}': {err}", game.title)
-                });
-
+            let encoded = encode_game(&self.encoder, game, policy);
             let file_path = format!("{}/{}", base_path, encoded.name);
             self.insert_file_path(root, &file_path, encoded.to_vfs_file(), policy);
         }
@@ -66,46 +62,18 @@ impl GroupedPresenter {
         base_path: &str,
         policy: &PolicySet,
     ) {
-        let mut disc_parts: Vec<&DiscPart> = game
-            .parts
-            .iter()
-            .filter_map(|part| match part {
-                GamePart::Disc(disc) => Some(disc),
-                _ => None,
-            })
-            .collect();
-
-        disc_parts.sort_by(|left, right| left.disc_number.cmp(&right.disc_number));
-
+        let disc_parts = sorted_disc_parts(game);
         let mut disc_names = Vec::new();
 
-        for disc in &disc_parts {
-            let encoded = self
-                .encoder
-                .encode_game_part(game, &GamePart::Disc((*disc).clone()), policy)
-                .unwrap_or_else(|err| {
-                    panic!(
-                        "multi-disc game part should encode for '{}' disc {}: {err}",
-                        game.title, disc.disc_number
-                    )
-                });
-
+        for disc in disc_parts {
+            let encoded = encode_disc(&self.encoder, game, disc, policy);
             disc_names.push(encoded.name.clone());
 
             let disc_path = format!("{}/{}", base_path, encoded.name);
             self.insert_file_path(root, &disc_path, encoded.to_vfs_file(), policy);
         }
 
-        let playlist_encoded = self
-            .encoder
-            .encode_playlist(game, &disc_names, policy)
-            .unwrap_or_else(|err| {
-                panic!(
-                    "multi-disc playlist should encode for '{}': {err}",
-                    game.title
-                )
-            });
-
+        let playlist_encoded = encode_playlist(&self.encoder, game, &disc_names, policy);
         let playlist_path = format!("{}/{}", base_path, playlist_encoded.name);
         self.insert_file_path(root, &playlist_path, playlist_encoded.to_vfs_file(), policy);
     }
@@ -127,22 +95,10 @@ impl GroupedPresenter {
             .map(|node| node.name().to_string())
             .collect();
 
-        let resolved_name = policy
-            .conflict()
-            .resolve_name_conflict(&file_name, &existing);
-
         let mut file = file;
-        file.name = resolved_name;
+        file.name = resolve_name(&file_name, &existing, policy);
 
         directory.add_child(VfsNode::File(file));
-    }
-
-    fn is_multi_disc_game(&self, game: &GameContent) -> bool {
-        game.parts.len() > 1
-            && game
-                .parts
-                .iter()
-                .all(|part| matches!(part, GamePart::Disc(_)))
     }
 }
 
@@ -202,7 +158,7 @@ fn ensure_directory<'a>(
             if existing.iter().any(|name| name == segment) {
                 segment.clone()
             } else {
-                policy.conflict().resolve_name_conflict(segment, &existing)
+                resolve_name(segment, &existing, policy)
             }
         };
 

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -238,6 +238,57 @@ mod tests {
     };
     use crate::core::source::SourceRef;
     use crate::core::vfs::FileBacking;
+    use crate::policy::{ConflictPolicy, FormattingPolicy, NamingPolicy, PolicySet};
+
+    struct AlternateNamingPolicy;
+
+    impl NamingPolicy for AlternateNamingPolicy {
+        fn game_name(&self, game: &GameContent) -> String {
+            format!("{} [ALT]", game.title)
+        }
+
+        fn part_name(&self, game: &GameContent, part: &GamePart) -> String {
+            match part {
+                GamePart::Rom(rom) => format!("ALT-{}", rom.source.file_name()),
+                GamePart::Disc(disc) => format!("{} - CD{}.cue", game.title, disc.disc_number),
+            }
+        }
+
+        fn playlist_name(&self, game: &GameContent) -> String {
+            format!("{} - Playlist.m3u", game.title)
+        }
+
+        fn platform_name(&self, platform: &Platform) -> String {
+            match platform {
+                Platform::Ps1 => "PlayStation".to_string(),
+                _ => platform.to_string(),
+            }
+        }
+    }
+
+    struct PassthroughFormattingPolicy;
+
+    impl FormattingPolicy for PassthroughFormattingPolicy {
+        fn format_name(&self, raw: &str) -> String {
+            raw.to_string()
+        }
+    }
+
+    struct PreserveConflictPolicy;
+
+    impl ConflictPolicy for PreserveConflictPolicy {
+        fn resolve_name_conflict(&self, proposed: &str, _existing: &[String]) -> String {
+            proposed.to_string()
+        }
+    }
+
+    fn alternate_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(AlternateNamingPolicy),
+            Box::new(PassthroughFormattingPolicy),
+            Box::new(PreserveConflictPolicy),
+        )
+    }
 
     #[test]
     fn presents_mixed_content_in_library_view() {
@@ -487,5 +538,73 @@ mod tests {
 
         let names: Vec<&str> = zips.children().iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["gameboy_collection.zip.bin"]);
+    }
+
+    #[test]
+    fn naming_policy_can_change_grouped_output_names_without_changing_structure() {
+        let presenter = GroupedPresenter::new();
+        let default_policy = PolicySet::default();
+        let alt_policy = alternate_policy();
+
+        let content = vec![NormalizedContent::Game(GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+                    disc_number: 2,
+                    consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+                }),
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+                    disc_number: 1,
+                    consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc1.bin")],
+                }),
+            ],
+            consumed_sources: vec![
+                SourceRef::new("cue:/roms/ff7-disc2.bin"),
+                SourceRef::new("cue:/roms/ff7-disc1.bin"),
+            ],
+        })];
+
+        let default_root = presenter.present(&content, &default_policy);
+        let alt_root = presenter.present(&content, &alt_policy);
+
+        let default_platform = default_root.find_directory("ps1").unwrap();
+        let default_game = default_platform
+            .find_directory("Final Fantasy VII")
+            .unwrap();
+        let default_names: Vec<&str> = default_game
+            .children()
+            .iter()
+            .map(|node| node.name())
+            .collect();
+        assert_eq!(
+            default_names,
+            vec![
+                "Final Fantasy VII (Disc 1).cue",
+                "Final Fantasy VII (Disc 2).cue",
+                "Final Fantasy VII.m3u",
+            ]
+        );
+
+        let alt_platform = alt_root.find_directory("PlayStation").unwrap();
+        let alt_game = alt_platform
+            .find_directory("Final Fantasy VII [ALT]")
+            .unwrap();
+        let alt_names: Vec<&str> = alt_game.children().iter().map(|node| node.name()).collect();
+        assert_eq!(
+            alt_names,
+            vec![
+                "Final Fantasy VII - CD1.cue",
+                "Final Fantasy VII - CD2.cue",
+                "Final Fantasy VII - Playlist.m3u",
+            ]
+        );
+
+        assert_eq!(default_root.children().len(), 1);
+        assert_eq!(alt_root.children().len(), 1);
     }
 }

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -1,11 +1,9 @@
-use crate::core::content::{GameContent, NormalizedContent};
+use crate::core::content::NormalizedContent;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
 use crate::output::present::OutputPresenter;
-use crate::output::presented::{build_presented_entries, PresentedEntry};
-use crate::output::presenter_utils::{
-    encode_disc, encode_game, encode_playlist, is_multi_disc_game, resolve_name, sorted_disc_parts,
-};
+use crate::output::presented::{build_presented_entries, PresentedEntry, PresentedGame};
+use crate::output::presenter_utils::resolve_name;
 use crate::policy::PolicySet;
 
 pub struct GroupedPresenter {
@@ -25,7 +23,7 @@ impl GroupedPresenter {
         for entry in entries {
             match entry {
                 PresentedEntry::Game(presented) => {
-                    self.insert_game_node(&mut root, &presented.game, policy);
+                    self.insert_game_node(&mut root, presented, policy);
                 }
                 PresentedEntry::File(encoded) => {
                     self.insert_file_path(&mut root, &encoded.name, encoded.to_vfs_file(), policy);
@@ -36,7 +34,13 @@ impl GroupedPresenter {
         root.children().to_vec()
     }
 
-    fn insert_game_node(&self, root: &mut VfsDirectory, game: &GameContent, policy: &PolicySet) {
+    fn insert_game_node(
+        &self,
+        root: &mut VfsDirectory,
+        presented: &PresentedGame,
+        policy: &PolicySet,
+    ) {
+        let game = &presented.game;
         let platform_name = policy.naming().platform_name(&game.platform);
         let game_name = policy.naming().game_name(game);
 
@@ -46,36 +50,10 @@ impl GroupedPresenter {
             policy.format_name(&game_name)
         );
 
-        if is_multi_disc_game(game) {
-            self.insert_multi_disc_game(root, game, &base_path, policy);
-        } else {
-            let encoded = encode_game(&self.encoder, game, policy);
+        for encoded in &presented.files {
             let file_path = format!("{}/{}", base_path, encoded.name);
             self.insert_file_path(root, &file_path, encoded.to_vfs_file(), policy);
         }
-    }
-
-    fn insert_multi_disc_game(
-        &self,
-        root: &mut VfsDirectory,
-        game: &GameContent,
-        base_path: &str,
-        policy: &PolicySet,
-    ) {
-        let disc_parts = sorted_disc_parts(game);
-        let mut disc_names = Vec::new();
-
-        for disc in disc_parts {
-            let encoded = encode_disc(&self.encoder, game, disc, policy);
-            disc_names.push(encoded.name.clone());
-
-            let disc_path = format!("{}/{}", base_path, encoded.name);
-            self.insert_file_path(root, &disc_path, encoded.to_vfs_file(), policy);
-        }
-
-        let playlist_encoded = encode_playlist(&self.encoder, game, &disc_names, policy);
-        let playlist_path = format!("{}/{}", base_path, playlist_encoded.name);
-        self.insert_file_path(root, &playlist_path, playlist_encoded.to_vfs_file(), policy);
     }
 
     fn insert_file_path(

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -1,9 +1,9 @@
 use crate::core::content::NormalizedContent;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
+use crate::output::name_allocator::{allocate_directory_name, allocate_file_name};
 use crate::output::present::OutputPresenter;
 use crate::output::presented::{build_presented_entries, PresentedEntry, PresentedGame};
-use crate::output::presenter_utils::resolve_name;
 use crate::policy::PolicySet;
 
 pub struct GroupedPresenter {
@@ -66,16 +66,8 @@ impl GroupedPresenter {
         let normalized = normalize_path(path);
         let (parents, file_name) = split_parent_dirs(&normalized);
         let directory = ensure_directory(root, &parents, policy);
-
-        let existing: Vec<String> = directory
-            .children()
-            .iter()
-            .map(|node| node.name().to_string())
-            .collect();
-
         let mut file = file;
-        file.name = resolve_name(&file_name, &existing, policy);
-
+        file.name = allocate_file_name(directory, &file_name, policy);
         directory.add_child(VfsNode::File(file));
     }
 }
@@ -123,23 +115,7 @@ fn ensure_directory<'a>(
     let mut current = root;
 
     for segment in parents {
-        let resolved_segment = {
-            let existing: Vec<String> = current
-                .children()
-                .iter()
-                .filter_map(|node| match node {
-                    VfsNode::Directory(dir) => Some(dir.name.clone()),
-                    _ => None,
-                })
-                .collect();
-
-            if existing.iter().any(|name| name == segment) {
-                segment.clone()
-            } else {
-                resolve_name(segment, &existing, policy)
-            }
-        };
-
+        let resolved_segment = allocate_directory_name(current, segment, policy);
         let index = match current.children.iter().position(
             |node| matches!(node, VfsNode::Directory(dir) if dir.name == resolved_segment),
         ) {

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -1,23 +1,13 @@
 use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
-use crate::output::encode::{EncodedFile, OutputEncoder};
+use crate::output::encode::OutputEncoder;
 use crate::output::present::OutputPresenter;
+use crate::output::presented::{build_presented_entries, PresentedEntry};
 use crate::policy::PolicySet;
 
 pub struct GroupedPresenter {
     encoder: BasicEncoder,
-}
-
-#[derive(Debug, Clone)]
-enum PresentedEntry {
-    Game(PresentedGame),
-    File(EncodedFile),
-}
-
-#[derive(Debug, Clone)]
-struct PresentedGame {
-    game: GameContent,
 }
 
 impl GroupedPresenter {
@@ -25,31 +15,6 @@ impl GroupedPresenter {
         Self {
             encoder: BasicEncoder::new(),
         }
-    }
-
-    fn build_presented_entries(
-        &self,
-        content: &[NormalizedContent],
-        policy: &PolicySet,
-    ) -> Vec<PresentedEntry> {
-        content
-            .iter()
-            .filter_map(|item| match item {
-                NormalizedContent::Game(game) => {
-                    Some(PresentedEntry::Game(PresentedGame { game: game.clone() }))
-                }
-                NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
-                    if !self.encoder.can_encode(item) {
-                        return None;
-                    }
-
-                    self.encoder
-                        .encode(item, policy)
-                        .ok()
-                        .map(PresentedEntry::File)
-                }
-            })
-            .collect()
     }
 
     fn build_root_children(&self, entries: &[PresentedEntry], policy: &PolicySet) -> Vec<VfsNode> {
@@ -189,7 +154,7 @@ impl Default for GroupedPresenter {
 
 impl OutputPresenter for GroupedPresenter {
     fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory {
-        let presented_entries = self.build_presented_entries(content, policy);
+        let presented_entries = build_presented_entries(content, &self.encoder, policy);
         let root_children = self.build_root_children(&presented_entries, policy);
 
         VfsDirectory::with_children("", root_children)

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -3,6 +3,7 @@ use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
+use crate::policy::PolicySet;
 
 pub struct GroupedPresenter {
     encoder: BasicEncoder,
@@ -21,26 +22,33 @@ impl GroupedPresenter {
         }
     }
 
-    fn encode_entries(&self, content: &[NormalizedContent]) -> Vec<EncodedEntry> {
+    fn encode_entries(
+        &self,
+        content: &[NormalizedContent],
+        policy: &PolicySet,
+    ) -> Vec<EncodedEntry> {
         content
             .iter()
             .filter(|item| self.encoder.can_encode(item))
             .filter_map(|item| {
-                self.encoder.encode(item).ok().map(|encoded| EncodedEntry {
-                    content: item.clone(),
-                    encoded,
-                })
+                self.encoder
+                    .encode(item, policy)
+                    .ok()
+                    .map(|encoded| EncodedEntry {
+                        content: item.clone(),
+                        encoded,
+                    })
             })
             .collect()
     }
 
-    fn build_root_children(&self, entries: &[EncodedEntry]) -> Vec<VfsNode> {
+    fn build_root_children(&self, entries: &[EncodedEntry], policy: &PolicySet) -> Vec<VfsNode> {
         let mut root = VfsDirectory::new("");
 
         for entry in entries {
             match &entry.content {
                 NormalizedContent::Game(game) => {
-                    self.insert_game_node(&mut root, game, &entry.encoded);
+                    self.insert_game_node(&mut root, game, &entry.encoded, policy);
                 }
                 NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
                     self.insert_file_path(
@@ -55,18 +63,37 @@ impl GroupedPresenter {
         root.children().to_vec()
     }
 
-    fn insert_game_node(&self, root: &mut VfsDirectory, game: &GameContent, encoded: &EncodedFile) {
-        let base_path = format!("{}/{}", game.platform, game.title);
+    fn insert_game_node(
+        &self,
+        root: &mut VfsDirectory,
+        game: &GameContent,
+        encoded: &EncodedFile,
+        policy: &PolicySet,
+    ) {
+        let platform_name = policy.naming().platform_name(&game.platform);
+        let game_name = policy.naming().game_name(game);
+
+        let base_path = format!(
+            "{}/{}",
+            policy.format_name(&platform_name),
+            policy.format_name(&game_name)
+        );
 
         if self.is_multi_disc_game(game) {
-            self.insert_multi_disc_game(root, game, &base_path);
+            self.insert_multi_disc_game(root, game, &base_path, policy);
         } else {
             let file_path = format!("{}/{}", base_path, encoded.name);
             self.insert_file_path(root, &file_path, encoded.to_vfs_file());
         }
     }
 
-    fn insert_multi_disc_game(&self, root: &mut VfsDirectory, game: &GameContent, base_path: &str) {
+    fn insert_multi_disc_game(
+        &self,
+        root: &mut VfsDirectory,
+        game: &GameContent,
+        base_path: &str,
+        policy: &PolicySet,
+    ) {
         let mut disc_parts: Vec<&DiscPart> = game
             .parts
             .iter()
@@ -83,7 +110,7 @@ impl GroupedPresenter {
         for disc in &disc_parts {
             let encoded = self
                 .encoder
-                .encode_game_part(game, &GamePart::Disc((*disc).clone()))
+                .encode_game_part(game, &GamePart::Disc((*disc).clone()), policy)
                 .unwrap_or_else(|err| {
                     panic!(
                         "multi-disc game part should encode for '{}' disc {}: {err}",
@@ -99,7 +126,7 @@ impl GroupedPresenter {
 
         let playlist_encoded = self
             .encoder
-            .encode_playlist(game, &disc_names)
+            .encode_playlist(game, &disc_names, policy)
             .unwrap_or_else(|err| {
                 panic!(
                     "multi-disc playlist should encode for '{}': {err}",
@@ -143,9 +170,9 @@ impl Default for GroupedPresenter {
 }
 
 impl OutputPresenter for GroupedPresenter {
-    fn present(&self, content: &[NormalizedContent]) -> VfsDirectory {
-        let encoded_entries = self.encode_entries(content);
-        let root_children = self.build_root_children(&encoded_entries);
+    fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory {
+        let encoded_entries = self.encode_entries(content, policy);
+        let root_children = self.build_root_children(&encoded_entries, policy);
 
         VfsDirectory::with_children("", root_children)
     }
@@ -215,6 +242,7 @@ mod tests {
     #[test]
     fn presents_mixed_content_in_library_view() {
         let presenter = GroupedPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![
             NormalizedContent::Bytes(BytesContent {
@@ -252,7 +280,7 @@ mod tests {
             }),
         ];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         let names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["megadrive", "ps1", "bios.bin", "manifest.txt"]);
@@ -261,6 +289,7 @@ mod tests {
     #[test]
     fn presents_single_rom_game_as_file_in_platform_title_directory() {
         let presenter = GroupedPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Game(GameContent {
             id: ContentId::new("smw"),
@@ -274,7 +303,7 @@ mod tests {
             consumed_sources: vec![],
         })];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         assert_eq!(root.children().len(), 1);
         assert_eq!(root.children()[0].name(), "snes");
@@ -296,6 +325,7 @@ mod tests {
     #[test]
     fn presents_multi_disc_game_as_directory_with_playlist_in_library_view() {
         let presenter = GroupedPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Game(GameContent {
             id: ContentId::new("ff7"),
@@ -320,7 +350,7 @@ mod tests {
             ],
         })];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         assert_eq!(root.children()[0].name(), "ps1");
 
@@ -363,6 +393,7 @@ mod tests {
     #[test]
     fn presents_multiple_games_under_platform_directories() {
         let presenter = GroupedPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![
             NormalizedContent::Game(GameContent {
@@ -400,7 +431,7 @@ mod tests {
             }),
         ];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         assert_eq!(root.children().len(), 1);
         assert_eq!(root.children()[0].name(), "ps1");
@@ -417,6 +448,7 @@ mod tests {
     #[test]
     fn presents_text_content_with_relative_path_using_leaf_file_name() {
         let presenter = GroupedPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Text(TextContent {
             id: ContentId::new("mixed/notes"),
@@ -424,7 +456,7 @@ mod tests {
             size: 12,
         })];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         let mixed = match root.find_directory("mixed") {
             Some(dir) => dir,
@@ -438,6 +470,7 @@ mod tests {
     #[test]
     fn presents_bytes_content_with_relative_path_using_leaf_file_name() {
         let presenter = GroupedPresenter::new();
+        let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Bytes(BytesContent {
             id: ContentId::new("zips/gameboy_collection.zip"),
@@ -445,7 +478,7 @@ mod tests {
             size: 481,
         })];
 
-        let root = presenter.present(&content);
+        let root = presenter.present(&content, &policy);
 
         let zips = match root.find_directory("zips") {
             Some(dir) => dir,

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -41,18 +41,16 @@ impl GroupedPresenter {
         policy: &PolicySet,
     ) {
         let game = &presented.game;
-        let platform_name = policy.naming().platform_name(&game.platform);
-        let game_name = policy.naming().game_name(game);
+        let platform_name = policy.format_name(&policy.naming().platform_name(&game.platform));
+        let game_name = policy.format_name(&policy.naming().game_name(game));
 
-        let base_path = format!(
-            "{}/{}",
-            policy.format_name(&platform_name),
-            policy.format_name(&game_name)
-        );
+        let platform_dir = ensure_directory(root, &[platform_name], policy);
+        let game_dir = ensure_distinct_child_directory(platform_dir, &game_name, policy);
 
         for encoded in &presented.files {
-            let file_path = format!("{}/{}", base_path, encoded.name);
-            self.insert_file_path(root, &file_path, encoded.to_vfs_file(), policy);
+            let mut file = encoded.to_vfs_file();
+            file.name = allocate_file_name(game_dir, &file.name, policy);
+            game_dir.add_child(VfsNode::File(file));
         }
     }
 
@@ -66,6 +64,7 @@ impl GroupedPresenter {
         let normalized = normalize_path(path);
         let (parents, file_name) = split_parent_dirs(&normalized);
         let directory = ensure_directory(root, &parents, policy);
+
         let mut file = file;
         file.name = allocate_file_name(directory, &file_name, policy);
         directory.add_child(VfsNode::File(file));
@@ -140,6 +139,27 @@ fn ensure_directory<'a>(
     }
 
     current
+}
+
+fn ensure_distinct_child_directory<'a>(
+    parent: &'a mut VfsDirectory,
+    proposed: &str,
+    policy: &PolicySet,
+) -> &'a mut VfsDirectory {
+    let resolved_name = allocate_file_name(parent, proposed, policy);
+
+    parent.add_child(VfsNode::Directory(VfsDirectory::new(&resolved_name)));
+
+    let index = parent
+        .children
+        .iter()
+        .position(|node| matches!(node, VfsNode::Directory(dir) if dir.name == resolved_name))
+        .expect("inserted child directory should be present");
+
+    match parent.children.get_mut(index) {
+        Some(VfsNode::Directory(dir)) => dir,
+        _ => unreachable!("child directory entry should be a directory"),
+    }
 }
 
 #[cfg(test)]
@@ -593,5 +613,70 @@ mod tests {
 
         let names: Vec<&str> = docs.children().iter().map(|node| node.name()).collect();
         assert_eq!(names, vec!["readme.bin", "readme.bin (1)"]);
+    }
+
+    #[test]
+    fn conflict_policy_can_disambiguate_game_directory_names_under_same_platform() {
+        let presenter = GroupedPresenter::new();
+        let policy = suffix_conflict_policy();
+
+        let content = vec![
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("game-1"),
+                source: SourceRef::new("file:/roms/game-1.bin"),
+                title: "Duplicate Game".to_string(),
+                platform: Platform::Ps1,
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("file:/roms/game-1.bin"),
+                    size: 100,
+                })],
+                consumed_sources: vec![],
+            }),
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("game-2"),
+                source: SourceRef::new("file:/roms/game-2.bin"),
+                title: "Duplicate Game".to_string(),
+                platform: Platform::Ps1,
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("file:/roms/game-2.bin"),
+                    size: 200,
+                })],
+                consumed_sources: vec![],
+            }),
+        ];
+
+        let root = presenter.present(&content, &policy);
+        let ps1 = root.find_directory("ps1").unwrap();
+
+        let names: Vec<&str> = ps1.children().iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["Duplicate Game", "Duplicate Game (1)"]);
+    }
+
+    #[test]
+    fn reuses_existing_directory_name_before_applying_conflict_suffixes() {
+        let presenter = GroupedPresenter::new();
+        let policy = suffix_conflict_policy();
+
+        let content = vec![
+            NormalizedContent::Text(TextContent {
+                id: ContentId::new("docs/notes"),
+                source: SourceRef::new("file:/roms/docs/notes.txt"),
+                size: 12,
+            }),
+            NormalizedContent::Text(TextContent {
+                id: ContentId::new("docs/todo"),
+                source: SourceRef::new("file:/roms/docs/todo.txt"),
+                size: 8,
+            }),
+        ];
+
+        let root = presenter.present(&content, &policy);
+
+        let root_names: Vec<&str> = root.children().iter().map(|node| node.name()).collect();
+        assert_eq!(root_names, vec!["docs"]);
+
+        let docs = root.find_directory("docs").unwrap();
+        let child_names: Vec<&str> = docs.children().iter().map(|node| node.name()).collect();
+        assert_eq!(child_names, vec!["notes.txt", "todo.txt"]);
     }
 }

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -1,5 +1,5 @@
 use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
-use crate::core::vfs::{VfsDirectory, VfsNode};
+use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::present::OutputPresenter;
@@ -55,6 +55,7 @@ impl GroupedPresenter {
                         &mut root,
                         &entry.encoded.name,
                         entry.encoded.to_vfs_file(),
+                        policy,
                     );
                 }
             }
@@ -83,7 +84,7 @@ impl GroupedPresenter {
             self.insert_multi_disc_game(root, game, &base_path, policy);
         } else {
             let file_path = format!("{}/{}", base_path, encoded.name);
-            self.insert_file_path(root, &file_path, encoded.to_vfs_file());
+            self.insert_file_path(root, &file_path, encoded.to_vfs_file(), policy);
         }
     }
 
@@ -121,7 +122,7 @@ impl GroupedPresenter {
             disc_names.push(encoded.name.clone());
 
             let disc_path = format!("{}/{}", base_path, encoded.name);
-            self.insert_file_path(root, &disc_path, encoded.to_vfs_file());
+            self.insert_file_path(root, &disc_path, encoded.to_vfs_file(), policy);
         }
 
         let playlist_encoded = self
@@ -135,21 +136,32 @@ impl GroupedPresenter {
             });
 
         let playlist_path = format!("{}/{}", base_path, playlist_encoded.name);
-        self.insert_file_path(root, &playlist_path, playlist_encoded.to_vfs_file());
+        self.insert_file_path(root, &playlist_path, playlist_encoded.to_vfs_file(), policy);
     }
 
     fn insert_file_path(
         &self,
         root: &mut VfsDirectory,
         path: &str,
-        file: crate::core::vfs::VfsFile,
+        file: VfsFile,
+        policy: &PolicySet,
     ) {
         let normalized = normalize_path(path);
         let (parents, file_name) = split_parent_dirs(&normalized);
-        let directory = ensure_directory(root, &parents);
+        let directory = ensure_directory(root, &parents, policy);
+
+        let existing: Vec<String> = directory
+            .children()
+            .iter()
+            .map(|node| node.name().to_string())
+            .collect();
+
+        let resolved_name = policy
+            .conflict()
+            .resolve_name_conflict(&file_name, &existing);
 
         let mut file = file;
-        file.name = file_name;
+        file.name = resolved_name;
 
         directory.add_child(VfsNode::File(file));
     }
@@ -198,25 +210,44 @@ fn split_parent_dirs(path: &str) -> (Vec<String>, String) {
     }
 }
 
-fn ensure_directory<'a>(root: &'a mut VfsDirectory, parents: &[String]) -> &'a mut VfsDirectory {
+fn ensure_directory<'a>(
+    root: &'a mut VfsDirectory,
+    parents: &[String],
+    policy: &PolicySet,
+) -> &'a mut VfsDirectory {
     let mut current = root;
 
     for segment in parents {
-        let index = match current
-            .children
-            .iter()
-            .position(|node| matches!(node, VfsNode::Directory(dir) if dir.name == *segment))
-        {
+        let resolved_segment = {
+            let existing: Vec<String> = current
+                .children()
+                .iter()
+                .filter_map(|node| match node {
+                    VfsNode::Directory(dir) => Some(dir.name.clone()),
+                    _ => None,
+                })
+                .collect();
+
+            if existing.iter().any(|name| name == segment) {
+                segment.clone()
+            } else {
+                policy.conflict().resolve_name_conflict(segment, &existing)
+            }
+        };
+
+        let index = match current.children.iter().position(
+            |node| matches!(node, VfsNode::Directory(dir) if dir.name == resolved_segment),
+        ) {
             Some(index) => index,
             None => {
-                current.add_child(VfsNode::Directory(VfsDirectory::new(segment)));
+                current.add_child(VfsNode::Directory(VfsDirectory::new(&resolved_segment)));
 
                 current
                     .children
                     .iter()
-                    .position(
-                        |node| matches!(node, VfsNode::Directory(dir) if dir.name == *segment),
-                    )
+                    .position(|node| {
+                        matches!(node, VfsNode::Directory(dir) if dir.name == resolved_segment)
+                    })
                     .expect("inserted directory should be present")
             }
         };
@@ -282,11 +313,61 @@ mod tests {
         }
     }
 
+    struct SuffixConflictPolicy;
+
+    impl ConflictPolicy for SuffixConflictPolicy {
+        fn resolve_name_conflict(&self, proposed: &str, existing: &[String]) -> String {
+            if !existing.iter().any(|name| name == proposed) {
+                return proposed.to_string();
+            }
+
+            let mut i = 1;
+            loop {
+                let candidate = format!("{proposed} ({i})");
+                if !existing.iter().any(|name| name == &candidate) {
+                    return candidate;
+                }
+                i += 1;
+            }
+        }
+    }
+
+    struct DefaultLikeNamingPolicy;
+
+    impl NamingPolicy for DefaultLikeNamingPolicy {
+        fn game_name(&self, game: &GameContent) -> String {
+            game.title.clone()
+        }
+
+        fn part_name(&self, game: &GameContent, part: &GamePart) -> String {
+            match part {
+                GamePart::Rom(rom) => rom.source.file_name(),
+                GamePart::Disc(disc) => format!("{} (Disc {}).cue", game.title, disc.disc_number),
+            }
+        }
+
+        fn playlist_name(&self, game: &GameContent) -> String {
+            format!("{}.m3u", game.title)
+        }
+
+        fn platform_name(&self, platform: &Platform) -> String {
+            platform.to_string()
+        }
+    }
+
     fn alternate_policy() -> PolicySet {
         PolicySet::new(
             Box::new(AlternateNamingPolicy),
             Box::new(PassthroughFormattingPolicy),
             Box::new(PreserveConflictPolicy),
+        )
+    }
+
+    fn suffix_conflict_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(DefaultLikeNamingPolicy),
+            Box::new(PassthroughFormattingPolicy),
+            Box::new(SuffixConflictPolicy),
         )
     }
 
@@ -606,5 +687,30 @@ mod tests {
 
         assert_eq!(default_root.children().len(), 1);
         assert_eq!(alt_root.children().len(), 1);
+    }
+
+    #[test]
+    fn conflict_policy_can_disambiguate_sibling_file_names() {
+        let presenter = GroupedPresenter::new();
+        let policy = suffix_conflict_policy();
+
+        let content = vec![
+            NormalizedContent::Bytes(BytesContent {
+                id: ContentId::new("docs/readme"),
+                source: SourceRef::new("file:/roms/docs/readme"),
+                size: 10,
+            }),
+            NormalizedContent::Bytes(BytesContent {
+                id: ContentId::new("docs/readme"),
+                source: SourceRef::new("file:/roms/docs/readme-copy"),
+                size: 11,
+            }),
+        ];
+
+        let root = presenter.present(&content, &policy);
+        let docs = root.find_directory("docs").unwrap();
+
+        let names: Vec<&str> = docs.children().iter().map(|node| node.name()).collect();
+        assert_eq!(names, vec!["readme.bin", "readme.bin (1)"]);
     }
 }

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -10,9 +10,14 @@ pub struct GroupedPresenter {
 }
 
 #[derive(Debug, Clone)]
-struct EncodedEntry {
-    content: NormalizedContent,
-    encoded: EncodedFile,
+enum PresentedEntry {
+    Game(PresentedGame),
+    File(EncodedFile),
+}
+
+#[derive(Debug, Clone)]
+struct PresentedGame {
+    game: GameContent,
 }
 
 impl GroupedPresenter {
@@ -22,41 +27,41 @@ impl GroupedPresenter {
         }
     }
 
-    fn encode_entries(
+    fn build_presented_entries(
         &self,
         content: &[NormalizedContent],
         policy: &PolicySet,
-    ) -> Vec<EncodedEntry> {
+    ) -> Vec<PresentedEntry> {
         content
             .iter()
-            .filter(|item| self.encoder.can_encode(item))
-            .filter_map(|item| {
-                self.encoder
-                    .encode(item, policy)
-                    .ok()
-                    .map(|encoded| EncodedEntry {
-                        content: item.clone(),
-                        encoded,
-                    })
+            .filter_map(|item| match item {
+                NormalizedContent::Game(game) => {
+                    Some(PresentedEntry::Game(PresentedGame { game: game.clone() }))
+                }
+                NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
+                    if !self.encoder.can_encode(item) {
+                        return None;
+                    }
+
+                    self.encoder
+                        .encode(item, policy)
+                        .ok()
+                        .map(PresentedEntry::File)
+                }
             })
             .collect()
     }
 
-    fn build_root_children(&self, entries: &[EncodedEntry], policy: &PolicySet) -> Vec<VfsNode> {
+    fn build_root_children(&self, entries: &[PresentedEntry], policy: &PolicySet) -> Vec<VfsNode> {
         let mut root = VfsDirectory::new("");
 
         for entry in entries {
-            match &entry.content {
-                NormalizedContent::Game(game) => {
-                    self.insert_game_node(&mut root, game, &entry.encoded, policy);
+            match entry {
+                PresentedEntry::Game(presented) => {
+                    self.insert_game_node(&mut root, &presented.game, policy);
                 }
-                NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
-                    self.insert_file_path(
-                        &mut root,
-                        &entry.encoded.name,
-                        entry.encoded.to_vfs_file(),
-                        policy,
-                    );
+                PresentedEntry::File(encoded) => {
+                    self.insert_file_path(&mut root, &encoded.name, encoded.to_vfs_file(), policy);
                 }
             }
         }
@@ -64,13 +69,7 @@ impl GroupedPresenter {
         root.children().to_vec()
     }
 
-    fn insert_game_node(
-        &self,
-        root: &mut VfsDirectory,
-        game: &GameContent,
-        encoded: &EncodedFile,
-        policy: &PolicySet,
-    ) {
+    fn insert_game_node(&self, root: &mut VfsDirectory, game: &GameContent, policy: &PolicySet) {
         let platform_name = policy.naming().platform_name(&game.platform);
         let game_name = policy.naming().game_name(game);
 
@@ -83,6 +82,13 @@ impl GroupedPresenter {
         if self.is_multi_disc_game(game) {
             self.insert_multi_disc_game(root, game, &base_path, policy);
         } else {
+            let encoded = self
+                .encoder
+                .encode(&NormalizedContent::Game(game.clone()), policy)
+                .unwrap_or_else(|err| {
+                    panic!("single game should encode for '{}': {err}", game.title)
+                });
+
             let file_path = format!("{}/{}", base_path, encoded.name);
             self.insert_file_path(root, &file_path, encoded.to_vfs_file(), policy);
         }
@@ -183,8 +189,8 @@ impl Default for GroupedPresenter {
 
 impl OutputPresenter for GroupedPresenter {
     fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory {
-        let encoded_entries = self.encode_entries(content, policy);
-        let root_children = self.build_root_children(&encoded_entries, policy);
+        let presented_entries = self.build_presented_entries(content, policy);
+        let root_children = self.build_root_children(&presented_entries, policy);
 
         VfsDirectory::with_children("", root_children)
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,3 +4,4 @@ pub mod flat_presenter;
 pub mod grouped_presenter;
 pub mod present;
 pub mod presented;
+pub mod presenter_utils;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -3,3 +3,4 @@ pub mod encode;
 pub mod flat_presenter;
 pub mod grouped_presenter;
 pub mod present;
+pub mod presented;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,5 +4,5 @@ pub mod flat_presenter;
 pub mod grouped_presenter;
 pub mod name_allocator;
 pub mod present;
+pub mod presentation_expansion;
 pub mod presented;
-pub mod presenter_utils;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -2,6 +2,7 @@ pub mod basic_encoder;
 pub mod encode;
 pub mod flat_presenter;
 pub mod grouped_presenter;
+pub mod name_allocator;
 pub mod present;
 pub mod presented;
 pub mod presenter_utils;

--- a/src/output/name_allocator.rs
+++ b/src/output/name_allocator.rs
@@ -1,0 +1,33 @@
+use crate::core::vfs::{VfsDirectory, VfsNode};
+use crate::policy::PolicySet;
+
+pub fn allocate_file_name(directory: &VfsDirectory, proposed: &str, policy: &PolicySet) -> String {
+    let existing: Vec<String> = directory
+        .children()
+        .iter()
+        .map(|node| node.name().to_string())
+        .collect();
+
+    policy.conflict().resolve_name_conflict(proposed, &existing)
+}
+
+pub fn allocate_directory_name(
+    directory: &VfsDirectory,
+    proposed: &str,
+    policy: &PolicySet,
+) -> String {
+    let existing: Vec<String> = directory
+        .children()
+        .iter()
+        .filter_map(|node| match node {
+            VfsNode::Directory(dir) => Some(dir.name.clone()),
+            _ => None,
+        })
+        .collect();
+
+    if existing.iter().any(|name| name == proposed) {
+        proposed.to_string()
+    } else {
+        policy.conflict().resolve_name_conflict(proposed, &existing)
+    }
+}

--- a/src/output/present.rs
+++ b/src/output/present.rs
@@ -1,5 +1,6 @@
 use crate::core::content::NormalizedContent;
 use crate::core::vfs::VfsDirectory;
+use crate::policy::PolicySet;
 
 /// Defines how normalized content is exposed in the output VFS.
 ///
@@ -7,7 +8,7 @@ use crate::core::vfs::VfsDirectory;
 /// Representation-specific decisions such as filenames and file backing
 /// remain encoder responsibilities.
 pub trait OutputPresenter: Send + Sync {
-    fn present(&self, content: &[NormalizedContent]) -> VfsDirectory;
+    fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/output/presentation_expansion.rs
+++ b/src/output/presentation_expansion.rs
@@ -2,6 +2,7 @@ use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::policy::PolicySet;
 
+/// Returns true when a game consists entirely of multiple disc parts.
 pub fn is_multi_disc_game(game: &GameContent) -> bool {
     game.parts.len() > 1
         && game
@@ -10,6 +11,7 @@ pub fn is_multi_disc_game(game: &GameContent) -> bool {
             .all(|part| matches!(part, GamePart::Disc(_)))
 }
 
+/// Returns disc parts sorted by disc number.
 pub fn sorted_disc_parts(game: &GameContent) -> Vec<&DiscPart> {
     let mut parts: Vec<&DiscPart> = game
         .parts
@@ -24,6 +26,7 @@ pub fn sorted_disc_parts(game: &GameContent) -> Vec<&DiscPart> {
     parts
 }
 
+/// Encodes a game that expands to a single output file.
 pub fn encode_game(
     encoder: &impl OutputEncoder,
     game: &GameContent,
@@ -34,6 +37,7 @@ pub fn encode_game(
         .unwrap_or_else(|err| panic!("game should encode for '{}': {err}", game.title))
 }
 
+/// Encodes a disc file for a multi-disc game.
 pub fn encode_disc(
     encoder: &impl OutputEncoder,
     game: &GameContent,
@@ -50,6 +54,7 @@ pub fn encode_disc(
         })
 }
 
+/// Encodes a playlist file for a multi-disc game.
 pub fn encode_playlist(
     encoder: &impl OutputEncoder,
     game: &GameContent,

--- a/src/output/presented.rs
+++ b/src/output/presented.rs
@@ -1,23 +1,34 @@
 use crate::core::content::{GameContent, NormalizedContent};
 use crate::output::basic_encoder::BasicEncoder;
 use crate::output::encode::{EncodedFile, OutputEncoder};
-use crate::output::presenter_utils::{
+use crate::output::presentation_expansion::{
     encode_disc, encode_game, encode_playlist, is_multi_disc_game, sorted_disc_parts,
 };
 use crate::policy::PolicySet;
 
+/// Expanded output intent consumed by presenters.
+///
+/// Presented entries represent the output artifacts that should exist
+/// before layout-specific presentation is applied.
 #[derive(Debug, Clone)]
 pub enum PresentedEntry {
     Game(PresentedGame),
     File(EncodedFile),
 }
 
+/// A logical game plus the output files it expands into.
+///
+/// Presenters use the game for layout decisions and the files for placement.
 #[derive(Debug, Clone)]
 pub struct PresentedGame {
     pub game: GameContent,
     pub files: Vec<EncodedFile>,
 }
 
+/// Builds expanded presentation entries from normalized content.
+///
+/// This is the boundary where logical content is expanded into the output
+/// artifacts that presenters will place into the VFS.
 pub fn build_presented_entries(
     content: &[NormalizedContent],
     encoder: &BasicEncoder,

--- a/src/output/presented.rs
+++ b/src/output/presented.rs
@@ -1,0 +1,38 @@
+use crate::core::content::{GameContent, NormalizedContent};
+use crate::output::basic_encoder::BasicEncoder;
+use crate::output::encode::EncodedFile;
+use crate::output::encode::OutputEncoder;
+use crate::policy::PolicySet;
+
+#[derive(Debug, Clone)]
+pub enum PresentedEntry {
+    Game(PresentedGame),
+    File(EncodedFile),
+}
+
+#[derive(Debug, Clone)]
+pub struct PresentedGame {
+    pub game: GameContent,
+}
+
+pub fn build_presented_entries(
+    content: &[NormalizedContent],
+    encoder: &BasicEncoder,
+    policy: &PolicySet,
+) -> Vec<PresentedEntry> {
+    content
+        .iter()
+        .filter_map(|item| match item {
+            NormalizedContent::Game(game) => {
+                Some(PresentedEntry::Game(PresentedGame { game: game.clone() }))
+            }
+            NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
+                if !encoder.can_encode(item) {
+                    return None;
+                }
+
+                encoder.encode(item, policy).ok().map(PresentedEntry::File)
+            }
+        })
+        .collect()
+}

--- a/src/output/presented.rs
+++ b/src/output/presented.rs
@@ -1,7 +1,9 @@
 use crate::core::content::{GameContent, NormalizedContent};
 use crate::output::basic_encoder::BasicEncoder;
-use crate::output::encode::EncodedFile;
-use crate::output::encode::OutputEncoder;
+use crate::output::encode::{EncodedFile, OutputEncoder};
+use crate::output::presenter_utils::{
+    encode_disc, encode_game, encode_playlist, is_multi_disc_game, sorted_disc_parts,
+};
 use crate::policy::PolicySet;
 
 #[derive(Debug, Clone)]
@@ -13,6 +15,7 @@ pub enum PresentedEntry {
 #[derive(Debug, Clone)]
 pub struct PresentedGame {
     pub game: GameContent,
+    pub files: Vec<EncodedFile>,
 }
 
 pub fn build_presented_entries(
@@ -23,16 +26,48 @@ pub fn build_presented_entries(
     content
         .iter()
         .filter_map(|item| match item {
-            NormalizedContent::Game(game) => {
-                Some(PresentedEntry::Game(PresentedGame { game: game.clone() }))
-            }
+            NormalizedContent::Game(game) => Some(PresentedEntry::Game(build_presented_game(
+                game, encoder, policy,
+            ))),
             NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
-                if !encoder.can_encode(item) {
-                    return None;
-                }
-
                 encoder.encode(item, policy).ok().map(PresentedEntry::File)
             }
         })
         .collect()
+}
+
+fn build_presented_game(
+    game: &GameContent,
+    encoder: &BasicEncoder,
+    policy: &PolicySet,
+) -> PresentedGame {
+    let files = if is_multi_disc_game(game) {
+        build_multi_disc_files(game, encoder, policy)
+    } else {
+        vec![encode_game(encoder, game, policy)]
+    };
+
+    PresentedGame {
+        game: game.clone(),
+        files,
+    }
+}
+
+fn build_multi_disc_files(
+    game: &GameContent,
+    encoder: &BasicEncoder,
+    policy: &PolicySet,
+) -> Vec<EncodedFile> {
+    let disc_parts = sorted_disc_parts(game);
+    let mut files = Vec::new();
+    let mut disc_names = Vec::new();
+
+    for disc in disc_parts {
+        let encoded = encode_disc(encoder, game, disc, policy);
+        disc_names.push(encoded.name.clone());
+        files.push(encoded);
+    }
+
+    files.push(encode_playlist(encoder, game, &disc_names, policy));
+    files
 }

--- a/src/output/presenter_utils.rs
+++ b/src/output/presenter_utils.rs
@@ -1,0 +1,77 @@
+use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
+use crate::output::encode::{EncodedFile, OutputEncoder};
+use crate::policy::PolicySet;
+
+/// Determines whether a game consists entirely of multiple disc parts.
+pub fn is_multi_disc_game(game: &GameContent) -> bool {
+    game.parts.len() > 1
+        && game
+            .parts
+            .iter()
+            .all(|part| matches!(part, GamePart::Disc(_)))
+}
+
+/// Extracts all disc parts from a game and returns them sorted by disc number.
+pub fn sorted_disc_parts(game: &GameContent) -> Vec<&DiscPart> {
+    let mut parts: Vec<&DiscPart> = game
+        .parts
+        .iter()
+        .filter_map(|part| match part {
+            GamePart::Disc(disc) => Some(disc),
+            _ => None,
+        })
+        .collect();
+
+    parts.sort_by(|a, b| a.disc_number.cmp(&b.disc_number));
+    parts
+}
+
+/// Encodes a full game (single-part).
+pub fn encode_game(
+    encoder: &impl OutputEncoder,
+    game: &GameContent,
+    policy: &PolicySet,
+) -> EncodedFile {
+    encoder
+        .encode(&NormalizedContent::Game(game.clone()), policy)
+        .unwrap_or_else(|err| panic!("game should encode for '{}': {err}", game.title))
+}
+
+/// Encodes a single disc part of a multi-disc game.
+pub fn encode_disc(
+    encoder: &impl OutputEncoder,
+    game: &GameContent,
+    disc: &DiscPart,
+    policy: &PolicySet,
+) -> EncodedFile {
+    encoder
+        .encode_game_part(game, &GamePart::Disc(disc.clone()), policy)
+        .unwrap_or_else(|err| {
+            panic!(
+                "multi-disc game part should encode for '{}' disc {}: {err}",
+                game.title, disc.disc_number
+            )
+        })
+}
+
+/// Encodes a playlist for a multi-disc game.
+pub fn encode_playlist(
+    encoder: &impl OutputEncoder,
+    game: &GameContent,
+    disc_names: &[String],
+    policy: &PolicySet,
+) -> EncodedFile {
+    encoder
+        .encode_playlist(game, disc_names, policy)
+        .unwrap_or_else(|err| {
+            panic!(
+                "multi-disc playlist should encode for '{}': {err}",
+                game.title
+            )
+        })
+}
+
+/// Resolves a filename conflict against existing sibling names.
+pub fn resolve_name(proposed: &str, existing: &[String], policy: &PolicySet) -> String {
+    policy.conflict().resolve_name_conflict(proposed, existing)
+}

--- a/src/output/presenter_utils.rs
+++ b/src/output/presenter_utils.rs
@@ -2,7 +2,6 @@ use crate::core::content::{DiscPart, GameContent, GamePart, NormalizedContent};
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::policy::PolicySet;
 
-/// Determines whether a game consists entirely of multiple disc parts.
 pub fn is_multi_disc_game(game: &GameContent) -> bool {
     game.parts.len() > 1
         && game
@@ -11,7 +10,6 @@ pub fn is_multi_disc_game(game: &GameContent) -> bool {
             .all(|part| matches!(part, GamePart::Disc(_)))
 }
 
-/// Extracts all disc parts from a game and returns them sorted by disc number.
 pub fn sorted_disc_parts(game: &GameContent) -> Vec<&DiscPart> {
     let mut parts: Vec<&DiscPart> = game
         .parts
@@ -26,7 +24,6 @@ pub fn sorted_disc_parts(game: &GameContent) -> Vec<&DiscPart> {
     parts
 }
 
-/// Encodes a full game (single-part).
 pub fn encode_game(
     encoder: &impl OutputEncoder,
     game: &GameContent,
@@ -37,7 +34,6 @@ pub fn encode_game(
         .unwrap_or_else(|err| panic!("game should encode for '{}': {err}", game.title))
 }
 
-/// Encodes a single disc part of a multi-disc game.
 pub fn encode_disc(
     encoder: &impl OutputEncoder,
     game: &GameContent,
@@ -54,7 +50,6 @@ pub fn encode_disc(
         })
 }
 
-/// Encodes a playlist for a multi-disc game.
 pub fn encode_playlist(
     encoder: &impl OutputEncoder,
     game: &GameContent,
@@ -71,7 +66,6 @@ pub fn encode_playlist(
         })
 }
 
-/// Resolves a filename conflict against existing sibling names.
 pub fn resolve_name(proposed: &str, existing: &[String], policy: &PolicySet) -> String {
     policy.conflict().resolve_name_conflict(proposed, existing)
 }

--- a/src/output/presenter_utils.rs
+++ b/src/output/presenter_utils.rs
@@ -65,7 +65,3 @@ pub fn encode_playlist(
             )
         })
 }
-
-pub fn resolve_name(proposed: &str, existing: &[String], policy: &PolicySet) -> String {
-    policy.conflict().resolve_name_conflict(proposed, existing)
-}

--- a/src/policy/default.rs
+++ b/src/policy/default.rs
@@ -1,0 +1,133 @@
+use crate::core::content::{GameContent, GamePart, Platform};
+use crate::policy::{ConflictPolicy, FormattingPolicy, NamingPolicy, PolicySet};
+
+pub struct DefaultNamingPolicy;
+pub struct DefaultFormattingPolicy;
+pub struct DefaultConflictPolicy;
+
+impl NamingPolicy for DefaultNamingPolicy {
+    fn game_name(&self, game: &GameContent) -> String {
+        game.title.clone()
+    }
+
+    fn part_name(&self, game: &GameContent, part: &GamePart) -> String {
+        match part {
+            GamePart::Rom(rom) => rom.source.file_name(),
+            GamePart::Disc(disc) => format!("{} (Disc {}).cue", game.title, disc.disc_number),
+        }
+    }
+
+    fn playlist_name(&self, game: &GameContent) -> String {
+        format!("{}.m3u", game.title)
+    }
+
+    fn platform_name(&self, platform: &Platform) -> String {
+        platform.to_string()
+    }
+}
+
+impl FormattingPolicy for DefaultFormattingPolicy {
+    fn format_name(&self, raw: &str) -> String {
+        raw.to_string()
+    }
+}
+
+impl ConflictPolicy for DefaultConflictPolicy {
+    fn resolve_name_conflict(&self, proposed: &str, _existing: &[String]) -> String {
+        proposed.to_string()
+    }
+}
+
+impl Default for PolicySet {
+    fn default() -> Self {
+        Self::new(
+            Box::new(DefaultNamingPolicy),
+            Box::new(DefaultFormattingPolicy),
+            Box::new(DefaultConflictPolicy),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::content::{ContentId, DiscPart, GameContent, GamePart, Platform, RomPart};
+    use crate::core::source::SourceRef;
+
+    #[test]
+    fn default_naming_policy_formats_disc_parts_like_current_behavior() {
+        let game = GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![],
+            consumed_sources: vec![],
+        };
+
+        let part = GamePart::Disc(DiscPart {
+            source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
+            disc_number: 2,
+            consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+        });
+
+        let policy = DefaultNamingPolicy;
+        assert_eq!(
+            policy.part_name(&game, &part),
+            "Final Fantasy VII (Disc 2).cue"
+        );
+    }
+
+    #[test]
+    fn default_naming_policy_uses_source_file_name_for_rom_parts() {
+        let game = GameContent {
+            id: ContentId::new("sonic"),
+            source: SourceRef::new("zip:/roms/megadrive.zip#Sonic the Hedgehog.bin"),
+            title: "Sonic the Hedgehog".to_string(),
+            platform: Platform::Megadrive,
+            parts: vec![],
+            consumed_sources: vec![],
+        };
+
+        let part = GamePart::Rom(RomPart {
+            source: SourceRef::new("zip:/roms/megadrive.zip#Sonic the Hedgehog.bin"),
+            size: 1024,
+        });
+
+        let policy = DefaultNamingPolicy;
+        assert_eq!(policy.part_name(&game, &part), "Sonic the Hedgehog.bin");
+    }
+
+    #[test]
+    fn default_naming_policy_formats_playlist_like_current_behavior() {
+        let game = GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("cue:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![],
+            consumed_sources: vec![],
+        };
+
+        let policy = DefaultNamingPolicy;
+        assert_eq!(policy.playlist_name(&game), "Final Fantasy VII.m3u");
+    }
+
+    #[test]
+    fn default_formatting_policy_is_passthrough() {
+        let policy = DefaultFormattingPolicy;
+        assert_eq!(
+            policy.format_name("Metal Gear Solid (Disc 1).cue"),
+            "Metal Gear Solid (Disc 1).cue"
+        );
+    }
+
+    #[test]
+    fn default_conflict_policy_preserves_proposed_name() {
+        let policy = DefaultConflictPolicy;
+        assert_eq!(
+            policy.resolve_name_conflict("game.cue", &["other.cue".to_string()]),
+            "game.cue"
+        );
+    }
+}

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1,0 +1,58 @@
+use crate::core::content::{GameContent, GamePart, Platform};
+
+pub mod default;
+
+pub trait NamingPolicy: Send + Sync {
+    fn game_name(&self, game: &GameContent) -> String;
+    fn part_name(&self, game: &GameContent, part: &GamePart) -> String;
+    fn playlist_name(&self, game: &GameContent) -> String;
+    fn platform_name(&self, platform: &Platform) -> String;
+}
+
+pub trait FormattingPolicy: Send + Sync {
+    fn format_name(&self, raw: &str) -> String;
+}
+
+pub trait ConflictPolicy: Send + Sync {
+    fn resolve_name_conflict(&self, proposed: &str, existing: &[String]) -> String;
+}
+
+pub struct PolicySet {
+    naming: Box<dyn NamingPolicy>,
+    formatting: Box<dyn FormattingPolicy>,
+    conflict: Box<dyn ConflictPolicy>,
+}
+
+impl PolicySet {
+    pub fn new(
+        naming: Box<dyn NamingPolicy>,
+        formatting: Box<dyn FormattingPolicy>,
+        conflict: Box<dyn ConflictPolicy>,
+    ) -> Self {
+        Self {
+            naming,
+            formatting,
+            conflict,
+        }
+    }
+
+    pub fn naming(&self) -> &dyn NamingPolicy {
+        self.naming.as_ref()
+    }
+
+    pub fn formatting(&self) -> &dyn FormattingPolicy {
+        self.formatting.as_ref()
+    }
+
+    pub fn conflict(&self) -> &dyn ConflictPolicy {
+        self.conflict.as_ref()
+    }
+
+    pub fn format_name(&self, raw: &str) -> String {
+        self.formatting.format_name(raw)
+    }
+
+    pub fn resolve_name_conflict(&self, proposed: &str, existing: &[String]) -> String {
+        self.conflict.resolve_name_conflict(proposed, existing)
+    }
+}


### PR DESCRIPTION
## Phase 4C — Policy-driven output behaviour

This PR completes Phase 4C of the Retromount roadmap by introducing policy-driven control over output naming, formatting, and conflict resolution, while also tightening the presentation and expansion boundaries established in earlier phases.

It establishes a cleaner separation between:

* **presentation structure** (handled by presenters)
* **output expansion and representation** (handled before and during encoding)
* **naming, formatting, and conflict behaviour** (handled by policy)

---

## Summary of Changes

### Policy system

* introduce `PolicySet` as a container for:

  * `NamingPolicy`
  * `FormattingPolicy`
  * `ConflictPolicy`
* add default policy implementations that preserve existing behaviour
* support alternate policies without changing presenters or pipeline orchestration

### Naming and conflict handling

* add `name_allocator.rs` to centralize sibling name allocation
* apply conflict policy at namespace insertion points
* remove direct conflict-resolution workflow from presenters
* keep core VFS policy-agnostic

### Presentation boundary refactor

* introduce `presented.rs` as the boundary between normalized content and layout-specific presentation
* define `PresentedEntry` / `PresentedGame` as expanded output intent consumed by presenters
* move multi-disc expansion and playlist generation out of presenters
* keep presenters focused on layout and placement only

### Expansion helper cleanup

* extract expansion helpers into `presentation_expansion.rs`
* clarify that expansion is an output-layer concern rather than presenter logic
* improve naming around the expansion boundary

### Presenter updates

* simplify `FlatPresenter` and `GroupedPresenter`
* remove direct disc/playlist encoding decisions from presenters
* keep grouped and flat layout behaviour while delegating naming/conflict handling
* fix grouped presentation so duplicate game titles under the same platform become distinct sibling directories rather than collapsing into a shared container
* preserve reuse of shared path directories for non-game content

### Documentation

* update `docs/roadmap/phase4c-policy.md`
* update `docs/architecture/boundaries.md`
* clarify separation between expansion, presentation, encoding, and policy
* document output-layer name allocation as the application point for conflict policy

### Tests

* add and expand unit tests for:

  * naming policy behaviour
  * conflict handling in flat and grouped presenters
  * grouped duplicate directory handling
  * reuse of shared path directories
* strengthen pipeline-level alternate-policy coverage
* verify that the same input and presenter can produce:

  * the same structure
  * different output names

---

## Architectural outcome

This phase establishes that:

* presenters define **structure and placement only**
* expansion determines **what output artifacts exist**
* encoders determine **how artifacts are represented**
* policy determines **how names are derived, formatted, and disambiguated**
* name allocation is an output-layer concern, not a core VFS concern

This removes remaining policy leakage from presenters and makes the default pipeline more extensible for future naming styles and compatibility profiles.

---

## Non-goals

This PR does **not** introduce:

* plugin loading or external extension mechanisms
* user-facing configuration formats beyond the internal architecture
* new VFS construction abstractions
* structural presentation redesign beyond what was required to preserve Phase 4C boundaries

---

## Follow-ups

Future phases may build on this with:

* configurable policy selection
* richer formatting and compatibility profiles
* profile-based composition of presenter, encoder, and policy
* deeper output-tree construction abstractions

---

## Validation

* default policy preserves existing output behaviour
* alternate policy changes names without changing structure
* docs and code now reflect the same architectural model
* all tests, formatting, and lint checks are green
