### PR TITLE
Phase 5C: Plugin protocol, client abstraction, and registry

### DIFF
--- a/docs/roadmap/phase5c-plugin-protocol.md
+++ b/docs/roadmap/phase5c-plugin-protocol.md
@@ -1,0 +1,428 @@
+# Phase 5C — Encoder Plugin Protocol
+
+This document defines the protocol boundary between the Retromount host and externally provided encoder plugins.
+
+Phase 5A introduced the declarative presentation plan.
+
+Phase 5B introduced deterministic capability resolution against encoder-declared capabilities.
+
+Phase 5C builds on those foundations by defining the **stable plugin-facing contract** that allows encoder implementations to participate in the runtime without being compiled directly into the main binary.
+
+---
+
+## Goal
+
+Define a **stable, serialisable, versioned protocol** for encoder plugins that allows the host to:
+
+* discover plugin metadata
+* inspect declared encoder capabilities
+* select a capability using the host resolution engine
+* request materialisation of a planned artifact
+* receive a structured materialisation result
+* surface protocol and runtime failures cleanly
+
+Specifically:
+
+> Encoder plugins should be replaceable runtime participants that declare capabilities and materialise artifacts through a host-controlled protocol boundary.
+
+---
+
+## Core Principle
+
+> The host owns planning and resolution. The plugin only declares capabilities and materialises artifacts requested by the host.
+
+The protocol must preserve the architectural boundaries established in earlier phases:
+
+* **presenters define what should exist**
+* **the host resolves which capability should satisfy each request**
+* **plugins materialise artifacts only after selection**
+* **plugins do not perform negotiation or planner-side decision-making**
+
+---
+
+## Scope
+
+Phase 5C includes:
+
+* protocol-level plugin metadata
+* protocol-level capability advertisement
+* protocol request and response types for encoder materialisation
+* protocol error model
+* protocol versioning and compatibility rules
+* validation requirements for protocol payloads
+
+Phase 5C does **not** include:
+
+* dynamic loading
+* process management
+* transport details such as pipes, sockets, or RPC framework selection
+* plugin discovery paths
+* sandboxing or security isolation
+* implementation of a real external plugin
+
+Those concerns belong to later phases.
+
+---
+
+## Why a Protocol Boundary Exists
+
+Built-in encoders can implement internal Rust traits directly.
+
+External plugins cannot safely depend on internal host types as their compatibility boundary.
+
+A protocol boundary is required so that:
+
+* compatibility can be versioned explicitly
+* plugin and host can evolve independently
+* transport/runtime model remains replaceable
+* future plugins are not forced to be Rust crates linked against host internals
+
+This means the plugin-facing model should be expressed as **serialisable protocol data**, not as direct exposure of internal engine types.
+
+---
+
+## Architectural Position
+
+The protocol sits between **host-side resolution/materialisation orchestration** and **plugin-side encoder implementation**.
+
+```text
+NormalizedContent
+    ↓
+Presenter
+    ↓
+PresentationPlan
+    ↓
+Host Capability Resolution
+    ↓
+Selected Capability
+    ↓
+Plugin Protocol Request
+    ↓
+Encoder Plugin
+    ↓
+Plugin Protocol Response
+    ↓
+Host VFS Materialisation
+```
+
+---
+
+## Protocol Design Principles
+
+### Host-driven selection
+
+The plugin advertises capabilities, but does not choose which one is used.
+
+The host always sends the selected capability ID as part of a materialisation request.
+
+---
+
+### Declarative capability advertisement
+
+Capabilities must be described as plain structured data.
+
+No imperative “can you handle this?” negotiation is allowed in protocol v1.
+
+---
+
+### Stable serialisable types
+
+All protocol messages must be serialisable and independent of internal Rust trait objects or engine-only abstractions.
+
+---
+
+### Explicit compatibility
+
+Protocol compatibility must be stated explicitly via version metadata.
+
+No implicit compatibility assumptions are allowed.
+
+---
+
+### Diagnostics-friendly failures
+
+Errors must be structured so that the host can distinguish:
+
+* protocol incompatibility
+* invalid request payloads
+* unsupported capability selection
+* plugin execution failure
+
+---
+
+## Protocol Surface
+
+Phase 5C defines four protocol areas:
+
+1. plugin metadata
+2. capability advertisement
+3. materialisation request/response
+4. protocol errors
+
+---
+
+## 1. Plugin Metadata
+
+A plugin must expose metadata describing its identity and compatibility.
+
+### PluginManifest
+
+A plugin manifest should include:
+
+* `plugin_id`
+* `plugin_version`
+* `protocol_version`
+* `display_name` (optional)
+* `description` (optional)
+* `capabilities`
+
+This metadata is returned before any materialisation call occurs.
+
+### Responsibilities
+
+The manifest allows the host to:
+
+* identify the plugin deterministically
+* validate protocol compatibility
+* inspect available capabilities
+* expose plugin information to users
+
+---
+
+## 2. Capability Advertisement
+
+Capabilities are the plugin-facing equivalent of the host’s internal encoder capability model.
+
+### ProtocolEncoderCapability
+
+Each capability should include:
+
+* `capability_id`
+* `content_type`
+* `formats`
+* `features`
+* `priority`
+* `supports_multi_source`
+
+This model should map cleanly onto host-side resolution data, while remaining protocol-stable.
+
+### Capability Semantics
+
+A capability describes what the plugin can materialise.
+
+It must not depend on dynamic host negotiation.
+
+The host should be able to evaluate capability suitability without calling plugin code.
+
+---
+
+## 3. Materialisation Request/Response
+
+Once the host selects a capability, it sends a materialisation request to the plugin.
+
+### MaterializationRequest
+
+The request should include:
+
+* `artifact_id`
+* `logical_name`
+* `selected_capability_id`
+* `artifact_kind`
+* `requirements`
+* `context`
+
+This request is intentionally richer than a bare capability ID because the plugin must know:
+
+* what artifact is being requested
+* which declared capability the host selected
+* what source or generated artifact shape it is materialising
+* what supporting context is available
+
+### Artifact Kind
+
+The request should include a protocol representation of the planned artifact kind.
+
+At minimum this must support:
+
+* source-backed artifacts
+* generated artifacts such as playlists
+
+The protocol representation must remain declarative.
+
+The host sends the resolved artifact description; the plugin materialises it.
+
+### MaterializationContext
+
+The host may provide supporting context needed for deterministic generation.
+
+Initial context should include:
+
+* referenced artifact names
+
+This allows plugins to generate outputs like playlists without host-specific hidden knowledge.
+
+---
+
+### MaterializationResponse
+
+The plugin returns a materialisation result that the host can convert into a `VfsFile`.
+
+Protocol v1 should support:
+
+* **source-backed output**
+
+  * reference to one source object
+* **inline output**
+
+  * complete generated bytes
+* optional metadata such as:
+
+  * size
+  * media/content type (future-friendly but optional)
+
+This keeps the protocol aligned with the current VFS materialisation model without overcommitting to future backing types.
+
+---
+
+## 4. Error Model
+
+Errors must be structured and machine-readable.
+
+### ProtocolError
+
+The protocol should distinguish between:
+
+* `IncompatibleProtocolVersion`
+* `UnknownCapabilityId`
+* `InvalidRequest`
+* `MissingContext`
+* `UnsupportedArtifactKind`
+* `MaterializationFailed`
+* `InternalPluginError`
+
+The host may choose to surface these differently in inspect/debug views, logs, or user-facing errors.
+
+### Error Boundaries
+
+Errors should indicate whether the failure is caused by:
+
+* host/plugin version mismatch
+* host request construction bug
+* plugin declaration inconsistency
+* plugin runtime failure
+
+This distinction is important for later runtime orchestration.
+
+---
+
+## Protocol Versioning
+
+Protocol versioning must be explicit in v1.
+
+### Requirements
+
+* the host declares the protocol version it supports
+* the plugin declares the protocol version it implements
+* incompatible versions fail before capability use or materialisation
+
+### Initial Rule
+
+For the initial implementation, compatibility should require an exact protocol version match.
+
+This is intentionally strict and can be relaxed later if needed.
+
+---
+
+## Validation Rules
+
+Protocol payloads must be validated at the boundary.
+
+### Manifest validation
+
+The host should reject manifests with:
+
+* empty plugin IDs
+* duplicate capability IDs within one plugin
+* invalid or missing protocol version
+* malformed capability definitions
+
+### Request validation
+
+The plugin should reject requests with:
+
+* unknown selected capability ID
+* malformed artifact definitions
+* missing required context
+* unsupported artifact kinds for the selected capability
+
+---
+
+## Relationship to Internal Types
+
+The protocol is expected to mirror existing internal concepts, but it must not expose internal implementation details as the stability boundary.
+
+This means the host will likely maintain:
+
+* internal planning and resolution types
+* protocol DTOs used for plugin communication
+* conversion logic between the two
+
+That separation is intentional.
+
+It prevents protocol compatibility from becoming coupled to internal refactors.
+
+---
+
+## Suggested Initial Protocol Model
+
+Conceptually, the protocol needs types equivalent to:
+
+* `PluginManifest`
+* `ProtocolEncoderCapability`
+* `ProtocolCapabilityRequirements`
+* `ProtocolArtifactKind`
+* `ProtocolMaterializationContext`
+* `MaterializationRequest`
+* `MaterializationResponse`
+* `ProtocolError`
+
+These may be represented as Rust structs/enums internally, but their real role is as the schema of the plugin boundary.
+
+---
+
+## Success Criteria
+
+Phase 5C is complete when:
+
+* a plugin-facing encoder protocol is documented
+* protocol request/response and manifest types are defined in code
+* protocol version compatibility rules are explicit
+* protocol payload validation rules are defined
+* the protocol can represent current built-in encoder use cases without leaking internal host-only abstractions
+
+---
+
+## Non-Goals Reaffirmed
+
+Phase 5C does not yet prove runtime plugin loading.
+
+It defines the contract that runtime loading will later use.
+
+That separation is intentional:
+
+* Phase 5C defines **what the boundary is**
+* Phase 5D will define **how the host crosses it**
+
+---
+
+## Follow-On Work
+
+Phase 5D will build on this by introducing:
+
+* runtime plugin loading model
+* transport/lifecycle management
+* host-side plugin client implementation
+* error propagation across the runtime boundary
+* plugin inspection/discovery commands
+
+A later phase can then prove the model with a real encoder plugin such as CHD.

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -29,7 +29,7 @@ pub struct MaterializationContext {
 }
 
 pub trait OutputEncoder: Send + Sync {
-    fn plugin_id(&self) -> &'static str;
+    fn plugin_id(&self) -> &str;
 
     fn capabilities(&self) -> Vec<EncoderCapability>;
 

--- a/src/output/materialize.rs
+++ b/src/output/materialize.rs
@@ -6,10 +6,24 @@ use crate::output::capabilities::EncoderCapability;
 use crate::output::encode::{MaterializationContext, OutputEncoder};
 use crate::output::encoder_registry::default_encoder_registry;
 use crate::output::plan::{ArtifactId, PlanEntry, PlanFile, PresentationPlan};
+use crate::output::plugin_registry::PluginRegistry;
 use crate::output::resolution::{CapabilityResolver, ResolutionResult};
 
 pub fn materialize_plan(plan: &PresentationPlan) -> Result<VfsDirectory, io::Error> {
     let encoders = default_encoder_registry().all();
+    materialize_plan_with_encoders(plan, &encoders)
+}
+
+pub fn materialize_plan_with_plugins(
+    plan: &PresentationPlan,
+    plugin_registry: &PluginRegistry,
+) -> Result<VfsDirectory, io::Error> {
+    let builtin_encoders = default_encoder_registry().all();
+    let plugin_encoders = plugin_registry
+        .build_encoders()
+        .map_err(|error| io::Error::other(format!("{error:?}")))?;
+
+    let encoders = merge_encoders(builtin_encoders, plugin_encoders);
     materialize_plan_with_encoders(plan, &encoders)
 }
 
@@ -20,6 +34,14 @@ pub fn materialize_plan_with_encoders(
     let artifact_names = collect_artifact_names(&plan.entries);
     let children = materialize_entries(&plan.entries, &artifact_names, encoders)?;
     Ok(VfsDirectory::with_children("", children))
+}
+
+fn merge_encoders(
+    mut builtin: Vec<Box<dyn OutputEncoder>>,
+    plugins: Vec<Box<dyn OutputEncoder>>,
+) -> Vec<Box<dyn OutputEncoder>> {
+    builtin.extend(plugins);
+    builtin
 }
 
 fn collect_artifact_names(entries: &[PlanEntry]) -> HashMap<ArtifactId, String> {
@@ -123,6 +145,8 @@ fn collect_capabilities(encoders: &[Box<dyn OutputEncoder>]) -> Vec<EncoderCapab
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::core::source::SourceRef;
     use crate::output::basic_encoder::BasicEncoder;
@@ -131,6 +155,53 @@ mod tests {
         ArtifactReference, ArtifactRequest, GeneratedArtifact, PlanFile, PlannedArtifactKind,
         PlaylistArtifact, SourceArtifact, SourceArtifactInput,
     };
+    use crate::output::plugin_client::EncoderPluginClient;
+    use crate::output::plugin_protocol::{
+        MaterializationRequest, MaterializationResponse, PluginManifest, ProtocolContentType,
+        ProtocolEncoderCapability, ProtocolFormat, ProtocolMaterializedSourceFile,
+        ENCODER_PLUGIN_PROTOCOL_V1,
+    };
+
+    #[derive(Clone)]
+    struct TestPluginClient {
+        manifest: PluginManifest,
+    }
+
+    impl EncoderPluginClient for TestPluginClient {
+        fn manifest(
+            &self,
+        ) -> Result<PluginManifest, crate::output::plugin_protocol::ProtocolError> {
+            Ok(self.manifest.clone())
+        }
+
+        fn materialize(
+            &self,
+            _request: &MaterializationRequest,
+        ) -> Result<MaterializationResponse, crate::output::plugin_protocol::ProtocolError>
+        {
+            Ok(MaterializationResponse::SourceBacked(
+                ProtocolMaterializedSourceFile {
+                    source: "file:/plugins/game.iso".to_string(),
+                    size: 8192,
+                },
+            ))
+        }
+    }
+
+    fn plugin_manifest() -> PluginManifest {
+        PluginManifest {
+            plugin_id: "plugin.test".to_string(),
+            plugin_version: "0.1.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: None,
+            description: None,
+            capabilities: vec![ProtocolEncoderCapability::new(
+                "disc.iso",
+                ProtocolContentType::Disc,
+            )
+            .supports_format(ProtocolFormat::Iso)],
+        }
+    }
 
     #[test]
     fn materializes_source_backed_file() {
@@ -254,5 +325,43 @@ mod tests {
 
         assert_eq!(root.children().len(), 1);
         assert_eq!(root.children()[0].name(), "game.bin");
+    }
+
+    #[test]
+    fn materializes_plan_with_plugin_registry() {
+        let plan = PresentationPlan::new(vec![PlanEntry::File(PlanFile::new(
+            "Game.iso",
+            ArtifactRequest::new(
+                ArtifactId::new("game"),
+                PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                    SourceRef::new("file:/roms/game.iso"),
+                    4096,
+                )),
+                CapabilityRequirements::new(ContentType::Disc).with_format(Format::Iso),
+            ),
+        ))]);
+
+        let mut plugin_registry = PluginRegistry::new();
+        let client: Arc<dyn EncoderPluginClient> = Arc::new(TestPluginClient {
+            manifest: plugin_manifest(),
+        });
+        plugin_registry.register(client).unwrap();
+
+        let root = materialize_plan_with_plugins(&plan, &plugin_registry).unwrap();
+
+        assert_eq!(root.children().len(), 1);
+
+        let file = match &root.children()[0] {
+            VfsNode::File(file) => file,
+            other => panic!("expected file, got {other:?}"),
+        };
+
+        match &file.backing {
+            crate::core::vfs::FileBacking::Source(source) => {
+                assert_eq!(source, &SourceRef::new("file:/plugins/game.iso"));
+                assert_eq!(file.size, 8192);
+            }
+            other => panic!("expected source-backed file, got {other:?}"),
+        }
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -8,6 +8,7 @@ pub mod materialize;
 pub mod name_allocator;
 pub mod plan;
 pub mod plugin_protocol;
+pub mod plugin_protocol_conversion;
 pub mod present;
 pub mod presentation_expansion;
 pub mod presenter_registry;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -7,6 +7,7 @@ pub mod grouped_presenter;
 pub mod materialize;
 pub mod name_allocator;
 pub mod plan;
+pub mod plugin_protocol;
 pub mod present;
 pub mod presentation_expansion;
 pub mod presenter_registry;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -11,6 +11,7 @@ pub mod plugin_client;
 pub mod plugin_encoder;
 pub mod plugin_protocol;
 pub mod plugin_protocol_conversion;
+pub mod plugin_registry;
 pub mod present;
 pub mod presentation_expansion;
 pub mod presenter_registry;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -7,6 +7,7 @@ pub mod grouped_presenter;
 pub mod materialize;
 pub mod name_allocator;
 pub mod plan;
+pub mod plugin_client;
 pub mod plugin_protocol;
 pub mod plugin_protocol_conversion;
 pub mod present;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -8,6 +8,7 @@ pub mod materialize;
 pub mod name_allocator;
 pub mod plan;
 pub mod plugin_client;
+pub mod plugin_encoder;
 pub mod plugin_protocol;
 pub mod plugin_protocol_conversion;
 pub mod present;

--- a/src/output/plugin_client.rs
+++ b/src/output/plugin_client.rs
@@ -1,0 +1,223 @@
+use crate::output::encode::{MaterializationContext, MaterializedArtifact};
+use crate::output::plan::ArtifactRequest;
+use crate::output::plugin_protocol::{
+    validate_manifest, validate_materialization_request, MaterializationRequest,
+    MaterializationResponse, PluginManifest, ProtocolError,
+};
+use crate::output::plugin_protocol_conversion::{
+    from_materialization_response, to_materialization_request,
+};
+
+pub trait EncoderPluginClient: Send + Sync {
+    fn manifest(&self) -> Result<PluginManifest, ProtocolError>;
+
+    fn materialize(
+        &self,
+        request: &MaterializationRequest,
+    ) -> Result<MaterializationResponse, ProtocolError>;
+}
+
+pub fn materialize_via_plugin(
+    client: &dyn EncoderPluginClient,
+    file_name: &str,
+    artifact: &ArtifactRequest,
+    selected_capability_id: &str,
+    context: &MaterializationContext,
+) -> Result<MaterializedArtifact, ProtocolError> {
+    let manifest = client.manifest()?;
+    validate_manifest(&manifest)?;
+
+    let request = to_materialization_request(file_name, artifact, selected_capability_id, context);
+
+    validate_materialization_request(&request, &manifest)?;
+
+    let response = client.materialize(&request)?;
+    from_materialization_response(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::core::source::SourceRef;
+    use crate::output::capabilities::{CapabilityRequirements, ContentType, Format};
+    use crate::output::encode::MaterializationContext;
+    use crate::output::plan::{
+        ArtifactId, ArtifactReference, ArtifactRequest, GeneratedArtifact, PlannedArtifactKind,
+        PlaylistArtifact, SourceArtifact,
+    };
+    use crate::output::plugin_protocol::{
+        PluginManifest, ProtocolCapabilityFeature, ProtocolContentType, ProtocolEncoderCapability,
+        ProtocolFormat, ProtocolInlineFile, ProtocolMaterializedSourceFile,
+        ENCODER_PLUGIN_PROTOCOL_V1,
+    };
+
+    #[derive(Debug, Clone)]
+    struct StaticEncoderPluginClient {
+        manifest: PluginManifest,
+        response: MaterializationResponse,
+    }
+
+    impl StaticEncoderPluginClient {
+        fn new(manifest: PluginManifest, response: MaterializationResponse) -> Self {
+            Self { manifest, response }
+        }
+    }
+
+    impl EncoderPluginClient for StaticEncoderPluginClient {
+        fn manifest(&self) -> Result<PluginManifest, ProtocolError> {
+            Ok(self.manifest.clone())
+        }
+
+        fn materialize(
+            &self,
+            _request: &MaterializationRequest,
+        ) -> Result<MaterializationResponse, ProtocolError> {
+            Ok(self.response.clone())
+        }
+    }
+
+    fn disc_manifest() -> PluginManifest {
+        PluginManifest {
+            plugin_id: "plugin.example".to_string(),
+            plugin_version: "0.1.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: Some("Example Plugin".to_string()),
+            description: Some("Example disc encoder".to_string()),
+            capabilities: vec![ProtocolEncoderCapability::new(
+                "disc.iso",
+                ProtocolContentType::Disc,
+            )
+            .supports_format(ProtocolFormat::Iso)
+            .with_feature(ProtocolCapabilityFeature::Lossless)],
+        }
+    }
+
+    fn playlist_manifest() -> PluginManifest {
+        PluginManifest {
+            plugin_id: "plugin.example".to_string(),
+            plugin_version: "0.1.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: Some("Example Plugin".to_string()),
+            description: Some("Example playlist encoder".to_string()),
+            capabilities: vec![ProtocolEncoderCapability::new(
+                "playlist.m3u",
+                ProtocolContentType::Playlist,
+            )
+            .supports_format(ProtocolFormat::M3u)
+            .with_feature(ProtocolCapabilityFeature::MultiSource)],
+        }
+    }
+
+    #[test]
+    fn materializes_source_backed_artifact_via_plugin_client() {
+        let client = StaticEncoderPluginClient::new(
+            disc_manifest(),
+            MaterializationResponse::SourceBacked(ProtocolMaterializedSourceFile {
+                source: "file:/roms/game.iso".to_string(),
+                size: 4096,
+            }),
+        );
+
+        let artifact = ArtifactRequest::new(
+            ArtifactId::new("game-1"),
+            PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                SourceRef::new("file:/roms/game.iso"),
+                4096,
+            )),
+            CapabilityRequirements::new(ContentType::Disc).with_format(Format::Iso),
+        );
+
+        let context = MaterializationContext {
+            artifact_names: HashMap::new(),
+        };
+
+        let materialized =
+            materialize_via_plugin(&client, "Game.iso", &artifact, "disc.iso", &context).unwrap();
+
+        assert_eq!(
+            materialized,
+            MaterializedArtifact::SourceBacked {
+                source: SourceRef::new("file:/roms/game.iso"),
+                size: 4096,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_request_when_selected_capability_is_unknown() {
+        let client = StaticEncoderPluginClient::new(
+            disc_manifest(),
+            MaterializationResponse::SourceBacked(ProtocolMaterializedSourceFile {
+                source: "file:/roms/game.iso".to_string(),
+                size: 4096,
+            }),
+        );
+
+        let artifact = ArtifactRequest::new(
+            ArtifactId::new("game-1"),
+            PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                SourceRef::new("file:/roms/game.iso"),
+                4096,
+            )),
+            CapabilityRequirements::new(ContentType::Disc).with_format(Format::Iso),
+        );
+
+        let context = MaterializationContext {
+            artifact_names: HashMap::new(),
+        };
+
+        let error = materialize_via_plugin(
+            &client,
+            "Game.iso",
+            &artifact,
+            "missing.capability",
+            &context,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            ProtocolError::UnknownCapabilityId {
+                capability_id: "missing.capability".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn materializes_inline_playlist_output_via_plugin_client() {
+        let client = StaticEncoderPluginClient::new(
+            playlist_manifest(),
+            MaterializationResponse::Inline(ProtocolInlineFile {
+                bytes: b"Game (Disc 1).cue\nGame (Disc 2).cue\n".to_vec(),
+            }),
+        );
+
+        let artifact = ArtifactRequest::new(
+            ArtifactId::new("playlist-1"),
+            PlannedArtifactKind::Generated(GeneratedArtifact::Playlist(PlaylistArtifact::new(
+                vec![
+                    ArtifactReference::new(ArtifactId::new("disc-1")),
+                    ArtifactReference::new(ArtifactId::new("disc-2")),
+                ],
+            ))),
+            CapabilityRequirements::new(ContentType::Playlist).with_format(Format::M3u),
+        );
+
+        let mut artifact_names = HashMap::new();
+        artifact_names.insert(ArtifactId::new("disc-1"), "Game (Disc 1).cue".to_string());
+        artifact_names.insert(ArtifactId::new("disc-2"), "Game (Disc 2).cue".to_string());
+
+        let context = MaterializationContext { artifact_names };
+
+        let materialized =
+            materialize_via_plugin(&client, "Game.m3u", &artifact, "playlist.m3u", &context)
+                .unwrap();
+
+        assert_eq!(
+            materialized,
+            MaterializedArtifact::Inline(b"Game (Disc 1).cue\nGame (Disc 2).cue\n".to_vec())
+        );
+    }
+}

--- a/src/output/plugin_encoder.rs
+++ b/src/output/plugin_encoder.rs
@@ -1,0 +1,186 @@
+use crate::output::capabilities::EncoderCapability;
+use crate::output::encode::{MaterializationContext, MaterializedArtifact, OutputEncoder};
+use crate::output::plan::ArtifactRequest;
+use crate::output::plugin_client::EncoderPluginClient;
+use crate::output::plugin_protocol::{validate_manifest, ProtocolError};
+use crate::output::plugin_protocol_conversion::{
+    from_materialization_response, to_encoder_capability, to_materialization_request,
+};
+
+pub struct PluginBackedEncoder {
+    plugin_id: String,
+    capabilities: Vec<EncoderCapability>,
+    client: Box<dyn EncoderPluginClient>,
+}
+
+impl PluginBackedEncoder {
+    pub fn new(
+        plugin_id: String,
+        capabilities: Vec<EncoderCapability>,
+        client: Box<dyn EncoderPluginClient>,
+    ) -> Self {
+        Self {
+            plugin_id,
+            capabilities,
+            client,
+        }
+    }
+
+    pub fn from_client(client: Box<dyn EncoderPluginClient>) -> Result<Self, ProtocolError> {
+        let manifest = client.manifest()?;
+        validate_manifest(&manifest)?;
+
+        let plugin_id = manifest.plugin_id.clone();
+        let capabilities = manifest
+            .capabilities
+            .into_iter()
+            .map(|capability| to_encoder_capability(&plugin_id, capability))
+            .collect();
+
+        Ok(Self {
+            plugin_id,
+            capabilities,
+            client,
+        })
+    }
+}
+
+impl OutputEncoder for PluginBackedEncoder {
+    fn plugin_id(&self) -> &str {
+        &self.plugin_id
+    }
+
+    fn capabilities(&self) -> Vec<EncoderCapability> {
+        self.capabilities.clone()
+    }
+
+    fn materialize(
+        &self,
+        file_name: &str,
+        artifact: &ArtifactRequest,
+        capability_id: &str,
+        context: &MaterializationContext,
+    ) -> Result<MaterializedArtifact, std::io::Error> {
+        let request = to_materialization_request(file_name, artifact, capability_id, context);
+
+        let response = self.client.materialize(&request).map_err(to_io_error)?;
+
+        from_materialization_response(response).map_err(to_io_error)
+    }
+}
+
+fn to_io_error(error: ProtocolError) -> std::io::Error {
+    std::io::Error::other(format!("{error:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::core::source::SourceRef;
+    use crate::output::capabilities::{CapabilityRequirements, ContentType, Format};
+    use crate::output::encode::MaterializationContext;
+    use crate::output::plan::{ArtifactId, ArtifactRequest, PlannedArtifactKind, SourceArtifact};
+    use crate::output::plugin_client::EncoderPluginClient;
+    use crate::output::plugin_protocol::{
+        MaterializationRequest, MaterializationResponse, PluginManifest, ProtocolContentType,
+        ProtocolEncoderCapability, ProtocolFormat, ProtocolMaterializedSourceFile,
+        ENCODER_PLUGIN_PROTOCOL_V1,
+    };
+
+    #[derive(Clone)]
+    struct TestClient {
+        manifest: PluginManifest,
+    }
+
+    impl EncoderPluginClient for TestClient {
+        fn manifest(&self) -> Result<PluginManifest, ProtocolError> {
+            Ok(self.manifest.clone())
+        }
+
+        fn materialize(
+            &self,
+            _request: &MaterializationRequest,
+        ) -> Result<MaterializationResponse, ProtocolError> {
+            Ok(MaterializationResponse::SourceBacked(
+                ProtocolMaterializedSourceFile {
+                    source: "file:/roms/game.iso".to_string(),
+                    size: 4096,
+                },
+            ))
+        }
+    }
+
+    fn manifest() -> PluginManifest {
+        PluginManifest {
+            plugin_id: "plugin.example".to_string(),
+            plugin_version: "0.1.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: None,
+            description: None,
+            capabilities: vec![ProtocolEncoderCapability::new(
+                "disc.iso",
+                ProtocolContentType::Disc,
+            )
+            .supports_format(ProtocolFormat::Iso)],
+        }
+    }
+
+    #[test]
+    fn plugin_encoder_integrates_with_output_encoder_trait() {
+        let encoder = PluginBackedEncoder::new(
+            "plugin.example".to_string(),
+            vec![
+                EncoderCapability::new("plugin.example", "disc.iso", ContentType::Disc)
+                    .supports_format(Format::Iso),
+            ],
+            Box::new(TestClient {
+                manifest: manifest(),
+            }),
+        );
+
+        let artifact = ArtifactRequest::new(
+            ArtifactId::new("game"),
+            PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                SourceRef::new("file:/roms/game.iso"),
+                4096,
+            )),
+            CapabilityRequirements::new(ContentType::Disc).with_format(Format::Iso),
+        );
+
+        let context = MaterializationContext {
+            artifact_names: HashMap::new(),
+        };
+
+        let result = encoder
+            .materialize("Game.iso", &artifact, "disc.iso", &context)
+            .unwrap();
+
+        assert_eq!(
+            result,
+            MaterializedArtifact::SourceBacked {
+                source: SourceRef::new("file:/roms/game.iso"),
+                size: 4096,
+            }
+        );
+    }
+
+    #[test]
+    fn builds_plugin_encoder_from_manifest() {
+        let manifest = manifest();
+        let expected_plugin_id = manifest.plugin_id.clone();
+        let expected_capability_count = manifest.capabilities.len();
+
+        let encoder = PluginBackedEncoder::from_client(Box::new(TestClient { manifest })).unwrap();
+
+        assert_eq!(encoder.plugin_id(), expected_plugin_id);
+        assert_eq!(encoder.capabilities().len(), expected_capability_count);
+
+        let capability = &encoder.capabilities()[0];
+        assert_eq!(capability.plugin_id, "plugin.example");
+        assert_eq!(capability.capability_id, "disc.iso");
+        assert_eq!(capability.content_type, ContentType::Disc);
+        assert!(capability.formats.contains(&Format::Iso));
+    }
+}

--- a/src/output/plugin_encoder.rs
+++ b/src/output/plugin_encoder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::output::capabilities::EncoderCapability;
 use crate::output::encode::{MaterializationContext, MaterializedArtifact, OutputEncoder};
 use crate::output::plan::ArtifactRequest;
@@ -10,14 +12,14 @@ use crate::output::plugin_protocol_conversion::{
 pub struct PluginBackedEncoder {
     plugin_id: String,
     capabilities: Vec<EncoderCapability>,
-    client: Box<dyn EncoderPluginClient>,
+    client: Arc<dyn EncoderPluginClient>,
 }
 
 impl PluginBackedEncoder {
     pub fn new(
         plugin_id: String,
         capabilities: Vec<EncoderCapability>,
-        client: Box<dyn EncoderPluginClient>,
+        client: Arc<dyn EncoderPluginClient>,
     ) -> Self {
         Self {
             plugin_id,
@@ -26,7 +28,7 @@ impl PluginBackedEncoder {
         }
     }
 
-    pub fn from_client(client: Box<dyn EncoderPluginClient>) -> Result<Self, ProtocolError> {
+    pub fn from_client(client: Arc<dyn EncoderPluginClient>) -> Result<Self, ProtocolError> {
         let manifest = client.manifest()?;
         validate_manifest(&manifest)?;
 
@@ -76,6 +78,7 @@ fn to_io_error(error: ProtocolError) -> std::io::Error {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use super::*;
     use crate::core::source::SourceRef;
@@ -129,15 +132,17 @@ mod tests {
 
     #[test]
     fn plugin_encoder_integrates_with_output_encoder_trait() {
+        let client: Arc<dyn EncoderPluginClient> = Arc::new(TestClient {
+            manifest: manifest(),
+        });
+
         let encoder = PluginBackedEncoder::new(
             "plugin.example".to_string(),
             vec![
                 EncoderCapability::new("plugin.example", "disc.iso", ContentType::Disc)
                     .supports_format(Format::Iso),
             ],
-            Box::new(TestClient {
-                manifest: manifest(),
-            }),
+            client,
         );
 
         let artifact = ArtifactRequest::new(
@@ -172,7 +177,8 @@ mod tests {
         let expected_plugin_id = manifest.plugin_id.clone();
         let expected_capability_count = manifest.capabilities.len();
 
-        let encoder = PluginBackedEncoder::from_client(Box::new(TestClient { manifest })).unwrap();
+        let client: Arc<dyn EncoderPluginClient> = Arc::new(TestClient { manifest });
+        let encoder = PluginBackedEncoder::from_client(client).unwrap();
 
         assert_eq!(encoder.plugin_id(), expected_plugin_id);
         assert_eq!(encoder.capabilities().len(), expected_capability_count);

--- a/src/output/plugin_protocol.rs
+++ b/src/output/plugin_protocol.rs
@@ -1,0 +1,637 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+pub const ENCODER_PLUGIN_PROTOCOL_V1: ProtocolVersion = ProtocolVersion::new(1, 0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ProtocolVersion {
+    pub major: u16,
+    pub minor: u16,
+}
+
+impl ProtocolVersion {
+    pub const fn new(major: u16, minor: u16) -> Self {
+        Self { major, minor }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginManifest {
+    pub plugin_id: String,
+    pub plugin_version: String,
+    pub protocol_version: ProtocolVersion,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
+    pub capabilities: Vec<ProtocolEncoderCapability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolEncoderCapability {
+    pub capability_id: String,
+    pub content_type: ProtocolContentType,
+    pub formats: BTreeSet<ProtocolFormat>,
+    pub features: BTreeSet<ProtocolCapabilityFeature>,
+    pub priority: u32,
+}
+
+impl ProtocolEncoderCapability {
+    pub fn new(capability_id: impl Into<String>, content_type: ProtocolContentType) -> Self {
+        Self {
+            capability_id: capability_id.into(),
+            content_type,
+            formats: BTreeSet::new(),
+            features: BTreeSet::new(),
+            priority: 0,
+        }
+    }
+
+    pub fn supports_format(mut self, format: ProtocolFormat) -> Self {
+        self.formats.insert(format);
+        self
+    }
+
+    pub fn with_feature(mut self, feature: ProtocolCapabilityFeature) -> Self {
+        self.features.insert(feature);
+        self
+    }
+
+    pub fn with_priority(mut self, priority: u32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    pub fn supports_multi_source(&self) -> bool {
+        self.features
+            .contains(&ProtocolCapabilityFeature::MultiSource)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ProtocolContentType {
+    Rom,
+    Disc,
+    Playlist,
+    Archive,
+    Directory,
+    Bytes,
+    Text,
+    Game,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ProtocolFormat {
+    Iso,
+    Chd,
+    Zip,
+    M3u,
+    Directory,
+    Bin,
+    Text,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ProtocolCapabilityFeature {
+    MultiSource,
+    Streaming,
+    Lossless,
+    RandomAccess,
+    SupportsPartial,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolCapabilityRequirements {
+    pub content_type: ProtocolContentType,
+    pub format: Option<ProtocolFormat>,
+    pub required_features: BTreeSet<ProtocolCapabilityFeature>,
+    pub preferred_features: BTreeSet<ProtocolCapabilityFeature>,
+    pub forbidden_features: BTreeSet<ProtocolCapabilityFeature>,
+}
+
+impl ProtocolCapabilityRequirements {
+    pub fn new(content_type: ProtocolContentType) -> Self {
+        Self {
+            content_type,
+            format: None,
+            required_features: BTreeSet::new(),
+            preferred_features: BTreeSet::new(),
+            forbidden_features: BTreeSet::new(),
+        }
+    }
+
+    pub fn with_format(mut self, format: ProtocolFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    pub fn require_feature(mut self, feature: ProtocolCapabilityFeature) -> Self {
+        self.required_features.insert(feature);
+        self
+    }
+
+    pub fn prefer_feature(mut self, feature: ProtocolCapabilityFeature) -> Self {
+        self.preferred_features.insert(feature);
+        self
+    }
+
+    pub fn forbid_feature(mut self, feature: ProtocolCapabilityFeature) -> Self {
+        self.forbidden_features.insert(feature);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaterializationRequest {
+    pub artifact_id: String,
+    pub logical_name: String,
+    pub selected_capability_id: String,
+    pub artifact_kind: ProtocolArtifactKind,
+    pub requirements: ProtocolCapabilityRequirements,
+    pub context: ProtocolMaterializationContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProtocolArtifactKind {
+    SourceBacked(ProtocolSourceArtifact),
+    Generated(ProtocolGeneratedArtifact),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolSourceArtifact {
+    pub inputs: Vec<ProtocolSourceArtifactInput>,
+}
+
+impl ProtocolSourceArtifact {
+    pub fn single(source: impl Into<String>, size: u64) -> Self {
+        Self {
+            inputs: vec![ProtocolSourceArtifactInput {
+                source: source.into(),
+                size,
+            }],
+        }
+    }
+
+    pub fn multiple(inputs: Vec<ProtocolSourceArtifactInput>) -> Self {
+        Self { inputs }
+    }
+
+    pub fn is_multi_source(&self) -> bool {
+        self.inputs.len() > 1
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolSourceArtifactInput {
+    pub source: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProtocolGeneratedArtifact {
+    Playlist(ProtocolPlaylistArtifact),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolPlaylistArtifact {
+    pub entries: Vec<ProtocolArtifactReference>,
+}
+
+impl ProtocolPlaylistArtifact {
+    pub fn new(entries: Vec<ProtocolArtifactReference>) -> Self {
+        Self { entries }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolArtifactReference {
+    pub artifact_id: String,
+}
+
+impl ProtocolArtifactReference {
+    pub fn new(artifact_id: impl Into<String>) -> Self {
+        Self {
+            artifact_id: artifact_id.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ProtocolMaterializationContext {
+    pub artifact_names: Vec<ProtocolArtifactName>,
+}
+
+impl ProtocolMaterializationContext {
+    pub fn with_artifact_name(
+        mut self,
+        artifact_id: impl Into<String>,
+        logical_name: impl Into<String>,
+    ) -> Self {
+        self.artifact_names.push(ProtocolArtifactName {
+            artifact_id: artifact_id.into(),
+            logical_name: logical_name.into(),
+        });
+        self
+    }
+
+    pub fn artifact_name_for(&self, artifact_id: &str) -> Option<&str> {
+        self.artifact_names
+            .iter()
+            .find(|entry| entry.artifact_id == artifact_id)
+            .map(|entry| entry.logical_name.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolArtifactName {
+    pub artifact_id: String,
+    pub logical_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MaterializationResponse {
+    SourceBacked(ProtocolMaterializedSourceFile),
+    Inline(ProtocolInlineFile),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolMaterializedSourceFile {
+    pub source: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolInlineFile {
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProtocolError {
+    IncompatibleProtocolVersion {
+        host: ProtocolVersion,
+        plugin: ProtocolVersion,
+    },
+    InvalidManifest {
+        message: String,
+    },
+    UnknownCapabilityId {
+        capability_id: String,
+    },
+    InvalidRequest {
+        message: String,
+    },
+    MissingContext {
+        message: String,
+    },
+    UnsupportedArtifactKind {
+        message: String,
+    },
+    MaterializationFailed {
+        message: String,
+    },
+    InternalPluginError {
+        message: String,
+    },
+}
+
+pub fn ensure_protocol_compatible(
+    host: &ProtocolVersion,
+    plugin: &ProtocolVersion,
+) -> Result<(), ProtocolError> {
+    if host == plugin {
+        Ok(())
+    } else {
+        Err(ProtocolError::IncompatibleProtocolVersion {
+            host: *host,
+            plugin: *plugin,
+        })
+    }
+}
+
+pub fn validate_manifest(manifest: &PluginManifest) -> Result<(), ProtocolError> {
+    if manifest.plugin_id.trim().is_empty() {
+        return Err(ProtocolError::InvalidManifest {
+            message: "plugin_id must not be empty".to_string(),
+        });
+    }
+
+    if manifest.plugin_version.trim().is_empty() {
+        return Err(ProtocolError::InvalidManifest {
+            message: "plugin_version must not be empty".to_string(),
+        });
+    }
+
+    ensure_protocol_compatible(&ENCODER_PLUGIN_PROTOCOL_V1, &manifest.protocol_version)?;
+
+    let mut capability_ids = BTreeSet::new();
+
+    for capability in &manifest.capabilities {
+        if capability.capability_id.trim().is_empty() {
+            return Err(ProtocolError::InvalidManifest {
+                message: "capability_id must not be empty".to_string(),
+            });
+        }
+
+        if capability.formats.is_empty() {
+            return Err(ProtocolError::InvalidManifest {
+                message: format!(
+                    "capability '{}' must declare at least one format",
+                    capability.capability_id
+                ),
+            });
+        }
+
+        if !capability_ids.insert(capability.capability_id.clone()) {
+            return Err(ProtocolError::InvalidManifest {
+                message: format!("duplicate capability_id '{}'", capability.capability_id),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_materialization_request(
+    request: &MaterializationRequest,
+    manifest: &PluginManifest,
+) -> Result<(), ProtocolError> {
+    if request.artifact_id.trim().is_empty() {
+        return Err(ProtocolError::InvalidRequest {
+            message: "artifact_id must not be empty".to_string(),
+        });
+    }
+
+    if request.logical_name.trim().is_empty() {
+        return Err(ProtocolError::InvalidRequest {
+            message: "logical_name must not be empty".to_string(),
+        });
+    }
+
+    if request.selected_capability_id.trim().is_empty() {
+        return Err(ProtocolError::InvalidRequest {
+            message: "selected_capability_id must not be empty".to_string(),
+        });
+    }
+
+    let capability = manifest
+        .capabilities
+        .iter()
+        .find(|capability| capability.capability_id == request.selected_capability_id)
+        .ok_or_else(|| ProtocolError::UnknownCapabilityId {
+            capability_id: request.selected_capability_id.clone(),
+        })?;
+
+    if capability.content_type != request.requirements.content_type {
+        return Err(ProtocolError::InvalidRequest {
+            message: format!(
+                "selected capability '{}' content type does not match request requirements",
+                capability.capability_id
+            ),
+        });
+    }
+
+    if let Some(required_format) = request.requirements.format {
+        if !capability.formats.contains(&required_format) {
+            return Err(ProtocolError::InvalidRequest {
+                message: format!(
+                    "selected capability '{}' does not support required format '{required_format:?}'",
+                    capability.capability_id
+                ),
+            });
+        }
+    }
+
+    for feature in &request.requirements.required_features {
+        if !capability.features.contains(feature) {
+            return Err(ProtocolError::InvalidRequest {
+                message: format!(
+                    "selected capability '{}' is missing required feature '{feature:?}'",
+                    capability.capability_id
+                ),
+            });
+        }
+    }
+
+    for feature in &request.requirements.forbidden_features {
+        if capability.features.contains(feature) {
+            return Err(ProtocolError::InvalidRequest {
+                message: format!(
+                    "selected capability '{}' includes forbidden feature '{feature:?}'",
+                    capability.capability_id
+                ),
+            });
+        }
+    }
+
+    match &request.artifact_kind {
+        ProtocolArtifactKind::SourceBacked(source_artifact) => {
+            if source_artifact.inputs.is_empty() {
+                return Err(ProtocolError::InvalidRequest {
+                    message: "source-backed artifact must include at least one input".to_string(),
+                });
+            }
+
+            if source_artifact.is_multi_source() && !capability.supports_multi_source() {
+                return Err(ProtocolError::InvalidRequest {
+                    message: format!(
+                        "selected capability '{}' does not support multi-source artifacts",
+                        capability.capability_id
+                    ),
+                });
+            }
+        }
+        ProtocolArtifactKind::Generated(ProtocolGeneratedArtifact::Playlist(playlist)) => {
+            if playlist.entries.is_empty() {
+                return Err(ProtocolError::InvalidRequest {
+                    message: "playlist artifact must include at least one entry".to_string(),
+                });
+            }
+
+            for entry in &playlist.entries {
+                if request
+                    .context
+                    .artifact_name_for(&entry.artifact_id)
+                    .is_none()
+                {
+                    return Err(ProtocolError::MissingContext {
+                        message: format!(
+                            "missing artifact name for referenced artifact '{}'",
+                            entry.artifact_id
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_manifest() -> PluginManifest {
+        PluginManifest {
+            plugin_id: "plugin.example".to_string(),
+            plugin_version: "0.1.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: Some("Example Plugin".to_string()),
+            description: Some("Example encoder plugin".to_string()),
+            capabilities: vec![
+                ProtocolEncoderCapability::new("disc.chd", ProtocolContentType::Disc)
+                    .supports_format(ProtocolFormat::Chd)
+                    .with_feature(ProtocolCapabilityFeature::Lossless)
+                    .with_priority(100),
+                ProtocolEncoderCapability::new("playlist.m3u", ProtocolContentType::Playlist)
+                    .supports_format(ProtocolFormat::M3u)
+                    .with_feature(ProtocolCapabilityFeature::MultiSource),
+            ],
+        }
+    }
+
+    #[test]
+    fn accepts_valid_manifest() {
+        let manifest = valid_manifest();
+        assert_eq!(validate_manifest(&manifest), Ok(()));
+    }
+
+    #[test]
+    fn rejects_empty_plugin_id() {
+        let mut manifest = valid_manifest();
+        manifest.plugin_id = String::new();
+
+        assert_eq!(
+            validate_manifest(&manifest),
+            Err(ProtocolError::InvalidManifest {
+                message: "plugin_id must not be empty".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_capability_ids() {
+        let mut manifest = valid_manifest();
+        manifest.capabilities.push(
+            ProtocolEncoderCapability::new("disc.chd", ProtocolContentType::Disc)
+                .supports_format(ProtocolFormat::Chd),
+        );
+
+        assert_eq!(
+            validate_manifest(&manifest),
+            Err(ProtocolError::InvalidManifest {
+                message: "duplicate capability_id 'disc.chd'".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_incompatible_protocol_version() {
+        let manifest = PluginManifest {
+            protocol_version: ProtocolVersion::new(2, 0),
+            ..valid_manifest()
+        };
+
+        assert_eq!(
+            validate_manifest(&manifest),
+            Err(ProtocolError::IncompatibleProtocolVersion {
+                host: ENCODER_PLUGIN_PROTOCOL_V1,
+                plugin: ProtocolVersion::new(2, 0),
+            })
+        );
+    }
+
+    #[test]
+    fn request_validation_rejects_unknown_capability_id() {
+        let manifest = valid_manifest();
+        let request = MaterializationRequest {
+            artifact_id: "artifact-1".to_string(),
+            logical_name: "Game.chd".to_string(),
+            selected_capability_id: "missing.capability".to_string(),
+            artifact_kind: ProtocolArtifactKind::SourceBacked(ProtocolSourceArtifact::single(
+                "file:/roms/game.bin",
+                1024,
+            )),
+            requirements: ProtocolCapabilityRequirements::new(ProtocolContentType::Disc)
+                .with_format(ProtocolFormat::Chd),
+            context: ProtocolMaterializationContext::default(),
+        };
+
+        assert_eq!(
+            validate_materialization_request(&request, &manifest),
+            Err(ProtocolError::UnknownCapabilityId {
+                capability_id: "missing.capability".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn request_validation_accepts_playlist_with_context() {
+        let manifest = valid_manifest();
+        let request = MaterializationRequest {
+            artifact_id: "playlist-1".to_string(),
+            logical_name: "Game.m3u".to_string(),
+            selected_capability_id: "playlist.m3u".to_string(),
+            artifact_kind: ProtocolArtifactKind::Generated(ProtocolGeneratedArtifact::Playlist(
+                ProtocolPlaylistArtifact::new(vec![
+                    ProtocolArtifactReference::new("disc-1"),
+                    ProtocolArtifactReference::new("disc-2"),
+                ]),
+            )),
+            requirements: ProtocolCapabilityRequirements::new(ProtocolContentType::Playlist)
+                .with_format(ProtocolFormat::M3u),
+            context: ProtocolMaterializationContext::default()
+                .with_artifact_name("disc-1", "Game (Disc 1).cue")
+                .with_artifact_name("disc-2", "Game (Disc 2).cue"),
+        };
+
+        assert_eq!(
+            validate_materialization_request(&request, &manifest),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn request_validation_rejects_playlist_without_context() {
+        let manifest = valid_manifest();
+        let request = MaterializationRequest {
+            artifact_id: "playlist-1".to_string(),
+            logical_name: "Game.m3u".to_string(),
+            selected_capability_id: "playlist.m3u".to_string(),
+            artifact_kind: ProtocolArtifactKind::Generated(ProtocolGeneratedArtifact::Playlist(
+                ProtocolPlaylistArtifact::new(vec![ProtocolArtifactReference::new("disc-1")]),
+            )),
+            requirements: ProtocolCapabilityRequirements::new(ProtocolContentType::Playlist)
+                .with_format(ProtocolFormat::M3u),
+            context: ProtocolMaterializationContext::default(),
+        };
+
+        assert_eq!(
+            validate_materialization_request(&request, &manifest),
+            Err(ProtocolError::MissingContext {
+                message: "missing artifact name for referenced artifact 'disc-1'".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn protocol_types_round_trip_through_json() {
+        let request = MaterializationRequest {
+            artifact_id: "artifact-1".to_string(),
+            logical_name: "Game.chd".to_string(),
+            selected_capability_id: "disc.chd".to_string(),
+            artifact_kind: ProtocolArtifactKind::SourceBacked(ProtocolSourceArtifact::single(
+                "file:/roms/game.bin",
+                1024,
+            )),
+            requirements: ProtocolCapabilityRequirements::new(ProtocolContentType::Disc)
+                .with_format(ProtocolFormat::Chd)
+                .require_feature(ProtocolCapabilityFeature::Lossless),
+            context: ProtocolMaterializationContext::default(),
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        let decoded: MaterializationRequest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, request);
+    }
+}

--- a/src/output/plugin_protocol_conversion.rs
+++ b/src/output/plugin_protocol_conversion.rs
@@ -442,6 +442,28 @@ pub fn to_protocol_response(artifact: MaterializedArtifact) -> MaterializationRe
     }
 }
 
+pub fn to_encoder_capability(
+    plugin_id: &str,
+    capability: ProtocolEncoderCapability,
+) -> EncoderCapability {
+    let mut result = EncoderCapability::new(
+        plugin_id,
+        capability.capability_id,
+        capability.content_type.into(),
+    )
+    .with_priority(capability.priority);
+
+    for format in capability.formats {
+        result = result.supports_format(format.into());
+    }
+
+    for feature in capability.features {
+        result = result.with_feature(feature.into());
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -582,5 +604,22 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn converts_protocol_capability_to_encoder_capability() {
+        let protocol = ProtocolEncoderCapability::new("disc.chd", ProtocolContentType::Disc)
+            .supports_format(ProtocolFormat::Chd)
+            .with_feature(ProtocolCapabilityFeature::Lossless)
+            .with_priority(100);
+
+        let capability = to_encoder_capability("plugin.example", protocol);
+
+        assert_eq!(capability.plugin_id, "plugin.example");
+        assert_eq!(capability.capability_id, "disc.chd");
+        assert_eq!(capability.content_type, ContentType::Disc);
+        assert!(capability.formats.contains(&Format::Chd));
+        assert!(capability.features.contains(&CapabilityFeature::Lossless));
+        assert_eq!(capability.priority, 100);
     }
 }

--- a/src/output/plugin_protocol_conversion.rs
+++ b/src/output/plugin_protocol_conversion.rs
@@ -1,0 +1,586 @@
+use std::collections::HashMap;
+
+use crate::core::source::SourceRef;
+use crate::output::capabilities::{
+    CapabilityFeature, CapabilityRequirements, ContentType, EncoderCapability, Format,
+};
+use crate::output::encode::{MaterializationContext, MaterializedArtifact};
+use crate::output::plan::{
+    ArtifactId, ArtifactReference, ArtifactRequest, GeneratedArtifact, PlannedArtifactKind,
+    PlaylistArtifact, SourceArtifact, SourceArtifactInput,
+};
+use crate::output::plugin_protocol::{
+    MaterializationRequest, MaterializationResponse, PluginManifest, ProtocolArtifactKind,
+    ProtocolArtifactName, ProtocolArtifactReference, ProtocolCapabilityFeature,
+    ProtocolCapabilityRequirements, ProtocolContentType, ProtocolEncoderCapability, ProtocolError,
+    ProtocolFormat, ProtocolGeneratedArtifact, ProtocolInlineFile, ProtocolMaterializationContext,
+    ProtocolMaterializedSourceFile, ProtocolPlaylistArtifact, ProtocolSourceArtifact,
+    ProtocolSourceArtifactInput,
+};
+
+pub fn to_protocol_manifest(
+    plugin_id: impl Into<String>,
+    plugin_version: impl Into<String>,
+    protocol_version: crate::output::plugin_protocol::ProtocolVersion,
+    display_name: Option<String>,
+    description: Option<String>,
+    capabilities: &[EncoderCapability],
+) -> PluginManifest {
+    PluginManifest {
+        plugin_id: plugin_id.into(),
+        plugin_version: plugin_version.into(),
+        protocol_version,
+        display_name,
+        description,
+        capabilities: capabilities
+            .iter()
+            .cloned()
+            .map(ProtocolEncoderCapability::from)
+            .collect(),
+    }
+}
+
+pub fn to_materialization_request(
+    file_name: &str,
+    artifact: &ArtifactRequest,
+    selected_capability_id: &str,
+    context: &MaterializationContext,
+) -> MaterializationRequest {
+    MaterializationRequest {
+        artifact_id: artifact.id.0.clone(),
+        logical_name: file_name.to_string(),
+        selected_capability_id: selected_capability_id.to_string(),
+        artifact_kind: ProtocolArtifactKind::from(artifact.kind.clone()),
+        requirements: ProtocolCapabilityRequirements::from(artifact.requirements.clone()),
+        context: ProtocolMaterializationContext::from(context.clone()),
+    }
+}
+
+pub fn from_materialization_response(
+    response: MaterializationResponse,
+) -> Result<MaterializedArtifact, ProtocolError> {
+    match response {
+        MaterializationResponse::SourceBacked(file) => Ok(MaterializedArtifact::SourceBacked {
+            source: SourceRef::new(file.source),
+            size: file.size,
+        }),
+        MaterializationResponse::Inline(file) => Ok(MaterializedArtifact::Inline(file.bytes)),
+    }
+}
+
+impl From<ContentType> for ProtocolContentType {
+    fn from(value: ContentType) -> Self {
+        match value {
+            ContentType::Rom => Self::Rom,
+            ContentType::Disc => Self::Disc,
+            ContentType::Playlist => Self::Playlist,
+            ContentType::Archive => Self::Archive,
+            ContentType::Directory => Self::Directory,
+            ContentType::Bytes => Self::Bytes,
+            ContentType::Text => Self::Text,
+            ContentType::Game => Self::Game,
+        }
+    }
+}
+
+impl From<ProtocolContentType> for ContentType {
+    fn from(value: ProtocolContentType) -> Self {
+        match value {
+            ProtocolContentType::Rom => Self::Rom,
+            ProtocolContentType::Disc => Self::Disc,
+            ProtocolContentType::Playlist => Self::Playlist,
+            ProtocolContentType::Archive => Self::Archive,
+            ProtocolContentType::Directory => Self::Directory,
+            ProtocolContentType::Bytes => Self::Bytes,
+            ProtocolContentType::Text => Self::Text,
+            ProtocolContentType::Game => Self::Game,
+        }
+    }
+}
+
+impl From<Format> for ProtocolFormat {
+    fn from(value: Format) -> Self {
+        match value {
+            Format::Iso => Self::Iso,
+            Format::Chd => Self::Chd,
+            Format::Zip => Self::Zip,
+            Format::M3u => Self::M3u,
+            Format::Directory => Self::Directory,
+            Format::Bin => Self::Bin,
+            Format::Text => Self::Text,
+        }
+    }
+}
+
+impl From<ProtocolFormat> for Format {
+    fn from(value: ProtocolFormat) -> Self {
+        match value {
+            ProtocolFormat::Iso => Self::Iso,
+            ProtocolFormat::Chd => Self::Chd,
+            ProtocolFormat::Zip => Self::Zip,
+            ProtocolFormat::M3u => Self::M3u,
+            ProtocolFormat::Directory => Self::Directory,
+            ProtocolFormat::Bin => Self::Bin,
+            ProtocolFormat::Text => Self::Text,
+        }
+    }
+}
+
+impl From<CapabilityFeature> for ProtocolCapabilityFeature {
+    fn from(value: CapabilityFeature) -> Self {
+        match value {
+            CapabilityFeature::MultiSource => Self::MultiSource,
+            CapabilityFeature::Streaming => Self::Streaming,
+            CapabilityFeature::Lossless => Self::Lossless,
+            CapabilityFeature::RandomAccess => Self::RandomAccess,
+            CapabilityFeature::SupportsPartial => Self::SupportsPartial,
+        }
+    }
+}
+
+impl From<ProtocolCapabilityFeature> for CapabilityFeature {
+    fn from(value: ProtocolCapabilityFeature) -> Self {
+        match value {
+            ProtocolCapabilityFeature::MultiSource => Self::MultiSource,
+            ProtocolCapabilityFeature::Streaming => Self::Streaming,
+            ProtocolCapabilityFeature::Lossless => Self::Lossless,
+            ProtocolCapabilityFeature::RandomAccess => Self::RandomAccess,
+            ProtocolCapabilityFeature::SupportsPartial => Self::SupportsPartial,
+        }
+    }
+}
+
+impl From<EncoderCapability> for ProtocolEncoderCapability {
+    fn from(value: EncoderCapability) -> Self {
+        let mut capability =
+            ProtocolEncoderCapability::new(value.capability_id, value.content_type.into())
+                .with_priority(value.priority);
+
+        for format in value.formats {
+            capability = capability.supports_format(format.into());
+        }
+
+        for feature in value.features {
+            capability = capability.with_feature(feature.into());
+        }
+
+        capability
+    }
+}
+
+impl From<CapabilityRequirements> for ProtocolCapabilityRequirements {
+    fn from(value: CapabilityRequirements) -> Self {
+        let mut requirements = ProtocolCapabilityRequirements::new(value.content_type.into());
+
+        if let Some(format) = value.format {
+            requirements = requirements.with_format(format.into());
+        }
+
+        for feature in value.required_features {
+            requirements = requirements.require_feature(feature.into());
+        }
+
+        for feature in value.preferred_features {
+            requirements = requirements.prefer_feature(feature.into());
+        }
+
+        for feature in value.forbidden_features {
+            requirements = requirements.forbid_feature(feature.into());
+        }
+
+        requirements
+    }
+}
+
+impl From<SourceArtifactInput> for ProtocolSourceArtifactInput {
+    fn from(value: SourceArtifactInput) -> Self {
+        Self {
+            source: value.source.0.as_ref().to_string(),
+            size: value.size,
+        }
+    }
+}
+
+impl From<SourceArtifact> for ProtocolSourceArtifact {
+    fn from(value: SourceArtifact) -> Self {
+        Self::multiple(
+            value
+                .inputs
+                .into_iter()
+                .map(ProtocolSourceArtifactInput::from)
+                .collect(),
+        )
+    }
+}
+
+impl From<ArtifactReference> for ProtocolArtifactReference {
+    fn from(value: ArtifactReference) -> Self {
+        Self::new(value.artifact_id.0)
+    }
+}
+
+impl From<PlaylistArtifact> for ProtocolPlaylistArtifact {
+    fn from(value: PlaylistArtifact) -> Self {
+        Self::new(
+            value
+                .entries
+                .into_iter()
+                .map(ProtocolArtifactReference::from)
+                .collect(),
+        )
+    }
+}
+
+impl From<GeneratedArtifact> for ProtocolGeneratedArtifact {
+    fn from(value: GeneratedArtifact) -> Self {
+        match value {
+            GeneratedArtifact::Playlist(playlist) => Self::Playlist(playlist.into()),
+        }
+    }
+}
+
+impl From<PlannedArtifactKind> for ProtocolArtifactKind {
+    fn from(value: PlannedArtifactKind) -> Self {
+        match value {
+            PlannedArtifactKind::SourceBacked(source_artifact) => {
+                Self::SourceBacked(source_artifact.into())
+            }
+            PlannedArtifactKind::Generated(generated_artifact) => {
+                Self::Generated(generated_artifact.into())
+            }
+        }
+    }
+}
+
+impl From<MaterializationContext> for ProtocolMaterializationContext {
+    fn from(value: MaterializationContext) -> Self {
+        Self {
+            artifact_names: value
+                .artifact_names
+                .into_iter()
+                .map(|(artifact_id, logical_name)| ProtocolArtifactName {
+                    artifact_id: artifact_id.0,
+                    logical_name,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<ProtocolCapabilityRequirements> for CapabilityRequirements {
+    type Error = ProtocolError;
+
+    fn try_from(value: ProtocolCapabilityRequirements) -> Result<Self, Self::Error> {
+        let mut requirements = CapabilityRequirements::new(value.content_type.into());
+
+        if let Some(format) = value.format {
+            requirements = requirements.with_format(format.into());
+        }
+
+        for feature in value.required_features {
+            requirements = requirements.require_feature(feature.into());
+        }
+
+        for feature in value.preferred_features {
+            requirements = requirements.prefer_feature(feature.into());
+        }
+
+        for feature in value.forbidden_features {
+            requirements = requirements.forbid_feature(feature.into());
+        }
+
+        Ok(requirements)
+    }
+}
+
+impl TryFrom<ProtocolSourceArtifactInput> for SourceArtifactInput {
+    type Error = ProtocolError;
+
+    fn try_from(value: ProtocolSourceArtifactInput) -> Result<Self, Self::Error> {
+        if value.source.trim().is_empty() {
+            return Err(ProtocolError::InvalidRequest {
+                message: "source artifact input source must not be empty".to_string(),
+            });
+        }
+
+        Ok(Self {
+            source: SourceRef::new(value.source),
+            size: value.size,
+        })
+    }
+}
+
+impl TryFrom<ProtocolSourceArtifact> for SourceArtifact {
+    type Error = ProtocolError;
+
+    fn try_from(value: ProtocolSourceArtifact) -> Result<Self, Self::Error> {
+        let inputs: Result<Vec<_>, _> = value
+            .inputs
+            .into_iter()
+            .map(SourceArtifactInput::try_from)
+            .collect();
+
+        let inputs = inputs?;
+
+        if inputs.is_empty() {
+            return Err(ProtocolError::InvalidRequest {
+                message: "source-backed artifact must include at least one input".to_string(),
+            });
+        }
+
+        Ok(SourceArtifact::multiple(inputs))
+    }
+}
+
+impl From<ProtocolArtifactReference> for ArtifactReference {
+    fn from(value: ProtocolArtifactReference) -> Self {
+        Self::new(ArtifactId::new(value.artifact_id))
+    }
+}
+
+impl TryFrom<ProtocolPlaylistArtifact> for PlaylistArtifact {
+    type Error = ProtocolError;
+
+    fn try_from(value: ProtocolPlaylistArtifact) -> Result<Self, Self::Error> {
+        if value.entries.is_empty() {
+            return Err(ProtocolError::InvalidRequest {
+                message: "playlist artifact must include at least one entry".to_string(),
+            });
+        }
+
+        Ok(PlaylistArtifact::new(
+            value
+                .entries
+                .into_iter()
+                .map(ArtifactReference::from)
+                .collect(),
+        ))
+    }
+}
+
+impl TryFrom<ProtocolGeneratedArtifact> for GeneratedArtifact {
+    type Error = ProtocolError;
+
+    fn try_from(value: ProtocolGeneratedArtifact) -> Result<Self, Self::Error> {
+        match value {
+            ProtocolGeneratedArtifact::Playlist(playlist) => {
+                Ok(GeneratedArtifact::Playlist(playlist.try_into()?))
+            }
+        }
+    }
+}
+
+impl TryFrom<ProtocolArtifactKind> for PlannedArtifactKind {
+    type Error = ProtocolError;
+
+    fn try_from(value: ProtocolArtifactKind) -> Result<Self, Self::Error> {
+        match value {
+            ProtocolArtifactKind::SourceBacked(source_artifact) => {
+                Ok(Self::SourceBacked(source_artifact.try_into()?))
+            }
+            ProtocolArtifactKind::Generated(generated_artifact) => {
+                Ok(Self::Generated(generated_artifact.try_into()?))
+            }
+        }
+    }
+}
+
+impl TryFrom<ProtocolMaterializationContext> for MaterializationContext {
+    type Error = ProtocolError;
+
+    fn try_from(value: ProtocolMaterializationContext) -> Result<Self, Self::Error> {
+        let mut artifact_names = HashMap::new();
+
+        for entry in value.artifact_names {
+            if entry.artifact_id.trim().is_empty() {
+                return Err(ProtocolError::InvalidRequest {
+                    message: "artifact context entry artifact_id must not be empty".to_string(),
+                });
+            }
+
+            if entry.logical_name.trim().is_empty() {
+                return Err(ProtocolError::InvalidRequest {
+                    message: "artifact context entry logical_name must not be empty".to_string(),
+                });
+            }
+
+            artifact_names.insert(ArtifactId::new(entry.artifact_id), entry.logical_name);
+        }
+
+        Ok(MaterializationContext { artifact_names })
+    }
+}
+
+pub fn to_artifact_request(
+    request: MaterializationRequest,
+) -> Result<(String, ArtifactRequest, String, MaterializationContext), ProtocolError> {
+    let logical_name = request.logical_name;
+
+    let artifact = ArtifactRequest::new(
+        ArtifactId::new(request.artifact_id),
+        request.artifact_kind.try_into()?,
+        request.requirements.try_into()?,
+    );
+
+    let selected_capability_id = request.selected_capability_id;
+    let context = request.context.try_into()?;
+
+    Ok((logical_name, artifact, selected_capability_id, context))
+}
+
+pub fn to_protocol_response(artifact: MaterializedArtifact) -> MaterializationResponse {
+    match artifact {
+        MaterializedArtifact::SourceBacked { source, size } => {
+            MaterializationResponse::SourceBacked(ProtocolMaterializedSourceFile {
+                source: source.0.as_ref().to_string(),
+                size,
+            })
+        }
+        MaterializedArtifact::Inline(bytes) => {
+            MaterializationResponse::Inline(ProtocolInlineFile { bytes })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_encoder_capability_to_protocol_capability() {
+        let capability = EncoderCapability::new("builtin.chd", "disc.chd", ContentType::Disc)
+            .supports_format(Format::Chd)
+            .with_feature(CapabilityFeature::Lossless)
+            .with_priority(100);
+
+        let protocol = ProtocolEncoderCapability::from(capability);
+
+        assert_eq!(protocol.capability_id, "disc.chd");
+        assert_eq!(protocol.content_type, ProtocolContentType::Disc);
+        assert!(protocol.formats.contains(&ProtocolFormat::Chd));
+        assert!(protocol
+            .features
+            .contains(&ProtocolCapabilityFeature::Lossless));
+        assert_eq!(protocol.priority, 100);
+    }
+
+    #[test]
+    fn converts_artifact_request_to_materialization_request() {
+        let artifact = ArtifactRequest::new(
+            ArtifactId::new("playlist-1"),
+            PlannedArtifactKind::Generated(GeneratedArtifact::Playlist(PlaylistArtifact::new(
+                vec![
+                    ArtifactReference::new(ArtifactId::new("disc-1")),
+                    ArtifactReference::new(ArtifactId::new("disc-2")),
+                ],
+            ))),
+            CapabilityRequirements::new(ContentType::Playlist).with_format(Format::M3u),
+        );
+
+        let mut artifact_names = HashMap::new();
+        artifact_names.insert(ArtifactId::new("disc-1"), "Game (Disc 1).cue".to_string());
+        artifact_names.insert(ArtifactId::new("disc-2"), "Game (Disc 2).cue".to_string());
+
+        let context = MaterializationContext { artifact_names };
+
+        let request = to_materialization_request("Game.m3u", &artifact, "playlist.m3u", &context);
+
+        assert_eq!(request.artifact_id, "playlist-1");
+        assert_eq!(request.logical_name, "Game.m3u");
+        assert_eq!(request.selected_capability_id, "playlist.m3u");
+        assert_eq!(
+            request.requirements,
+            ProtocolCapabilityRequirements::new(ProtocolContentType::Playlist)
+                .with_format(ProtocolFormat::M3u)
+        );
+
+        match request.artifact_kind {
+            ProtocolArtifactKind::Generated(ProtocolGeneratedArtifact::Playlist(playlist)) => {
+                assert_eq!(playlist.entries.len(), 2);
+                assert_eq!(playlist.entries[0].artifact_id, "disc-1");
+                assert_eq!(playlist.entries[1].artifact_id, "disc-2");
+            }
+            other => panic!("expected generated playlist artifact, got {other:?}"),
+        }
+
+        assert_eq!(
+            request.context.artifact_name_for("disc-1"),
+            Some("Game (Disc 1).cue")
+        );
+        assert_eq!(
+            request.context.artifact_name_for("disc-2"),
+            Some("Game (Disc 2).cue")
+        );
+    }
+
+    #[test]
+    fn converts_materialization_response_to_materialized_artifact() {
+        let response = MaterializationResponse::Inline(ProtocolInlineFile {
+            bytes: b"hello".to_vec(),
+        });
+
+        let artifact = from_materialization_response(response).unwrap();
+
+        assert_eq!(artifact, MaterializedArtifact::Inline(b"hello".to_vec()));
+    }
+
+    #[test]
+    fn round_trips_request_through_protocol_conversion() {
+        let artifact = ArtifactRequest::new(
+            ArtifactId::new("game-1"),
+            PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                SourceRef::new("file:/roms/game.iso"),
+                4096,
+            )),
+            CapabilityRequirements::new(ContentType::Disc)
+                .with_format(Format::Iso)
+                .require_feature(CapabilityFeature::Lossless),
+        );
+
+        let mut artifact_names = HashMap::new();
+        artifact_names.insert(ArtifactId::new("game-1"), "Game.iso".to_string());
+
+        let context = MaterializationContext { artifact_names };
+
+        let protocol_request =
+            to_materialization_request("Game.iso", &artifact, "disc.iso", &context);
+
+        let (logical_name, decoded_artifact, selected_capability_id, decoded_context) =
+            to_artifact_request(protocol_request).unwrap();
+
+        assert_eq!(logical_name, "Game.iso");
+        assert_eq!(decoded_artifact, artifact);
+        assert_eq!(selected_capability_id, "disc.iso");
+        assert_eq!(decoded_context.artifact_names, context.artifact_names);
+    }
+
+    #[test]
+    fn rejects_empty_protocol_source_when_decoding_request() {
+        let request = MaterializationRequest {
+            artifact_id: "artifact-1".to_string(),
+            logical_name: "Game.iso".to_string(),
+            selected_capability_id: "disc.iso".to_string(),
+            artifact_kind: ProtocolArtifactKind::SourceBacked(ProtocolSourceArtifact::multiple(
+                vec![ProtocolSourceArtifactInput {
+                    source: String::new(),
+                    size: 123,
+                }],
+            )),
+            requirements: ProtocolCapabilityRequirements::new(ProtocolContentType::Disc)
+                .with_format(ProtocolFormat::Iso),
+            context: ProtocolMaterializationContext::default(),
+        };
+
+        match to_artifact_request(request) {
+            Ok(_) => panic!("expected invalid request error"),
+            Err(error) => {
+                assert_eq!(
+                    error,
+                    ProtocolError::InvalidRequest {
+                        message: "source artifact input source must not be empty".to_string(),
+                    }
+                );
+            }
+        }
+    }
+}

--- a/src/output/plugin_registry.rs
+++ b/src/output/plugin_registry.rs
@@ -1,0 +1,156 @@
+use std::sync::Arc;
+
+use crate::output::encode::OutputEncoder;
+use crate::output::plugin_client::EncoderPluginClient;
+use crate::output::plugin_encoder::PluginBackedEncoder;
+use crate::output::plugin_protocol::ProtocolError;
+
+#[derive(Default)]
+pub struct PluginRegistry {
+    clients: Vec<Arc<dyn EncoderPluginClient>>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, client: Arc<dyn EncoderPluginClient>) -> Result<(), ProtocolError> {
+        PluginBackedEncoder::from_client(client.clone())?;
+        self.clients.push(client);
+        Ok(())
+    }
+
+    pub fn build_encoders(&self) -> Result<Vec<Box<dyn OutputEncoder>>, ProtocolError> {
+        let mut encoders: Vec<Box<dyn OutputEncoder>> = Vec::with_capacity(self.clients.len());
+
+        for client in &self.clients {
+            let encoder = PluginBackedEncoder::from_client(client.clone())?;
+            encoders.push(Box::new(encoder));
+        }
+
+        Ok(encoders)
+    }
+
+    pub fn len(&self) -> usize {
+        self.clients.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.clients.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::output::plugin_client::EncoderPluginClient;
+    use crate::output::plugin_protocol::{
+        MaterializationRequest, MaterializationResponse, PluginManifest, ProtocolContentType,
+        ProtocolEncoderCapability, ProtocolFormat, ProtocolMaterializedSourceFile,
+        ENCODER_PLUGIN_PROTOCOL_V1,
+    };
+
+    #[derive(Clone)]
+    struct TestClient {
+        manifest: PluginManifest,
+    }
+
+    impl EncoderPluginClient for TestClient {
+        fn manifest(&self) -> Result<PluginManifest, ProtocolError> {
+            Ok(self.manifest.clone())
+        }
+
+        fn materialize(
+            &self,
+            _request: &MaterializationRequest,
+        ) -> Result<MaterializationResponse, ProtocolError> {
+            Ok(MaterializationResponse::SourceBacked(
+                ProtocolMaterializedSourceFile {
+                    source: "file:/roms/game.iso".to_string(),
+                    size: 1234,
+                },
+            ))
+        }
+    }
+
+    fn manifest() -> PluginManifest {
+        PluginManifest {
+            plugin_id: "plugin.test".to_string(),
+            plugin_version: "0.1.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: None,
+            description: None,
+            capabilities: vec![ProtocolEncoderCapability::new(
+                "disc.iso",
+                ProtocolContentType::Disc,
+            )
+            .supports_format(ProtocolFormat::Iso)],
+        }
+    }
+
+    #[test]
+    fn registers_valid_plugin_client() {
+        let mut registry = PluginRegistry::new();
+
+        let client: Arc<dyn EncoderPluginClient> = Arc::new(TestClient {
+            manifest: manifest(),
+        });
+
+        registry.register(client).unwrap();
+
+        assert_eq!(registry.len(), 1);
+        assert!(!registry.is_empty());
+    }
+
+    #[test]
+    fn builds_encoders_from_registered_clients() {
+        let mut registry = PluginRegistry::new();
+
+        let client: Arc<dyn EncoderPluginClient> = Arc::new(TestClient {
+            manifest: manifest(),
+        });
+
+        registry.register(client).unwrap();
+
+        let encoders = registry.build_encoders().unwrap();
+
+        assert_eq!(encoders.len(), 1);
+        assert_eq!(encoders[0].plugin_id(), "plugin.test");
+        assert_eq!(encoders[0].capabilities().len(), 1);
+    }
+
+    #[test]
+    fn rejects_invalid_plugin_manifest_during_registration() {
+        let mut registry = PluginRegistry::new();
+
+        let invalid_manifest = PluginManifest {
+            plugin_id: String::new(),
+            plugin_version: "0.1.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: None,
+            description: None,
+            capabilities: vec![ProtocolEncoderCapability::new(
+                "disc.iso",
+                ProtocolContentType::Disc,
+            )
+            .supports_format(ProtocolFormat::Iso)],
+        };
+
+        let client: Arc<dyn EncoderPluginClient> = Arc::new(TestClient {
+            manifest: invalid_manifest,
+        });
+
+        let error = registry.register(client).unwrap_err();
+
+        assert_eq!(
+            error,
+            ProtocolError::InvalidManifest {
+                message: "plugin_id must not be empty".to_string(),
+            }
+        );
+        assert!(registry.is_empty());
+    }
+}


### PR DESCRIPTION
# Phase 5C — Plugin Protocol & Host Integration

This PR introduces the foundational plugin system architecture for Retromount.

### Key additions

* **Plugin protocol**

  * Typed request/response model (`plugin_protocol.rs`)
  * Validation for manifests and materialization requests
  * JSON round-trip compatibility

* **Protocol conversion layer**

  * Mapping between internal model and protocol types
  * Ensures strict boundary separation

* **Plugin client abstraction**

  * `EncoderPluginClient` trait defining host ↔ plugin interaction
  * Fully testable without runtime transport

* **Plugin-backed encoder**

  * `PluginBackedEncoder` implements `OutputEncoder`
  * Allows plugins to participate in capability resolution and materialization

* **Plugin registry**

  * In-memory registry of plugin clients
  * Builds encoders from plugin manifests
  * Early validation of plugin correctness

* **Materialization integration**

  * New entrypoint: `materialize_plan_with_plugins`
  * Merges builtin and plugin encoders seamlessly

### Architectural impact

This establishes a clean separation:

```
WHAT (PresentationPlan)
    ↓
CapabilityResolver
    ↓
HOW (OutputEncoder)
    ↓
Materialization
```

Plugins now integrate at the `OutputEncoder` layer and are indistinguishable from built-in encoders.

### Not included (Phase 5D)

* Runtime plugin loading
* Process or IPC transport
* Plugin discovery

These will be introduced in Phase 5D.

### Result

Retromount now has a complete, transport-agnostic plugin architecture ready for runtime implementation.
