### PR TITLE
feat(plugin): complete Phase 5D runtime plugin execution and discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -382,12 +382,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -815,9 +815,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -987,18 +987,18 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -1193,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -1290,18 +1290,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -12,6 +12,8 @@ pub mod plugin_encoder;
 pub mod plugin_protocol;
 pub mod plugin_protocol_conversion;
 pub mod plugin_registry;
+pub mod plugin_runtime;
+pub mod plugin_runtime_error;
 pub mod present;
 pub mod presentation_expansion;
 pub mod presenter_registry;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -8,6 +8,7 @@ pub mod materialize;
 pub mod name_allocator;
 pub mod plan;
 pub mod plugin_client;
+pub mod plugin_discovery;
 pub mod plugin_encoder;
 pub mod plugin_protocol;
 pub mod plugin_protocol_conversion;

--- a/src/output/plugin_discovery.rs
+++ b/src/output/plugin_discovery.rs
@@ -174,16 +174,18 @@ mod tests {
             &format!(
                 r#"#!/bin/sh
 cat >/dev/null
-printf '%s' '{}'
+cat <<'EOF'
+{}
+EOF
 "#,
-                manifest_json.replace('\'', "'\\''")
+                manifest_json
             ),
         );
 
         let report = discover_encoder_plugins(dir.path());
 
-        assert_eq!(report.discovered.len(), 1);
-        assert_eq!(report.rejected.len(), 0);
+        assert_eq!(report.discovered.len(), 1, "report: {report:?}");
+        assert_eq!(report.rejected.len(), 0, "report: {report:?}");
         assert_eq!(report.discovered[0].manifest.plugin_id, "plugin.discovery");
     }
 
@@ -237,9 +239,11 @@ printf '%s' 'not-json'
             &format!(
                 r#"#!/bin/sh
 cat >/dev/null
-printf '%s' '{}'
+cat <<'EOF'
+{}
+EOF
 "#,
-                manifest_json.replace('\'', "'\\''")
+                manifest_json
             ),
         );
 
@@ -282,25 +286,28 @@ printf '%s' '{}'
 
         let script = format!(
             r#"#!/bin/sh
-    request="$(cat)"
-    case "$request" in
-    *'"type":"get_manifest"'*)
-        printf '%s' '{}'
-        ;;
-    *)
-        printf '%s' '{}'
-        ;;
-    esac
-    "#,
-            manifest_json.replace('\'', "'\\''"),
-            materialize_json.replace('\'', "'\\''")
+request="$(cat)"
+case "$request" in
+  *'"type":"get_manifest"'*)
+    cat <<'EOF'
+{}
+EOF
+    ;;
+  *)
+    cat <<'EOF'
+{}
+EOF
+    ;;
+esac
+"#,
+            manifest_json, materialize_json
         );
 
         write_executable_script(&dir, "plugin-ok.sh", &script);
 
         let report = discover_encoder_plugins(dir.path());
-        assert_eq!(report.discovered.len(), 1);
-        assert_eq!(report.rejected.len(), 0);
+        assert_eq!(report.discovered.len(), 1, "report: {report:?}");
+        assert_eq!(report.rejected.len(), 0, "report: {report:?}");
 
         let registry = build_registry_from_discovery(report).unwrap();
 

