### PR TITLE
refactor: compose presenters with encoders explicitly

### DIFF
--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -2,6 +2,7 @@ use crate::output::basic_encoder::BasicEncoder;
 use crate::output::encoder_registry::EncoderRegistry;
 use crate::output::flat_presenter::FlatPresenter;
 use crate::output::grouped_presenter::GroupedPresenter;
+use crate::output::present::OutputPresenter;
 use crate::output::presenter_registry::PresenterRegistry;
 
 pub fn default_encoder_registry() -> EncoderRegistry {
@@ -16,20 +17,38 @@ pub fn default_presenter_registry() -> PresenterRegistry {
     let mut registry = PresenterRegistry::new();
 
     registry.register("grouped", || {
-        let encoder = default_encoder_registry()
-            .get("basic")
-            .expect("encoder 'basic' is not registered");
-
-        Box::new(GroupedPresenter::new(encoder))
+        Box::new(GroupedPresenter::default()) as Box<dyn OutputPresenter>
     });
 
     registry.register("flat", || {
-        let encoder = default_encoder_registry()
-            .get("basic")
-            .expect("encoder 'basic' is not registered");
-
-        Box::new(FlatPresenter::new(encoder))
+        Box::new(FlatPresenter::default()) as Box<dyn OutputPresenter>
     });
 
     registry
+}
+
+pub fn build_presenter(
+    presenter_name: &str,
+    encoder_name: &str,
+) -> Result<Box<dyn OutputPresenter>, String> {
+    let encoder_registry = default_encoder_registry();
+
+    let encoder = encoder_registry.get(encoder_name).ok_or_else(|| {
+        format!(
+            "unsupported encoder '{encoder_name}'; expected one of: {}",
+            encoder_registry.names().join(", ")
+        )
+    })?;
+
+    match presenter_name {
+        "grouped" => Ok(Box::new(GroupedPresenter::new(encoder))),
+        "flat" => Ok(Box::new(FlatPresenter::new(encoder))),
+        _ => {
+            let presenter_registry = default_presenter_registry();
+            Err(format!(
+                "unsupported view '{presenter_name}'; expected one of: {}",
+                presenter_registry.names().join(", ")
+            ))
+        }
+    }
 }

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -1,4 +1,6 @@
-use crate::engine::bootstrap::default_presenter_registry;
+use crate::engine::bootstrap::{
+    build_presenter, default_encoder_registry, default_presenter_registry,
+};
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
 use crate::input::decode::InputDecoder;
@@ -20,20 +22,31 @@ pub struct PipelineComponents {
 }
 
 pub fn default_pipeline_components() -> Result<PipelineComponents, RetromountError> {
-    pipeline_components_for_presenter("grouped")
+    pipeline_components("grouped", "basic")
 }
 
-pub fn pipeline_components_for_presenter(
-    name: &str,
+pub fn pipeline_components(
+    presenter_name: &str,
+    encoder_name: &str,
 ) -> Result<PipelineComponents, RetromountError> {
-    let registry = default_presenter_registry();
+    let presenter_registry = default_presenter_registry();
+    if presenter_registry.get(presenter_name).is_none() {
+        return Err(RetromountError::LoadError(format!(
+            "unsupported view '{presenter_name}'; expected one of: {}",
+            presenter_registry.names().join(", ")
+        )));
+    }
 
-    let presenter = registry.get(name).ok_or_else(|| {
-        RetromountError::LoadError(format!(
-            "unsupported view '{name}'; expected one of: {}",
-            registry.names().join(", ")
-        ))
-    })?;
+    let encoder_registry = default_encoder_registry();
+    if encoder_registry.get(encoder_name).is_none() {
+        return Err(RetromountError::LoadError(format!(
+            "unsupported encoder '{encoder_name}'; expected one of: {}",
+            encoder_registry.names().join(", ")
+        )));
+    }
+
+    let presenter =
+        build_presenter(presenter_name, encoder_name).map_err(RetromountError::LoadError)?;
 
     Ok(PipelineComponents {
         identifier: Box::new(BasicInputIdentifier::new()),
@@ -41,4 +54,10 @@ pub fn pipeline_components_for_presenter(
         presenter,
         policy: PolicySet::default(),
     })
+}
+
+pub fn pipeline_components_for_presenter(
+    presenter_name: &str,
+) -> Result<PipelineComponents, RetromountError> {
+    pipeline_components(presenter_name, "basic")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use retromount::core::content::{
 };
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
+use retromount::engine::bootstrap::default_presenter_registry;
 use retromount::engine::components::default_pipeline_components;
 use retromount::engine::inspect::run_phase3_inspect;
 use retromount::engine::mount::run_mount_command;
@@ -72,12 +73,15 @@ fn main() -> Result<(), RetromountError> {
 
 fn parse_presenter_name(value: &std::ffi::OsStr) -> Result<String, RetromountError> {
     let value = value.to_string_lossy().to_string();
+    let registry = default_presenter_registry();
 
-    match value.as_str() {
-        "grouped" | "flat" => Ok(value),
-        _ => Err(RetromountError::LoadError(format!(
-            "unsupported view '{value}'; expected one of: grouped, flat"
-        ))),
+    if registry.get(&value).is_some() {
+        Ok(value)
+    } else {
+        Err(RetromountError::LoadError(format!(
+            "unsupported view '{value}'; expected one of: {}",
+            registry.names().join(", ")
+        )))
     }
 }
 

--- a/src/output/present.rs
+++ b/src/output/present.rs
@@ -10,26 +10,3 @@ use crate::policy::PolicySet;
 pub trait OutputPresenter: Send + Sync {
     fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> VfsDirectory;
 }
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PresenterKind {
-    Grouped,
-    Flat,
-}
-
-impl PresenterKind {
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "grouped" => Some(Self::Grouped),
-            "flat" => Some(Self::Flat),
-            _ => None,
-        }
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Grouped => "grouped",
-            Self::Flat => "flat",
-        }
-    }
-}


### PR DESCRIPTION
## Summary

Make presenter and encoder composition explicit in the pipeline
composition layer and remove the obsolete `PresenterKind` enum.

This builds on the earlier presenter registry, encoder registry, and
registry-based presenter resolution work by moving encoder selection out
of implicit bootstrap wiring and into explicit composition.

## Changes

- add explicit presenter construction via `build_presenter(presenter_name, encoder_name)`
- move encoder selection into pipeline composition instead of hiding it inside presenter registry closures
- introduce `pipeline_components(presenter_name, encoder_name)` as the primary composition path
- retain `pipeline_components_for_presenter(...)` as a compatibility shim using the default `basic` encoder
- update CLI presenter validation to use registered presenter names rather than hardcoded matches
- remove the now-unused `PresenterKind` enum from `present.rs`

## Why

Before this change, presenter resolution was registry-driven, but encoder
selection was still implicitly fixed inside bootstrap wiring. That meant
presenter choice was dynamic while encoder choice was not.

This change:

- completes the move to explicit presenter/encoder composition
- keeps presenters dependent on encoder behaviour rather than a hidden default
- aligns runtime composition with the extensibility goals of Phase 4D
- removes the last obsolete enum-based presenter selection artifact

## Notes

This PR intentionally does not yet expose encoder selection via the CLI
or configuration.

Current behaviour remains unchanged:
- `grouped` remains the default built-in presenter
- `basic` remains the default built-in encoder

The change is architectural: composition is now explicit and ready for
future configuration-driven presenter/encoder pairing.