### PR TITLE
docs: document config-driven composition and mark Phase 4 complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,9 @@ Retromount is under active development and progressing through a structured road
 * Phase 4A — Mountable filesystem (FUSE integration)
 * Phase 4B — Consumer views (multiple presenters)
 * Phase 4C — Naming and conflict resolution policies
+* Phase 4D — Extensibility and configuration layer
 
 ### In Progress
-
-* Phase 4D — Extensibility and configuration layer
 
 ### Planned
 
@@ -140,6 +139,8 @@ Create a file called `retromount.yaml`:
   source: /roms/ps1/Ridge Racer.cue
   mount: /mnt/retromount/ps1
   platform: ps1
+  presenter: grouped
+  encoder: basic
 
 - name: snes
   source: /roms/snes
@@ -150,18 +151,37 @@ Create a file called `retromount.yaml`:
   source: /roms/megadrive
   mount: /mnt/retromount/megadrive
   platform: megadrive
+  presenter: flat
 ```
 
 Fields:
 
-| Field      | Description                                       |
-| ---------- | ------------------------------------------------- |
-| `name`     | Logical name for the mounted view                 |
-| `source`   | Source directory, archive, or disc image          |
-| `mount`    | Mount point for the virtual filesystem            |
-| `platform` | Target platform (e.g. `ps1`, `snes`, `megadrive`) |
+| Field       | Description                                                |
+| ----------- | ---------------------------------------------------------- |
+| `name`      | Logical name for the mounted view                          |
+| `source`    | Source directory, archive, or disc image                   |
+| `mount`     | Mount point for the virtual filesystem                     |
+| `platform`  | Target platform (e.g. `ps1`, `snes`, `megadrive`)          |
+| `presenter` | Filesystem layout (`grouped`, `flat`) (default: `grouped`) |
+| `encoder`   | File representation strategy (default: `basic`)            |
 
 Platform names are **case-insensitive** and accept friendly aliases.
+
+---
+
+### Composition
+
+Each configured view is composed of:
+
+* a **presenter** (defines filesystem structure)
+* an **encoder** (defines file representation)
+
+If not specified:
+
+* `presenter` defaults to `grouped`
+* `encoder` defaults to `basic`
+
+This allows different views to present the same underlying data in different layouts without duplicating files.
 
 ---
 
@@ -242,12 +262,12 @@ Output-specific filtering will be implemented in the **view/output layer** in a 
 
 ## Roadmap
 
-### Phase 4 (current)
+### Phase 4 (completed)
 
-* Consumer-specific filesystem views
-* Presentation policies (naming, filtering, grouping)
-* Performance improvements (e.g. read caching)
-* Output translators (e.g. CHD → ISO)
+* Mountable virtual filesystem (FUSE)
+* Multiple consumer views (presenters)
+* Presentation policies (naming, conflict resolution)
+* Explicit, configurable composition of presenters and encoders
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -132,7 +132,9 @@ Within that stage:
 * the presenter determines structure, grouping, and layout
 * the encoder materializes individual output files
 
-In the default implementation, the presenter composes an encoder while constructing the VFS tree.
+Presenters and encoders are composed explicitly through the runtime composition layer.
+
+Built-in implementations are selected via registry-backed composition, and configured views can choose presenter and encoder combinations independently.
 
 Together, they produce the final VFS tree exposed to consumers.
 
@@ -204,7 +206,7 @@ The architecture review work in this directory aims to:
 * identify confusing or redundant structures
 * remove obsolete or transitional code
 * ensure the system is aligned with a pipeline-first design
-* prepare the codebase for future extensibility (including plugin-style architecture)
+* establish explicit composition and extension boundaries for future external plugin-style architecture
 
 ---
 

--- a/docs/architecture/cleanup-tracker.md
+++ b/docs/architecture/cleanup-tracker.md
@@ -63,6 +63,32 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 - [x] Update architecture docs and findings
 - [x] Update tests for new stage-aligned types
 
+---
+
+### F-104: Presenter selection hardcoded in runtime composition
+
+**Issue:** [#61](https://github.com/lloydsmart/retromount/issues/61)
+
+- [x] Introduce presenter registry
+- [x] Resolve built-in presenters through registry-backed lookup
+- [x] Remove hardcoded presenter branching from composition
+- [x] Remove legacy `PresenterKind` selection path
+- [x] Support presenter selection in configuration
+- [x] Update architecture docs and findings
+
+---
+
+### F-106: Presenter and encoder composition implicit in built-in wiring
+
+**Issue:** [#63](https://github.com/lloydsmart/retromount/issues/63)
+
+- [x] Introduce encoder registry
+- [x] Make presenters depend on `OutputEncoder`
+- [x] Remove concrete encoder ownership from presenter composition paths
+- [x] Compose presenters and encoders explicitly in the composition layer
+- [x] Support presenter/encoder selection per configured view
+- [x] Update architecture docs and findings
+
 ## Medium priority (post-boundary cleanup)
 
 - [x] Review naming consistency for presenter / encoder / output terminology
@@ -87,3 +113,5 @@ This document tracks architectural findings (F-XXX) and the concrete work requir
 - [x] D-003: enforce presenter/encoder separation
 - [x] D-004: ensure core model remains presentation-agnostic
 - [x] D-005: define decoded vs normalized content boundary
+- [x] D-006: resolve presenters via registry-backed composition
+- [x] D-007: make presenter and encoder composition explicit

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -412,3 +412,107 @@ The pipeline is now explicitly layered as:
 - presented/encoded output
 
 See `boundaries.md` for the detailed model shape and pipeline contracts.
+
+---
+
+## D-006: Resolve presenters via registry-backed composition
+
+**Date:** 2026-04-08  
+**Status:** Implemented  
+**Related:** F-104  
+**Issue:** [#61](https://github.com/lloydsmart/retromount/issues/61)
+
+### D-006 Context
+
+Retromount introduced multiple presenter implementations in Phase 4B, but presenter selection remained hardcoded in runtime composition.
+
+This meant presenter extensibility existed at the type level, but not yet at the composition level.
+
+### D-006 Decision
+
+Retromount will resolve presenters through a registry-backed composition model rather than enum-based or hardcoded branching.
+
+Presenter selection becomes a first-class composition concern.
+
+### D-006 Consequences
+
+- presenter selection now flows through `PresenterRegistry`
+- built-in presenter validation and lookup are registry-backed
+- `PresenterKind` has been removed
+- configured and runtime execution resolve presenters by name
+- configuration can select presenters per view
+
+### D-006 Rationale
+
+This change:
+
+- removes hardcoded presenter branching from runtime composition
+- makes presenter selection consistent with extensibility goals
+- provides a cleaner boundary for future plugin-oriented presenter integrations
+- aligns the runtime model with the architecture established in Phase 4B
+
+### D-006 Alternatives considered
+
+- **Keep presenter branching in composition code**  
+  Rejected — preserves unnecessary coupling and weakens extensibility
+
+- **Defer all presenter selection cleanup to a future plugin phase**  
+  Rejected — leaves the built-in composition model inconsistent and incomplete
+
+### D-006 Notes
+
+This decision has been fully implemented.
+
+Presenter selection is now registry-backed and configuration-driven.
+
+---
+
+## D-007: Make presenter and encoder composition explicit
+
+**Date:** 2026-04-08  
+**Status:** Implemented  
+**Related:** F-106  
+**Issue:** [#63](https://github.com/lloydsmart/retromount/issues/63)
+
+### D-007 Context
+
+Retromount already separated structure (Presenter) from representation (Encoder), but the actual pairing of presenters and encoders remained implicit.
+
+Encoders were effectively selected inside presenter construction, which prevented composition from being treated as an explicit runtime concern.
+
+### D-007 Decision
+
+Retromount will compose presenters and encoders explicitly through the composition layer.
+
+Presenter and encoder selection are both first-class runtime/configuration concerns.
+
+### D-007 Consequences
+
+- encoder selection now flows through `EncoderRegistry`
+- presenters depend on `OutputEncoder` rather than concrete encoder ownership
+- the composition layer explicitly selects both presenter and encoder
+- configured views can specify presenter and encoder independently
+- default built-in composition remains `grouped` + `basic` when omitted
+
+### D-007 Rationale
+
+This change:
+
+- completes the Presenter/Encoder separation established by D-003
+- removes hidden encoder coupling from presenter construction
+- makes composition easier to reason about and configure
+- provides the foundation for future extension/plugin work without contaminating core behaviour
+
+### D-007 Alternatives considered
+
+- **Keep encoder selection implicit inside presenter construction**  
+  Rejected — leaves composition hidden and weakens extensibility
+
+- **Expose only presenter selection and defer encoder composition**  
+  Rejected — produces an incomplete composition model
+
+### D-007 Notes
+
+This decision has been fully implemented.
+
+Retromount now supports explicit, registry-backed presenter and encoder composition, including per-view configuration.

--- a/docs/architecture/review-findings.md
+++ b/docs/architecture/review-findings.md
@@ -270,3 +270,104 @@ Retromount now uses an explicit type separation between decoded content and norm
 - encode consumes `NormalizedContent`
 
 This makes the decode → normalize → present pipeline contract explicit in the type model and removes impossible pre-normalized variants from post-normalization stage boundaries.
+
+---
+
+## F-104: Presenter selection was hardcoded rather than registry-backed
+
+**Status:** Resolved  
+**Issue:** [#61](https://github.com/lloydsmart/retromount/issues/61)  
+**Resolved by:** D-006
+
+### F-104 Context
+
+Retromount supported multiple presenters, but presenter selection was originally hardcoded in runtime composition.
+
+This meant that although the output architecture had presenter abstractions, the system still relied on fixed built-in branching when choosing which presenter to use.
+
+### F-104 Evidence
+
+- presenter construction was previously performed via direct branching in pipeline component composition
+- runtime flows selected presenters through hardcoded paths rather than registry-backed lookup
+- configured and CLI-driven view selection depended on built-in selection logic rather than a first-class composition boundary
+
+### F-104 Why it matters
+
+Hardcoded presenter selection weakens extensibility.
+
+If presenter selection is not registry-backed, then:
+
+- adding new presenters requires modifying composition code directly
+- runtime selection remains coupled to built-in implementations
+- configuration cannot act as a clean composition surface
+- future plugin-style presenter integrations become harder to support cleanly
+
+### F-104 Options
+
+- keep built-in presenter branching and document it as acceptable
+- introduce presenter registry-backed selection while keeping built-ins static
+- defer all presenter extensibility until a future plugin phase
+
+### F-104 Decision
+
+Resolved by D-006.
+
+Retromount now resolves presenters via a registry-backed composition model rather than hardcoded branching.
+
+This includes:
+
+- `PresenterRegistry`
+- registry-backed presenter validation and lookup
+- removal of the legacy `PresenterKind` selection path
+- configuration-driven presenter selection per view
+
+---
+
+## F-106: Presenter and encoder composition was implicit rather than explicit
+
+**Status:** Resolved  
+**Issue:** [#63](https://github.com/lloydsmart/retromount/issues/63)  
+**Resolved by:** D-007
+
+### F-106 Context
+
+Retromount had separate presenter and encoder abstractions, but their composition was originally implicit.
+
+In practice, encoder selection was hidden behind presenter construction, and presenter/encoder pairing was not exposed as an explicit runtime or configuration concern.
+
+### F-106 Evidence
+
+- presenters previously owned concrete encoder implementations directly
+- encoder choice was effectively fixed inside presenter construction paths
+- runtime composition selected presenters without exposing encoder selection explicitly
+- configured execution did not initially allow presenter/encoder pairing to vary per view
+
+### F-106 Why it matters
+
+Implicit composition weakens the architectural boundary between structure and representation.
+
+If presenter/encoder composition is not explicit, then:
+
+- encoder choice remains hidden and harder to reason about
+- composition cannot be configured cleanly per view
+- future alternate encoders are harder to introduce safely
+- extensibility work remains partial even when separate abstractions exist
+
+### F-106 Options
+
+- keep encoder selection implicit inside presenter construction
+- make presenter/encoder composition explicit in the composition layer
+- defer encoder composability until a later plugin phase
+
+### F-106 Decision
+
+Resolved by D-007.
+
+Retromount now composes presenters and encoders explicitly through the composition layer.
+
+This includes:
+
+- `EncoderRegistry`
+- explicit presenter/encoder construction in bootstrap and pipeline composition
+- configuration-driven presenter/encoder selection per view
+- removal of hidden built-in encoder coupling from presenter selection paths

--- a/docs/roadmap/phase4-roadmap.md
+++ b/docs/roadmap/phase4-roadmap.md
@@ -226,24 +226,41 @@ feature/phase4c-presentation-policy
 
 ---
 
-## Phase 4D — Plugin System (Deferred)
+## Phase 4D — Composition & Extensibility Foundations
 
 ### Phase 4D Goal
 
-Enable external extensions to the pipeline (inputs, transforms, outputs).
+Make presenter and encoder composition explicit, configurable, and extensible.
+
+Status: Implemented
 
 ---
 
 ### Phase 4D Branch
 
-feature/plugin-system
+feature/phase4d-config-driven-composition
 
 ---
 
 ### Phase 4D Success Criteria
 
-* External components can integrate via stable interfaces
-* Interfaces validated by Phase 4A–4C work
+* [x] presenter selection is registry-backed
+* [x] encoder selection is registry-backed
+* [x] presenter/encoder composition is explicit
+* [x] configuration can select presenter and encoder per view
+* [x] defaults are applied when fields are omitted
+* [x] legacy hardcoded presenter selection removed
+
+---
+
+### Phase 4D Outcome
+
+Retromount now supports explicit, registry-backed composition of presenters and encoders.
+
+Views can be configured independently, allowing the same underlying content
+to be exposed in different layouts and representations without duplication.
+
+This establishes the foundation for future extension work in Phase 5.
 
 ---
 

--- a/retromount.yaml.example
+++ b/retromount.yaml.example
@@ -2,20 +2,27 @@
 #
 # Copy this file to `retromount.yaml` and adjust paths for your system.
 # platform accepts friendly names like ps1, snes, megadrive, playstation, etc.
+#
+# Each view can optionally specify:
+#   presenter → filesystem layout (default: grouped)
+#   encoder   → file representation (default: basic)
 
 - name: ps1
   source: /roms/ps1/Ridge Racer.cue
   mount: /mnt/retromount/ps1
   platform: ps1
+  presenter: grouped
+  encoder: basic
 
-# Directory source example
+# Directory source example (uses defaults: grouped + basic)
 - name: snes
   source: /roms/snes
   mount: /mnt/retromount/snes
   platform: snes
 
-# ZIP-based ROM collection example
+# ZIP-based ROM collection example with alternate presenter
 - name: megadrive
   source: /roms/megadrive
   mount: /mnt/retromount/megadrive
   platform: megadrive
+  presenter: flat

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,10 @@ pub struct ViewConfig {
     pub source: PathBuf,
     pub mount: PathBuf,
     pub platform: Platform,
+
+    #[serde(default)]
+    pub presenter: Option<String>,
+
+    #[serde(default)]
+    pub encoder: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use retromount::core::content::{
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
 use retromount::engine::bootstrap::default_presenter_registry;
-use retromount::engine::components::default_pipeline_components;
+use retromount::engine::components::pipeline_components;
 use retromount::engine::inspect::run_phase3_inspect;
 use retromount::engine::mount::run_mount_command;
 use retromount::engine::pipeline::run_pipeline_with_options;
@@ -94,13 +94,17 @@ fn run_configured_views() -> Result<(), RetromountError> {
 
     info!("Loaded {} view(s) from config", config.len());
 
-    let components = default_pipeline_components()?;
-
     for view in &config {
+        let presenter_name = view.presenter.as_deref().unwrap_or("grouped");
+        let encoder_name = view.encoder.as_deref().unwrap_or("basic");
+
         info!("View: {}", view.name);
         info!("  Source: {}", view.source.display());
         info!("  Mount: {}", view.mount.display());
+        info!("  Presenter: {}", presenter_name);
+        info!("  Encoder: {}", encoder_name);
 
+        let components = pipeline_components(presenter_name, encoder_name)?;
         let source = build_input_source(&view.source)?;
 
         let trace = run_pipeline_with_options(


### PR DESCRIPTION
## Summary

Update documentation to reflect the completion of Phase 4D and the
introduction of config-driven presenter and encoder composition.

This PR aligns the README, example configuration, roadmap, and
architecture documentation with the current architecture and behaviour
of Retromount.

Closes #61  
Closes #63

## Changes

### Configuration

- add `presenter` and `encoder` fields to example `retromount.yaml`
- document default behaviour (`grouped` + `basic`) when fields are omitted
- include an example showing alternate presenter selection (`flat`)

### README

- update example configuration to include presenter/encoder usage
- document the composition model:
  - presenter = filesystem structure
  - encoder = file representation
- extend the configuration field table with the new fields
- mark Phase 4D as complete and Phase 4 as completed

### Roadmap

- replace the outdated Phase 4D “plugin system” placeholder
- document the actual Phase 4D implementation:
  - registry-backed presenter selection
  - registry-backed encoder selection
  - explicit presenter/encoder composition
  - config-driven composition per view
- mark Phase 4D as implemented
- mark Phase 4 as completed

### Architecture docs

- add and resolve F-104: hardcoded presenter selection
- add and resolve F-106: implicit presenter/encoder composition
- record D-006: resolve presenters via registry-backed composition
- record D-007: make presenter and encoder composition explicit
- update cleanup tracker to reflect completed composition work
- align architecture overview wording with explicit composition and future plugin boundaries

## Why

Previous documentation no longer matched the implemented system:

- Phase 4D was described as a deferred plugin system
- config-driven presenter/encoder composition was not documented
- the architecture review did not yet record the closure of the Phase 4D findings around composition

This PR brings the docs back into sync with reality and formally closes
the remaining Phase 4D tracking issues.

## Result

Retromount now provides:

- mountable virtual filesystem (Phase 4A)
- multiple presentation layouts (Phase 4B)
- policy-driven naming and conflict handling (Phase 4C)
- explicit, registry-backed, config-driven presenter/encoder composition (Phase 4D)

Phase 4 is now documented as complete.

## Notes

- no functional changes
- fully backwards compatible configuration
- markdownlint compliance verified