### PR TITLE
refactor: resolve presenters via registry instead of PresenterKind

### DIFF
--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -3,8 +3,9 @@ use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentifier;
-use crate::output::present::{OutputPresenter, PresenterKind};
+use crate::output::present::OutputPresenter;
 use crate::policy::PolicySet;
+use crate::RetromountError;
 
 /// The concrete pipeline components used to run Retromount.
 ///
@@ -18,21 +19,26 @@ pub struct PipelineComponents {
     pub policy: PolicySet,
 }
 
-pub fn default_pipeline_components() -> PipelineComponents {
-    pipeline_components_for_presenter(PresenterKind::Grouped)
+pub fn default_pipeline_components() -> Result<PipelineComponents, RetromountError> {
+    pipeline_components_for_presenter("grouped")
 }
 
-pub fn pipeline_components_for_presenter(kind: PresenterKind) -> PipelineComponents {
+pub fn pipeline_components_for_presenter(
+    name: &str,
+) -> Result<PipelineComponents, RetromountError> {
     let registry = default_presenter_registry();
 
-    let presenter = registry
-        .get(kind.as_str())
-        .unwrap_or_else(|| panic!("presenter '{}' is not registered", kind.as_str()));
+    let presenter = registry.get(name).ok_or_else(|| {
+        RetromountError::LoadError(format!(
+            "unsupported view '{name}'; expected one of: {}",
+            registry.names().join(", ")
+        ))
+    })?;
 
-    PipelineComponents {
+    Ok(PipelineComponents {
         identifier: Box::new(BasicInputIdentifier::new()),
         decoder: Box::new(BasicInputDecoder::new()),
         presenter,
         policy: PolicySet::default(),
-    }
+    })
 }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use crate::core::content::{DecodedContent, GamePart, NormalizedContent};
 use crate::engine::components::pipeline_components_for_presenter;
 use crate::error::RetromountError;
-use crate::output::present::PresenterKind;
 
 use super::pipeline::{run_pipeline_with_trace, PipelineTrace};
 use super::preview::{build_input_source, write_vfs_tree};
@@ -12,11 +11,11 @@ use super::preview::{build_input_source, write_vfs_tree};
 pub fn run_phase3_inspect(
     path: &Path,
     json: bool,
-    presenter_kind: PresenterKind,
+    presenter_name: &str,
 ) -> Result<(), RetromountError> {
     let source = build_input_source(path)?;
     let kind = source.kind();
-    let components = pipeline_components_for_presenter(presenter_kind);
+    let components = pipeline_components_for_presenter(presenter_name)?;
     let trace = run_pipeline_with_trace(
         source.as_ref(),
         components.identifier.as_ref(),

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -7,7 +7,6 @@ use crate::engine::pipeline::run_pipeline;
 use crate::engine::preview::build_input_source;
 use crate::error::RetromountError;
 use crate::mount::session::MountSession;
-use crate::output::present::PresenterKind;
 
 #[cfg(target_os = "linux")]
 use crate::mount::adapter::FilesystemAdapter;
@@ -17,10 +16,10 @@ use crate::mount::fuse_fs::RetromountFuseFs;
 pub fn run_mount_command(
     input: &Path,
     mountpoint: &Path,
-    presenter_kind: PresenterKind,
+    presenter_name: &str,
 ) -> Result<(), RetromountError> {
     let source = build_input_source(input)?;
-    let components = pipeline_components_for_presenter(presenter_kind);
+    let components = pipeline_components_for_presenter(presenter_name)?;
 
     let root = run_pipeline(
         source.as_ref(),
@@ -38,7 +37,7 @@ pub fn run_mount_command(
 
     info!("Prepared mount input: {}", input.display());
     info!("Prepared mountpoint: {}", mountpoint.display());
-    info!("Presenter view: {}", presenter_kind.as_str());
+    info!("Presenter view: {}", presenter_name);
     info!("Indexed VFS nodes: {}", session.node_count());
     info!("Root inode: {}", session.root_inode());
     info!("Root child entries: {}", root_children);

--- a/src/engine/preview.rs
+++ b/src/engine/preview.rs
@@ -13,7 +13,7 @@ use super::pipeline::run_pipeline;
 
 pub fn run_phase3_preview(path: &Path) -> Result<(), RetromountError> {
     let source = build_input_source(path)?;
-    let components = default_pipeline_components();
+    let components = default_pipeline_components()?;
     let root = run_pipeline(
         source.as_ref(),
         components.identifier.as_ref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use retromount::engine::inspect::run_phase3_inspect;
 use retromount::engine::mount::run_mount_command;
 use retromount::engine::pipeline::run_pipeline_with_options;
 use retromount::engine::preview::{build_input_source, run_phase3_preview, write_vfs_tree};
-use retromount::output::present::PresenterKind;
 use retromount::{RetromountError, ViewConfig};
 
 fn main() -> Result<(), RetromountError> {
@@ -27,20 +26,20 @@ fn main() -> Result<(), RetromountError> {
         }
         [command, path] if command.to_string_lossy() == "inspect" => {
             let path = PathBuf::from(path);
-            run_phase3_inspect(&path, false, PresenterKind::Grouped)
+            run_phase3_inspect(&path, false, "grouped")
         }
         [command, path, flag]
             if command.to_string_lossy() == "inspect" && flag.to_string_lossy() == "--json" =>
         {
             let path = PathBuf::from(path);
-            run_phase3_inspect(&path, true, PresenterKind::Grouped)
+            run_phase3_inspect(&path, true, "grouped")
         }
         [command, path, view_flag, view]
             if command.to_string_lossy() == "inspect" && view_flag.to_string_lossy() == "--view" =>
         {
             let path = PathBuf::from(path);
-            let presenter_kind = parse_presenter_kind(view)?;
-            run_phase3_inspect(&path, false, presenter_kind)
+            let presenter_name = parse_presenter_name(view)?;
+            run_phase3_inspect(&path, false, &presenter_name)
         }
         [command, path, flag, view_flag, view]
             if command.to_string_lossy() == "inspect"
@@ -48,21 +47,21 @@ fn main() -> Result<(), RetromountError> {
                 && view_flag.to_string_lossy() == "--view" =>
         {
             let path = PathBuf::from(path);
-            let presenter_kind = parse_presenter_kind(view)?;
-            run_phase3_inspect(&path, true, presenter_kind)
+            let presenter_name = parse_presenter_name(view)?;
+            run_phase3_inspect(&path, true, &presenter_name)
         }
         [command, input, mountpoint] if command.to_string_lossy() == "mount" => {
             let input = PathBuf::from(input);
             let mountpoint = PathBuf::from(mountpoint);
-            run_mount_command(&input, &mountpoint, PresenterKind::Grouped)
+            run_mount_command(&input, &mountpoint, "grouped")
         }
         [command, input, mountpoint, view_flag, view]
             if command.to_string_lossy() == "mount" && view_flag.to_string_lossy() == "--view" =>
         {
             let input = PathBuf::from(input);
             let mountpoint = PathBuf::from(mountpoint);
-            let presenter_kind = parse_presenter_kind(view)?;
-            run_mount_command(&input, &mountpoint, presenter_kind)
+            let presenter_name = parse_presenter_name(view)?;
+            run_mount_command(&input, &mountpoint, &presenter_name)
         }
         _ => Err(RetromountError::LoadError(
             "usage:\n  retromount\n  retromount phase3-preview <path>\n  retromount inspect <path> [--json] [--view <grouped|flat>]\n  retromount mount <input> <mountpoint> [--view <grouped|flat>]"
@@ -71,13 +70,15 @@ fn main() -> Result<(), RetromountError> {
     }
 }
 
-fn parse_presenter_kind(value: &std::ffi::OsStr) -> Result<PresenterKind, RetromountError> {
-    let value = value.to_string_lossy();
-    PresenterKind::parse(&value).ok_or_else(|| {
-        RetromountError::LoadError(format!(
+fn parse_presenter_name(value: &std::ffi::OsStr) -> Result<String, RetromountError> {
+    let value = value.to_string_lossy().to_string();
+
+    match value.as_str() {
+        "grouped" | "flat" => Ok(value),
+        _ => Err(RetromountError::LoadError(format!(
             "unsupported view '{value}'; expected one of: grouped, flat"
-        ))
-    })
+        ))),
+    }
 }
 
 fn run_configured_views() -> Result<(), RetromountError> {
@@ -89,7 +90,7 @@ fn run_configured_views() -> Result<(), RetromountError> {
 
     info!("Loaded {} view(s) from config", config.len());
 
-    let components = default_pipeline_components();
+    let components = default_pipeline_components()?;
 
     for view in &config {
         info!("View: {}", view.name);


### PR DESCRIPTION
## Summary

Replace `PresenterKind`-based presenter selection with registry-driven
presenter resolution.

This builds on the earlier presenter and encoder registry work by making
the application actually resolve presenters through `PresenterRegistry`
instead of branching on an enum in the composition layer.

## Changes

- update pipeline component composition to resolve presenters by name
- make default pipeline component construction fallible
- replace `PresenterKind` usage in CLI, inspect, and mount paths with presenter name strings
- keep `grouped` as the default built-in presenter for existing flows
- update preview path to handle fallible pipeline component construction
- improve unsupported view errors using registered presenter names

## Why

Previous Phase 4D work introduced presenter and encoder registries, but
presenter selection still flowed through `PresenterKind`, which meant the
application was not yet truly using registry-based composition.

This change:

- removes enum-based presenter branching from the composition path
- makes presenter resolution actually flow through the registry
- aligns runtime composition with the extensibility model introduced in Phase 4D
- keeps current behaviour intact while reducing hardcoded selection logic

## Notes

This PR intentionally focuses only on presenter resolution:

- no configuration-driven presenter/encoder pairing yet
- no CLI-exposed encoder selection yet
- no behaviour changes to output layout or encoding

It completes the move from hardcoded presenter branching to
registry-driven presenter lookup.