--- a/src/output/plugin_discovery.rs
+++ b/src/output/plugin_discovery.rs
@@ -1,0 +1,196 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::output::plugin_client::EncoderPluginClient;
+use crate::output::plugin_protocol::PluginManifest;
+use crate::output::plugin_runtime::SubprocessEncoderPluginClient;
+use crate::output::plugin_runtime_error::PluginRuntimeError;
+
+#[derive(Clone)]
+pub struct DiscoveredPlugin {
+    pub executable: PathBuf,
+    pub manifest: PluginManifest,
+    pub client: Arc<dyn EncoderPluginClient>,
+}
+
+impl std::fmt::Debug for DiscoveredPlugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscoveredPlugin")
+            .field("executable", &self.executable)
+            .field("manifest", &self.manifest)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct RejectedPlugin {
+    pub executable: PathBuf,
+    pub error: PluginRuntimeError,
+}
+
+#[derive(Debug)]
+pub struct PluginDiscoveryReport {
+    pub discovered: Vec<DiscoveredPlugin>,
+    pub rejected: Vec<RejectedPlugin>,
+}
+
+pub fn discover_encoder_plugins(dir: &Path) -> PluginDiscoveryReport {
+    let mut discovered = Vec::new();
+    let mut rejected = Vec::new();
+
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            rejected.push(RejectedPlugin {
+                executable: dir.to_path_buf(),
+                error: PluginRuntimeError::Io {
+                    path: dir.to_path_buf(),
+                    message: error.to_string(),
+                },
+            });
+            return PluginDiscoveryReport {
+                discovered,
+                rejected,
+            };
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+
+        if !path.is_file() {
+            continue;
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let metadata = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+
+            if metadata.permissions().mode() & 0o111 == 0 {
+                continue;
+            }
+        }
+
+        let client = SubprocessEncoderPluginClient::new(&path);
+
+        match client.manifest_runtime() {
+            Ok(manifest) => {
+                discovered.push(DiscoveredPlugin {
+                    executable: path.clone(),
+                    manifest,
+                    client: Arc::new(client),
+                });
+            }
+            Err(error) => {
+                rejected.push(RejectedPlugin {
+                    executable: path.clone(),
+                    error,
+                });
+            }
+        }
+    }
+
+    PluginDiscoveryReport {
+        discovered,
+        rejected,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::plugin_protocol::{
+        PluginManifest, PluginResponse, ProtocolContentType, ProtocolEncoderCapability,
+        ProtocolFormat, ENCODER_PLUGIN_PROTOCOL_V1,
+    };
+
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    use std::fs;
+
+    fn example_manifest() -> PluginManifest {
+        PluginManifest {
+            plugin_id: "plugin.discovery".to_string(),
+            plugin_version: "1.0.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: None,
+            description: None,
+            capabilities: vec![ProtocolEncoderCapability::new(
+                "disc.iso",
+                ProtocolContentType::Disc,
+            )
+            .supports_format(ProtocolFormat::Iso)],
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_exec(dir: &TempDir, name: &str, body: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        fs::write(&path, body).unwrap();
+
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).unwrap();
+
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovers_valid_plugin() {
+        let dir = TempDir::new().unwrap();
+
+        let manifest_json = serde_json::to_string(&PluginResponse::Manifest {
+            manifest: example_manifest(),
+        })
+        .unwrap();
+
+        write_exec(
+            &dir,
+            "plugin-ok.sh",
+            &format!(
+                r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{}'
+"#,
+                manifest_json.replace('\'', "'\\''")
+            ),
+        );
+
+        let report = discover_encoder_plugins(dir.path());
+
+        assert_eq!(report.discovered.len(), 1);
+        assert_eq!(report.rejected.len(), 0);
+
+        assert_eq!(report.discovered[0].manifest.plugin_id, "plugin.discovery");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_invalid_plugin() {
+        let dir = TempDir::new().unwrap();
+
+        write_exec(
+            &dir,
+            "plugin-bad.sh",
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s' 'not-json'
+"#,
+        );
+
+        let report = discover_encoder_plugins(dir.path());
+
+        assert_eq!(report.discovered.len(), 0);
+        assert_eq!(report.rejected.len(), 1);
+    }
+}

--- a/src/output/plugin_discovery.rs
+++ b/src/output/plugin_discovery.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::output::plugin_client::EncoderPluginClient;
-use crate::output::plugin_protocol::PluginManifest;
+use crate::output::plugin_protocol::{PluginManifest, ProtocolError};
+use crate::output::plugin_registry::PluginRegistry;
 use crate::output::plugin_runtime::SubprocessEncoderPluginClient;
 use crate::output::plugin_runtime_error::PluginRuntimeError;
 
@@ -49,6 +50,7 @@ pub fn discover_encoder_plugins(dir: &Path) -> PluginDiscoveryReport {
                     message: error.to_string(),
                 },
             });
+
             return PluginDiscoveryReport {
                 discovered,
                 rejected,
@@ -68,7 +70,7 @@ pub fn discover_encoder_plugins(dir: &Path) -> PluginDiscoveryReport {
             use std::os::unix::fs::PermissionsExt;
 
             let metadata = match entry.metadata() {
-                Ok(m) => m,
+                Ok(metadata) => metadata,
                 Err(_) => continue,
             };
 
@@ -102,28 +104,40 @@ pub fn discover_encoder_plugins(dir: &Path) -> PluginDiscoveryReport {
     }
 }
 
+pub fn build_registry_from_discovery(
+    report: PluginDiscoveryReport,
+) -> Result<PluginRegistry, ProtocolError> {
+    let mut registry = PluginRegistry::new();
+
+    for plugin in report.discovered {
+        registry.register(plugin.client)?;
+    }
+
+    Ok(registry)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::output::plugin_protocol::{
-        PluginManifest, PluginResponse, ProtocolContentType, ProtocolEncoderCapability,
-        ProtocolFormat, ENCODER_PLUGIN_PROTOCOL_V1,
-    };
+    use std::fs;
 
     use tempfile::TempDir;
 
+    use super::*;
+    use crate::output::plugin_protocol::{
+        PluginResponse, ProtocolContentType, ProtocolEncoderCapability, ProtocolFormat,
+        ENCODER_PLUGIN_PROTOCOL_V1,
+    };
+
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-
-    use std::fs;
 
     fn example_manifest() -> PluginManifest {
         PluginManifest {
             plugin_id: "plugin.discovery".to_string(),
             plugin_version: "1.0.0".to_string(),
             protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
-            display_name: None,
-            description: None,
+            display_name: Some("Discovery Plugin".to_string()),
+            description: Some("Fixture plugin for discovery tests".to_string()),
             capabilities: vec![ProtocolEncoderCapability::new(
                 "disc.iso",
                 ProtocolContentType::Disc,
@@ -133,13 +147,13 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn write_exec(dir: &TempDir, name: &str, body: &str) -> PathBuf {
+    fn write_executable_script(dir: &TempDir, name: &str, body: &str) -> PathBuf {
         let path = dir.path().join(name);
         fs::write(&path, body).unwrap();
 
-        let mut perms = fs::metadata(&path).unwrap().permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&path, perms).unwrap();
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).unwrap();
 
         path
     }
@@ -154,7 +168,7 @@ mod tests {
         })
         .unwrap();
 
-        write_exec(
+        write_executable_script(
             &dir,
             "plugin-ok.sh",
             &format!(
@@ -170,7 +184,6 @@ printf '%s' '{}'
 
         assert_eq!(report.discovered.len(), 1);
         assert_eq!(report.rejected.len(), 0);
-
         assert_eq!(report.discovered[0].manifest.plugin_id, "plugin.discovery");
     }
 
@@ -179,7 +192,7 @@ printf '%s' '{}'
     fn rejects_invalid_plugin() {
         let dir = TempDir::new().unwrap();
 
-        write_exec(
+        write_executable_script(
             &dir,
             "plugin-bad.sh",
             r#"#!/bin/sh
@@ -192,5 +205,132 @@ printf '%s' 'not-json'
 
         assert_eq!(report.discovered.len(), 0);
         assert_eq!(report.rejected.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skips_non_executable_files() {
+        let dir = TempDir::new().unwrap();
+
+        let path = dir.path().join("not-executable.sh");
+        fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+
+        let report = discover_encoder_plugins(dir.path());
+
+        assert_eq!(report.discovered.len(), 0);
+        assert_eq!(report.rejected.len(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn builds_registry_from_discovered_plugins() {
+        let dir = TempDir::new().unwrap();
+
+        let manifest_json = serde_json::to_string(&PluginResponse::Manifest {
+            manifest: example_manifest(),
+        })
+        .unwrap();
+
+        write_executable_script(
+            &dir,
+            "plugin-ok.sh",
+            &format!(
+                r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{}'
+"#,
+                manifest_json.replace('\'', "'\\''")
+            ),
+        );
+
+        let report = discover_encoder_plugins(dir.path());
+        let registry = build_registry_from_discovery(report).unwrap();
+        let encoders = registry.build_encoders().unwrap();
+
+        assert_eq!(encoders.len(), 1);
+        assert_eq!(encoders[0].plugin_id(), "plugin.discovery");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovered_plugin_can_materialize_plan() {
+        use crate::core::source::SourceRef;
+        use crate::core::vfs::VfsNode;
+        use crate::output::capabilities::{CapabilityRequirements, ContentType, Format};
+        use crate::output::materialize::materialize_plan_with_plugins;
+        use crate::output::plan::{
+            ArtifactId, ArtifactRequest, PlanEntry, PlanFile, PlannedArtifactKind,
+            PresentationPlan, SourceArtifact,
+        };
+        use crate::output::plugin_protocol::{
+            MaterializationResponse, PluginResponse, ProtocolInlineFile,
+        };
+
+        let dir = TempDir::new().unwrap();
+
+        let manifest_json = serde_json::to_string(&PluginResponse::Manifest {
+            manifest: example_manifest(),
+        })
+        .unwrap();
+
+        let materialize_json = serde_json::to_string(&PluginResponse::Materialized {
+            response: MaterializationResponse::Inline(ProtocolInlineFile {
+                bytes: b"plugin-output".to_vec(),
+            }),
+        })
+        .unwrap();
+
+        let script = format!(
+            r#"#!/bin/sh
+    request="$(cat)"
+    case "$request" in
+    *'"type":"get_manifest"'*)
+        printf '%s' '{}'
+        ;;
+    *)
+        printf '%s' '{}'
+        ;;
+    esac
+    "#,
+            manifest_json.replace('\'', "'\\''"),
+            materialize_json.replace('\'', "'\\''")
+        );
+
+        write_executable_script(&dir, "plugin-ok.sh", &script);
+
+        let report = discover_encoder_plugins(dir.path());
+        assert_eq!(report.discovered.len(), 1);
+        assert_eq!(report.rejected.len(), 0);
+
+        let registry = build_registry_from_discovery(report).unwrap();
+
+        let plan = PresentationPlan::new(vec![PlanEntry::File(PlanFile::new(
+            "Game.iso",
+            ArtifactRequest::new(
+                ArtifactId::new("game"),
+                PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                    SourceRef::new("file:/roms/game.iso"),
+                    4096,
+                )),
+                CapabilityRequirements::new(ContentType::Disc).with_format(Format::Iso),
+            ),
+        ))]);
+
+        let root = materialize_plan_with_plugins(&plan, &registry).unwrap();
+
+        assert_eq!(root.children().len(), 1);
+
+        let file = match &root.children()[0] {
+            VfsNode::File(file) => file,
+            other => panic!("expected file, got {other:?}"),
+        };
+
+        match &file.backing {
+            crate::core::vfs::FileBacking::Inline(contents) => {
+                assert_eq!(contents, b"plugin-output");
+                assert_eq!(file.size, b"plugin-output".len() as u64);
+            }
+            other => panic!("expected inline plugin output, got {other:?}"),
+        }
     }
 }

--- a/src/output/plugin_protocol.rs
+++ b/src/output/plugin_protocol.rs
@@ -248,6 +248,29 @@ pub struct ProtocolArtifactName {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PluginRequest {
+    GetManifest,
+    Materialize {
+        request: Box<MaterializationRequest>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PluginResponse {
+    Manifest { manifest: PluginManifest },
+    Materialized { response: MaterializationResponse },
+    Error { error: ProtocolPluginError },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolPluginError {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MaterializationResponse {
     SourceBacked(ProtocolMaterializedSourceFile),
     Inline(ProtocolInlineFile),

--- a/src/output/plugin_runtime.rs
+++ b/src/output/plugin_runtime.rs
@@ -1,0 +1,300 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::output::plugin_client::EncoderPluginClient;
+use crate::output::plugin_protocol::{
+    validate_manifest, MaterializationRequest, MaterializationResponse, PluginManifest,
+    PluginRequest, PluginResponse, ProtocolError,
+};
+use crate::output::plugin_runtime_error::PluginRuntimeError;
+
+#[derive(Debug, Clone)]
+pub struct SubprocessEncoderPluginClient {
+    executable: PathBuf,
+}
+
+impl SubprocessEncoderPluginClient {
+    pub fn new(executable: impl Into<PathBuf>) -> Self {
+        Self {
+            executable: executable.into(),
+        }
+    }
+
+    pub fn executable(&self) -> &Path {
+        &self.executable
+    }
+
+    fn invoke(&self, request: &PluginRequest) -> Result<PluginResponse, PluginRuntimeError> {
+        if !self.executable.exists() {
+            return Err(PluginRuntimeError::ExecutableNotFound {
+                path: self.executable.clone(),
+            });
+        }
+
+        let mut child = Command::new(&self.executable)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| PluginRuntimeError::SpawnFailed {
+                path: self.executable.clone(),
+                message: error.to_string(),
+            })?;
+
+        {
+            let stdin = child.stdin.as_mut().ok_or_else(|| PluginRuntimeError::Io {
+                path: self.executable.clone(),
+                message: "failed to open stdin for plugin process".to_string(),
+            })?;
+
+            serde_json::to_writer(&mut *stdin, request).map_err(|error| {
+                PluginRuntimeError::Io {
+                    path: self.executable.clone(),
+                    message: format!("failed to serialize request: {error}"),
+                }
+            })?;
+
+            stdin.flush().map_err(|error| PluginRuntimeError::Io {
+                path: self.executable.clone(),
+                message: format!("failed to flush request to plugin stdin: {error}"),
+            })?;
+        }
+
+        let output = child
+            .wait_with_output()
+            .map_err(|error| PluginRuntimeError::Io {
+                path: self.executable.clone(),
+                message: format!("failed waiting for plugin process: {error}"),
+            })?;
+
+        if !output.status.success() {
+            return Err(PluginRuntimeError::NonZeroExit {
+                path: self.executable.clone(),
+                status: output.status.code().unwrap_or(-1),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+
+        let response: PluginResponse = serde_json::from_slice(&output.stdout).map_err(|error| {
+            PluginRuntimeError::InvalidJson {
+                path: self.executable.clone(),
+                message: error.to_string(),
+            }
+        })?;
+
+        Ok(response)
+    }
+
+    pub fn manifest_runtime(&self) -> Result<PluginManifest, PluginRuntimeError> {
+        match self.invoke(&PluginRequest::GetManifest)? {
+            PluginResponse::Manifest { manifest } => {
+                validate_manifest(&manifest)?;
+                Ok(manifest)
+            }
+            PluginResponse::Error { error } => Err(PluginRuntimeError::Protocol {
+                error: ProtocolError::InternalPluginError {
+                    message: format!("plugin error [{}]: {}", error.code, error.message),
+                },
+            }),
+            other => Err(PluginRuntimeError::UnexpectedResponse {
+                path: self.executable.clone(),
+                message: format!("expected manifest response, got {other:?}"),
+            }),
+        }
+    }
+
+    pub fn materialize_runtime(
+        &self,
+        request: &MaterializationRequest,
+    ) -> Result<MaterializationResponse, PluginRuntimeError> {
+        match self.invoke(&PluginRequest::Materialize {
+            request: Box::new(request.clone()),
+        })? {
+            PluginResponse::Materialized { response } => Ok(response),
+            PluginResponse::Error { error } => Err(PluginRuntimeError::Protocol {
+                error: ProtocolError::MaterializationFailed {
+                    message: format!("plugin error [{}]: {}", error.code, error.message),
+                },
+            }),
+            other => Err(PluginRuntimeError::UnexpectedResponse {
+                path: self.executable.clone(),
+                message: format!("expected materialized response, got {other:?}"),
+            }),
+        }
+    }
+}
+
+impl EncoderPluginClient for SubprocessEncoderPluginClient {
+    fn manifest(&self) -> Result<PluginManifest, ProtocolError> {
+        self.manifest_runtime()
+            .map_err(|error| error.to_protocol_error())
+    }
+
+    fn materialize(
+        &self,
+        request: &MaterializationRequest,
+    ) -> Result<MaterializationResponse, ProtocolError> {
+        self.materialize_runtime(request)
+            .map_err(|error| error.to_protocol_error())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::output::plugin_protocol::ProtocolInlineFile;
+
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::output::plugin_protocol::{
+        PluginManifest, ProtocolContentType, ProtocolEncoderCapability, ProtocolFormat,
+        ENCODER_PLUGIN_PROTOCOL_V1,
+    };
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn example_manifest() -> PluginManifest {
+        PluginManifest {
+            plugin_id: "plugin.subprocess".to_string(),
+            plugin_version: "0.1.0".to_string(),
+            protocol_version: ENCODER_PLUGIN_PROTOCOL_V1,
+            display_name: Some("Subprocess Plugin".to_string()),
+            description: Some("Fixture subprocess encoder plugin".to_string()),
+            capabilities: vec![ProtocolEncoderCapability::new(
+                "disc.iso",
+                ProtocolContentType::Disc,
+            )
+            .supports_format(ProtocolFormat::Iso)],
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_executable_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        fs::write(&path, body).unwrap();
+
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).unwrap();
+
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn subprocess_client_reads_valid_manifest() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let manifest_json = serde_json::to_string(&PluginResponse::Manifest {
+            manifest: example_manifest(),
+        })
+        .unwrap();
+
+        let script = format!(
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s' '{}'
+"#,
+            manifest_json.replace('\'', "'\\''")
+        );
+
+        let path = write_executable_script(&temp_dir, "plugin-manifest.sh", &script);
+        let client = SubprocessEncoderPluginClient::new(path);
+
+        let manifest = client.manifest_runtime().unwrap();
+
+        assert_eq!(manifest.plugin_id, "plugin.subprocess");
+        assert_eq!(manifest.plugin_version, "0.1.0");
+        assert_eq!(manifest.capabilities.len(), 1);
+        assert_eq!(manifest.capabilities[0].capability_id, "disc.iso");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn subprocess_client_rejects_unexpected_response_type() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let response_json = serde_json::to_string(&PluginResponse::Materialized {
+            response: MaterializationResponse::Inline(ProtocolInlineFile {
+                bytes: vec![1, 2, 3],
+            }),
+        })
+        .unwrap();
+
+        let script = format!(
+            r#"#!/bin/sh
+    cat >/dev/null
+    printf '%s' '{}'
+    "#,
+            response_json.replace('\'', "'\\''")
+        );
+
+        let path = write_executable_script(&temp_dir, "plugin-wrong-response.sh", &script);
+        let client = SubprocessEncoderPluginClient::new(path);
+
+        let error = client.manifest_runtime().unwrap_err();
+
+        match error {
+            PluginRuntimeError::UnexpectedResponse { .. } => {}
+            other => panic!("expected UnexpectedResponse, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn subprocess_client_surfaces_non_zero_exit() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let script = r#"#!/bin/sh
+echo "boom" >&2
+exit 12
+"#;
+
+        let path = write_executable_script(&temp_dir, "plugin-fails.sh", script);
+        let client = SubprocessEncoderPluginClient::new(path);
+
+        let error = client.manifest_runtime().unwrap_err();
+
+        match error {
+            PluginRuntimeError::NonZeroExit { status, stderr, .. } => {
+                assert_eq!(status, 12);
+                assert_eq!(stderr, "boom");
+            }
+            other => panic!("expected NonZeroExit, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn subprocess_client_surfaces_invalid_json() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let script = r#"#!/bin/sh
+cat >/dev/null
+printf '%s' 'not-json'
+"#;
+
+        let path = write_executable_script(&temp_dir, "plugin-invalid-json.sh", script);
+        let client = SubprocessEncoderPluginClient::new(path);
+
+        let error = client.manifest_runtime().unwrap_err();
+
+        match error {
+            PluginRuntimeError::InvalidJson { .. } => {}
+            other => panic!("expected InvalidJson, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn executable_path_is_exposed() {
+        let path = Path::new("/tmp/example-plugin");
+        let client = SubprocessEncoderPluginClient::new(path);
+
+        assert_eq!(client.executable(), path);
+    }
+}

--- a/src/output/plugin_runtime.rs
+++ b/src/output/plugin_runtime.rs
@@ -251,6 +251,7 @@ printf '%s' '{}'
         let temp_dir = TempDir::new().unwrap();
 
         let script = r#"#!/bin/sh
+cat >/dev/null
 echo "boom" >&2
 exit 12
 "#;

--- a/src/output/plugin_runtime_error.rs
+++ b/src/output/plugin_runtime_error.rs
@@ -1,0 +1,50 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use crate::output::plugin_protocol::ProtocolError;
+
+#[derive(Debug, Error)]
+pub enum PluginRuntimeError {
+    #[error("plugin executable not found: {path}")]
+    ExecutableNotFound { path: PathBuf },
+
+    #[error("failed to spawn plugin executable '{path}': {message}")]
+    SpawnFailed { path: PathBuf, message: String },
+
+    #[error("failed to communicate with plugin executable '{path}': {message}")]
+    Io { path: PathBuf, message: String },
+
+    #[error("plugin executable '{path}' exited with non-zero status {status}: {stderr}")]
+    NonZeroExit {
+        path: PathBuf,
+        status: i32,
+        stderr: String,
+    },
+
+    #[error("plugin executable '{path}' produced invalid JSON: {message}")]
+    InvalidJson { path: PathBuf, message: String },
+
+    #[error("plugin executable '{path}' returned an unexpected response: {message}")]
+    UnexpectedResponse { path: PathBuf, message: String },
+
+    #[error("plugin protocol error")]
+    Protocol { error: ProtocolError },
+}
+
+impl From<ProtocolError> for PluginRuntimeError {
+    fn from(error: ProtocolError) -> Self {
+        Self::Protocol { error }
+    }
+}
+
+impl PluginRuntimeError {
+    pub fn to_protocol_error(&self) -> ProtocolError {
+        match self {
+            Self::Protocol { error } => error.clone(),
+            other => ProtocolError::InternalPluginError {
+                message: other.to_string(),
+            },
+        }
+    }
+}


### PR DESCRIPTION
# Complete Phase 5D runtime plugin execution and discovery

---

## Summary

This PR completes **Phase 5D — Plugin Runtime**, introducing a full end-to-end implementation of runtime-loaded encoder plugins.

It enables Retromount to discover, validate, and execute external plugins at runtime, integrating them into the existing capability resolution and materialization pipeline.

This represents the first fully working vertical slice of **runtime extensibility** in the system.

---

## What’s included

### 🔌 Subprocess plugin runtime

* Executes plugins as external processes via stdin/stdout JSON protocol
* Implements request/response handling for:

  * manifest retrieval
  * artifact materialization
* Robust process lifecycle handling (spawn, write, wait, parse)

### ⚠️ Runtime error model

* Introduces `PluginRuntimeError` for:

  * executable not found
  * spawn failures
  * I/O errors (stdin/stdout)
  * invalid JSON responses
  * non-zero exit handling
  * protocol-level errors
* Clean mapping to `ProtocolError` for upstream compatibility

### 🔍 Plugin discovery

* Filesystem-based discovery of executable plugins
* Validation via manifest loading
* Differentiates:

  * discovered (valid plugins)
  * rejected (invalid/malformed plugins)
* Provides structured `PluginDiscoveryReport` with diagnostics

### 🔗 Registry integration

* Adds bridge from discovery → `PluginRegistry`
* Discovered plugins are registered as `EncoderPluginClient`s
* Enables dynamic inclusion of external encoders in resolution

### 🔄 End-to-end integration

* Discovered plugins participate in:

  * capability resolution
  * artifact materialization
* Proven via integration test:

  * external executable → discovered → selected → produces VFS output

### 🧪 Test coverage

* Subprocess runtime:

  * valid manifest
  * invalid JSON
  * unexpected response types
  * non-zero exit handling
* Discovery:

  * valid plugin detection
  * rejection of invalid plugins
  * executable filtering
* Integration:

  * discovery → registry → materialization pipeline

---

## Architectural impact

This PR completes the runtime portion of the Phase 5 architecture:

```
PresentationPlan → CapabilityResolver → Plugin (external) → Materialization → VFS
```

Key properties now achieved:

* Runtime extensibility without recompilation
* Strict protocol boundary between core and plugins
* Deterministic capability selection remains intact
* Core pipeline remains presentation-agnostic

---

## Notes

* Plugins are currently implemented as subprocesses (by design, per ADR-006 direction)
* Test fixtures use shell scripts; Phase 5E will introduce a real plugin binary
* No CLI integration yet — this PR focuses purely on runtime capability

---

## Follow-ups (Phase 5E)

* Introduce a reference plugin crate (Rust)
* Replace test fixtures with real plugin binaries
* Validate real-world encoding scenarios
* Improve plugin developer ergonomics and documentation

---

## Checklist

* [x] `cargo fmt`
* [x] `cargo check`
* [x] `cargo test` (all passing)
* [x] `cargo clippy --all-targets --all-features -D warnings`
