### PR TITLE
feat: introduce encoder registry for presenter composition

### DIFF
--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -1,12 +1,35 @@
+use crate::output::basic_encoder::BasicEncoder;
+use crate::output::encoder_registry::EncoderRegistry;
 use crate::output::flat_presenter::FlatPresenter;
 use crate::output::grouped_presenter::GroupedPresenter;
 use crate::output::presenter_registry::PresenterRegistry;
 
+pub fn default_encoder_registry() -> EncoderRegistry {
+    let mut registry = EncoderRegistry::new();
+
+    registry.register("basic", || Box::new(BasicEncoder::new()));
+
+    registry
+}
+
 pub fn default_presenter_registry() -> PresenterRegistry {
     let mut registry = PresenterRegistry::new();
 
-    registry.register("grouped", || Box::new(GroupedPresenter::new()));
-    registry.register("flat", || Box::new(FlatPresenter::new()));
+    registry.register("grouped", || {
+        let encoder = default_encoder_registry()
+            .get("basic")
+            .expect("encoder 'basic' is not registered");
+
+        Box::new(GroupedPresenter::new(encoder))
+    });
+
+    registry.register("flat", || {
+        let encoder = default_encoder_registry()
+            .get("basic")
+            .expect("encoder 'basic' is not registered");
+
+        Box::new(FlatPresenter::new(encoder))
+    });
 
     registry
 }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -127,6 +127,7 @@ mod tests {
     use crate::input::basic_decoder::BasicInputDecoder;
     use crate::input::basic_identifier::BasicInputIdentifier;
     use crate::input::directory_source::DirectoryInputSource;
+    use crate::output::basic_encoder::BasicEncoder;
     use crate::output::flat_presenter::FlatPresenter;
     use crate::output::grouped_presenter::GroupedPresenter;
     use crate::policy::{ConflictPolicy, FormattingPolicy, NamingPolicy, PolicySet};
@@ -199,7 +200,7 @@ mod tests {
         let source = DirectoryInputSource::new(temp_dir.path());
         let identifier = BasicInputIdentifier::new();
         let decoder = BasicInputDecoder::new();
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
 
         let policy = PolicySet::default();
         let root = run_pipeline(&source, &identifier, &decoder, &presenter, &policy).unwrap();
@@ -236,7 +237,7 @@ mod tests {
         let source = ZipInputSource::new(&zip_path);
         let identifier = BasicInputIdentifier::new();
         let decoder = BasicInputDecoder::new();
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
         let root = run_pipeline(&source, &identifier, &decoder, &presenter, &policy).unwrap();
 
@@ -254,7 +255,7 @@ mod tests {
         let source = DirectoryInputSource::new(temp_dir.path());
         let identifier = BasicInputIdentifier::new();
         let decoder = BasicInputDecoder::new();
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
 
         let policy = PolicySet::default();
         let trace =
@@ -314,8 +315,8 @@ mod tests {
         let identifier = crate::input::basic_identifier::BasicInputIdentifier::new();
         let decoder = crate::input::basic_decoder::BasicInputDecoder::new();
 
-        let grouped = GroupedPresenter::new();
-        let flat = FlatPresenter::new();
+        let grouped = GroupedPresenter::new(Box::new(BasicEncoder::new()));
+        let flat = FlatPresenter::new(Box::new(BasicEncoder::new()));
 
         let policy = PolicySet::default();
         let grouped_root = run_pipeline(&source, &identifier, &decoder, &grouped, &policy).unwrap();
@@ -370,7 +371,7 @@ mod tests {
         let source = DirectoryInputSource::new(temp_dir.path());
         let identifier = BasicInputIdentifier::new();
         let decoder = BasicInputDecoder::new();
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
 
         let default_policy = PolicySet::default();
         let alt_policy = alternate_policy();

--- a/src/output/encoder_registry.rs
+++ b/src/output/encoder_registry.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+use crate::output::encode::OutputEncoder;
+
+pub struct EncoderRegistry {
+    encoders: HashMap<String, Box<dyn Fn() -> Box<dyn OutputEncoder>>>,
+}
+
+impl EncoderRegistry {
+    pub fn new() -> Self {
+        Self {
+            encoders: HashMap::new(),
+        }
+    }
+
+    pub fn register<F>(&mut self, name: &str, factory: F)
+    where
+        F: Fn() -> Box<dyn OutputEncoder> + 'static,
+    {
+        self.encoders.insert(name.to_string(), Box::new(factory));
+    }
+
+    pub fn get(&self, name: &str) -> Option<Box<dyn OutputEncoder>> {
+        self.encoders.get(name).map(|factory| factory())
+    }
+
+    pub fn names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.encoders.keys().map(|k| k.as_str()).collect();
+        names.sort_unstable();
+        names
+    }
+}
+
+impl Default for EncoderRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/output/flat_presenter.rs
+++ b/src/output/flat_presenter.rs
@@ -1,20 +1,19 @@
 use crate::core::content::NormalizedContent;
 use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
+use crate::output::encode::OutputEncoder;
 use crate::output::name_allocator::allocate_file_name;
 use crate::output::present::OutputPresenter;
 use crate::output::presented::{build_presented_entries, PresentedEntry, PresentedGame};
 use crate::policy::PolicySet;
 
 pub struct FlatPresenter {
-    encoder: BasicEncoder,
+    encoder: Box<dyn OutputEncoder>,
 }
 
 impl FlatPresenter {
-    pub fn new() -> Self {
-        Self {
-            encoder: BasicEncoder::new(),
-        }
+    pub fn new(encoder: Box<dyn OutputEncoder>) -> Self {
+        Self { encoder }
     }
 
     fn build_root_children(&self, entries: &[PresentedEntry], policy: &PolicySet) -> Vec<VfsNode> {
@@ -57,13 +56,13 @@ impl FlatPresenter {
 
 impl Default for FlatPresenter {
     fn default() -> Self {
-        Self::new()
+        Self::new(Box::new(BasicEncoder::new()))
     }
 }
 
 impl OutputPresenter for FlatPresenter {
     fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory {
-        let presented_entries = build_presented_entries(content, &self.encoder, policy);
+        let presented_entries = build_presented_entries(content, self.encoder.as_ref(), policy);
         let root_children = self.build_root_children(&presented_entries, policy);
 
         VfsDirectory::with_children("", root_children)
@@ -139,7 +138,7 @@ mod tests {
 
     #[test]
     fn presents_mixed_content_at_root() {
-        let presenter = FlatPresenter::new();
+        let presenter = FlatPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![
@@ -206,7 +205,7 @@ mod tests {
 
     #[test]
     fn presents_single_rom_game_as_root_file() {
-        let presenter = FlatPresenter::new();
+        let presenter = FlatPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Game(GameContent {
@@ -229,7 +228,7 @@ mod tests {
 
     #[test]
     fn presents_multi_disc_game_as_root_files_with_playlist() {
-        let presenter = FlatPresenter::new();
+        let presenter = FlatPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Game(GameContent {
@@ -285,7 +284,7 @@ mod tests {
 
     #[test]
     fn flattens_non_game_content_to_leaf_file_names() {
-        let presenter = FlatPresenter::new();
+        let presenter = FlatPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![
@@ -314,7 +313,7 @@ mod tests {
 
     #[test]
     fn conflict_policy_can_disambiguate_flat_sibling_file_names() {
-        let presenter = FlatPresenter::new();
+        let presenter = FlatPresenter::new(Box::new(BasicEncoder::new()));
         let policy = suffix_conflict_policy();
 
         let content = vec![
@@ -338,7 +337,7 @@ mod tests {
 
     #[test]
     fn conflict_policy_can_disambiguate_game_file_and_non_game_file_at_root() {
-        let presenter = FlatPresenter::new();
+        let presenter = FlatPresenter::new(Box::new(BasicEncoder::new()));
         let policy = suffix_conflict_policy();
 
         let content = vec![
@@ -368,7 +367,7 @@ mod tests {
 
     #[test]
     fn conflict_policy_can_disambiguate_playlist_between_duplicate_multi_disc_games() {
-        let presenter = FlatPresenter::new();
+        let presenter = FlatPresenter::new(Box::new(BasicEncoder::new()));
         let policy = suffix_conflict_policy();
 
         let content = vec![

--- a/src/output/grouped_presenter.rs
+++ b/src/output/grouped_presenter.rs
@@ -1,20 +1,19 @@
 use crate::core::content::NormalizedContent;
 use crate::core::vfs::{VfsDirectory, VfsFile, VfsNode};
 use crate::output::basic_encoder::BasicEncoder;
+use crate::output::encode::OutputEncoder;
 use crate::output::name_allocator::{allocate_directory_name, allocate_file_name};
 use crate::output::present::OutputPresenter;
 use crate::output::presented::{build_presented_entries, PresentedEntry, PresentedGame};
 use crate::policy::PolicySet;
 
 pub struct GroupedPresenter {
-    encoder: BasicEncoder,
+    encoder: Box<dyn OutputEncoder>,
 }
 
 impl GroupedPresenter {
-    pub fn new() -> Self {
-        Self {
-            encoder: BasicEncoder::new(),
-        }
+    pub fn new(encoder: Box<dyn OutputEncoder>) -> Self {
+        Self { encoder }
     }
 
     fn build_root_children(&self, entries: &[PresentedEntry], policy: &PolicySet) -> Vec<VfsNode> {
@@ -73,13 +72,13 @@ impl GroupedPresenter {
 
 impl Default for GroupedPresenter {
     fn default() -> Self {
-        Self::new()
+        Self::new(Box::new(BasicEncoder::new()))
     }
 }
 
 impl OutputPresenter for GroupedPresenter {
     fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory {
-        let presented_entries = build_presented_entries(content, &self.encoder, policy);
+        let presented_entries = build_presented_entries(content, self.encoder.as_ref(), policy);
         let root_children = self.build_root_children(&presented_entries, policy);
 
         VfsDirectory::with_children("", root_children)
@@ -274,7 +273,7 @@ mod tests {
 
     #[test]
     fn presents_mixed_content_in_library_view() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![
@@ -321,7 +320,7 @@ mod tests {
 
     #[test]
     fn presents_single_rom_game_as_file_in_platform_title_directory() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Game(GameContent {
@@ -357,7 +356,7 @@ mod tests {
 
     #[test]
     fn presents_multi_disc_game_as_directory_with_playlist_in_library_view() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Game(GameContent {
@@ -425,7 +424,7 @@ mod tests {
 
     #[test]
     fn presents_multiple_games_under_platform_directories() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![
@@ -480,7 +479,7 @@ mod tests {
 
     #[test]
     fn presents_text_content_with_relative_path_using_leaf_file_name() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Text(TextContent {
@@ -502,7 +501,7 @@ mod tests {
 
     #[test]
     fn presents_bytes_content_with_relative_path_using_leaf_file_name() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = PolicySet::default();
 
         let content = vec![NormalizedContent::Bytes(BytesContent {
@@ -524,7 +523,7 @@ mod tests {
 
     #[test]
     fn naming_policy_can_change_grouped_output_names_without_changing_structure() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let default_policy = PolicySet::default();
         let alt_policy = alternate_policy();
 
@@ -592,7 +591,7 @@ mod tests {
 
     #[test]
     fn conflict_policy_can_disambiguate_sibling_file_names() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = suffix_conflict_policy();
 
         let content = vec![
@@ -617,7 +616,7 @@ mod tests {
 
     #[test]
     fn conflict_policy_can_disambiguate_game_directory_names_under_same_platform() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = suffix_conflict_policy();
 
         let content = vec![
@@ -654,7 +653,7 @@ mod tests {
 
     #[test]
     fn reuses_existing_directory_name_before_applying_conflict_suffixes() {
-        let presenter = GroupedPresenter::new();
+        let presenter = GroupedPresenter::new(Box::new(BasicEncoder::new()));
         let policy = suffix_conflict_policy();
 
         let content = vec![

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,6 @@
 pub mod basic_encoder;
 pub mod encode;
+pub mod encoder_registry;
 pub mod flat_presenter;
 pub mod grouped_presenter;
 pub mod name_allocator;

--- a/src/output/presentation_expansion.rs
+++ b/src/output/presentation_expansion.rs
@@ -28,7 +28,7 @@ pub fn sorted_disc_parts(game: &GameContent) -> Vec<&DiscPart> {
 
 /// Encodes a game that expands to a single output file.
 pub fn encode_game(
-    encoder: &impl OutputEncoder,
+    encoder: &(impl OutputEncoder + ?Sized),
     game: &GameContent,
     policy: &PolicySet,
 ) -> EncodedFile {
@@ -39,7 +39,7 @@ pub fn encode_game(
 
 /// Encodes a disc file for a multi-disc game.
 pub fn encode_disc(
-    encoder: &impl OutputEncoder,
+    encoder: &(impl OutputEncoder + ?Sized),
     game: &GameContent,
     disc: &DiscPart,
     policy: &PolicySet,
@@ -56,7 +56,7 @@ pub fn encode_disc(
 
 /// Encodes a playlist file for a multi-disc game.
 pub fn encode_playlist(
-    encoder: &impl OutputEncoder,
+    encoder: &(impl OutputEncoder + ?Sized),
     game: &GameContent,
     disc_names: &[String],
     policy: &PolicySet,

--- a/src/output/presented.rs
+++ b/src/output/presented.rs
@@ -1,5 +1,4 @@
 use crate::core::content::{GameContent, NormalizedContent};
-use crate::output::basic_encoder::BasicEncoder;
 use crate::output::encode::{EncodedFile, OutputEncoder};
 use crate::output::presentation_expansion::{
     encode_disc, encode_game, encode_playlist, is_multi_disc_game, sorted_disc_parts,
@@ -31,7 +30,7 @@ pub struct PresentedGame {
 /// artifacts that presenters will place into the VFS.
 pub fn build_presented_entries(
     content: &[NormalizedContent],
-    encoder: &BasicEncoder,
+    encoder: &dyn OutputEncoder,
     policy: &PolicySet,
 ) -> Vec<PresentedEntry> {
     content
@@ -49,7 +48,7 @@ pub fn build_presented_entries(
 
 fn build_presented_game(
     game: &GameContent,
-    encoder: &BasicEncoder,
+    encoder: &dyn OutputEncoder,
     policy: &PolicySet,
 ) -> PresentedGame {
     let files = if is_multi_disc_game(game) {
@@ -66,7 +65,7 @@ fn build_presented_game(
 
 fn build_multi_disc_files(
     game: &GameContent,
-    encoder: &BasicEncoder,
+    encoder: &dyn OutputEncoder,
     policy: &PolicySet,
 ) -> Vec<EncodedFile> {
     let disc_parts = sorted_disc_parts(game);


### PR DESCRIPTION
## Summary

Introduce an encoder registry and use it to compose presenters with
encoders through bootstrap wiring.

This removes direct `BasicEncoder` ownership from presenters and replaces
it with dependency on the `OutputEncoder` abstraction, extending the
Phase 4D composition model beyond presenter selection.

## Changes

- add `EncoderRegistry` for factory-based encoder registration
- add built-in encoder bootstrap wiring for `basic`
- update built-in presenter registration to resolve encoders via the registry
- refactor `FlatPresenter` and `GroupedPresenter` to depend on `Box<dyn OutputEncoder>`
- generalize presented-output expansion helpers to operate on encoder trait objects
- update pipeline and presenter tests to inject `BasicEncoder` explicitly

## Why

Before this change, presenters still constructed and owned
`BasicEncoder` directly, which meant encoding remained hardwired even
after presenter selection had been moved behind a registry.

Moving encoder construction behind a registry:

- creates a clearer composition boundary for built-in encoders
- keeps presenters dependent on encoder behaviour rather than encoder type
- prepares the codebase for configurable presenter/encoder composition
- continues Phase 4D extensibility work without changing runtime behaviour

## Notes

This PR is intentionally limited in scope:

- no configuration layer yet
- no runtime encoder selection exposed in the CLI yet
- no behaviour changes to presentation or encoding output

It only introduces registry-based encoder composition as the next
incremental step in Phase 4D.