### PR TITLE
feat(presenter): resolve built-in presenters via registry

### DIFF
--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -1,0 +1,12 @@
+use crate::output::flat_presenter::FlatPresenter;
+use crate::output::grouped_presenter::GroupedPresenter;
+use crate::output::presenter_registry::PresenterRegistry;
+
+pub fn default_presenter_registry() -> PresenterRegistry {
+    let mut registry = PresenterRegistry::new();
+
+    registry.register("grouped", || Box::new(GroupedPresenter::new()));
+    registry.register("flat", || Box::new(FlatPresenter::new()));
+
+    registry
+}

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -1,9 +1,8 @@
+use crate::engine::bootstrap::default_presenter_registry;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentifier;
-use crate::output::flat_presenter::FlatPresenter;
-use crate::output::grouped_presenter::GroupedPresenter;
 use crate::output::present::{OutputPresenter, PresenterKind};
 use crate::policy::PolicySet;
 
@@ -24,10 +23,11 @@ pub fn default_pipeline_components() -> PipelineComponents {
 }
 
 pub fn pipeline_components_for_presenter(kind: PresenterKind) -> PipelineComponents {
-    let presenter: Box<dyn OutputPresenter> = match kind {
-        PresenterKind::Grouped => Box::new(GroupedPresenter::new()),
-        PresenterKind::Flat => Box::new(FlatPresenter::new()),
-    };
+    let registry = default_presenter_registry();
+
+    let presenter = registry
+        .get(kind.as_str())
+        .unwrap_or_else(|| panic!("presenter '{}' is not registered", kind.as_str()));
 
     PipelineComponents {
         identifier: Box::new(BasicInputIdentifier::new()),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod bootstrap;
 pub mod components;
 pub mod inspect;
 pub mod mount;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -6,3 +6,4 @@ pub mod name_allocator;
 pub mod present;
 pub mod presentation_expansion;
 pub mod presented;
+pub mod presenter_registry;

--- a/src/output/presenter_registry.rs
+++ b/src/output/presenter_registry.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+use crate::output::present::OutputPresenter;
+
+pub struct PresenterRegistry {
+    presenters: HashMap<String, Box<dyn Fn() -> Box<dyn OutputPresenter>>>,
+}
+
+impl PresenterRegistry {
+    pub fn new() -> Self {
+        Self {
+            presenters: HashMap::new(),
+        }
+    }
+
+    pub fn register<F>(&mut self, name: &str, factory: F)
+    where
+        F: Fn() -> Box<dyn OutputPresenter> + 'static,
+    {
+        self.presenters.insert(name.to_string(), Box::new(factory));
+    }
+
+    pub fn get(&self, name: &str) -> Option<Box<dyn OutputPresenter>> {
+        self.presenters.get(name).map(|factory| factory())
+    }
+
+    pub fn names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.presenters.keys().map(|k| k.as_str()).collect();
+        names.sort_unstable();
+        names
+    }
+}
+
+impl Default for PresenterRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Summary

Introduce a presenter registry for built-in presenter selection.

This changes presenter resolution from direct construction in the pipeline
composition layer to registry-based lookup, creating the first explicit
extension point for presenter implementations in Phase 4D.

## Changes

- add `PresenterRegistry` for factory-based presenter registration
- add engine bootstrap wiring for built-in presenter registration
- register built-in `grouped` and `flat` presenters
- update pipeline component composition to resolve presenters via the registry
- add deterministic registry name ordering and `Default` implementation support

## Why

Until now, built-in presenters were constructed directly inside
`pipeline_components_for_presenter`, which kept presenter selection coupled
to concrete types.

Moving presenter resolution behind a registry:

- creates a clearer composition boundary for built-in presenters
- prepares the codebase for configurable presenter selection
- establishes the first concrete Phase 4D extensibility mechanism
- keeps current runtime behaviour unchanged while removing hardcoded wiring

## Notes

This PR is intentionally narrow in scope:

- no pipeline behaviour changes
- no configuration layer yet
- no encoder registry yet

It only introduces registry-based selection for built-in presenters as the
first step toward a more extensible composition model.