### PR TITLE
docs(phase5f): align documentation with runtime plugin integration

### DIFF
--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -1,6 +1,6 @@
 # Architecture Boundaries
 
-This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation, D-002 through D-005, Phase 4A FUSE implementation, and Phase 4C policy introduction.
+This document describes the intended architectural boundaries of Retromount following Phase 3 consolidation, D-002 through D-005, Phase 4A FUSE implementation, Phase 4C policy introduction, and Phase 5 runtime plugin integration.
 
 ---
 
@@ -152,10 +152,18 @@ Responsible for:
 * generating file contents (e.g. playlists)
 * applying representation-specific transformations
 
+Encoders may be:
+
+* built-in implementations (e.g. `BasicEncoder`)
+* runtime plugin-provided implementations (Phase 5)
+
+Encoder selection is performed via **capability resolution**, based on the requirements expressed by the presentation layer.
+
 Key components:
 
 * `OutputEncoder`
 * `BasicEncoder`
+* Plugin-backed encoders (via plugin registry)
 * `VfsFile`
 
 This stage answers:
@@ -231,8 +239,8 @@ Conflict resolution is applied when inserting entries into a namespace, not by t
 ### Presenter → Encoder
 
 * Presenter defines structure and grouping
-* Encoder defines representation of each item
 * Expansion determines the set of output artifacts
+* Encoder selection is resolved via capability matching (built-in or plugin)
 * Policy determines naming and conflict behaviour
 
 Responsibilities remain strictly separated:
@@ -264,7 +272,7 @@ Responsibilities remain strictly separated:
   Naming, formatting, and conflict handling must not leak into core model or VFS primitives
 
 * **Extensibility**
-  Each stage should be replaceable or extensible without affecting others
+  Each stage should be replaceable or extensible without affecting others, including runtime extension via plugins
 
 ---
 

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -1,0 +1,341 @@
+# Plugins
+
+## Overview
+
+Retromount supports runtime-extensible output encoding through a plugin system.
+
+Plugins allow external programs to participate in the materialization phase of the pipeline, enabling new output formats and behaviors without modifying the core codebase.
+
+Plugins are executed out-of-process and communicate with Retromount via a structured JSON protocol over standard input/output.
+
+---
+
+## Goals
+
+The plugin system is designed to:
+
+* Enable extensibility without compromising core stability
+* Keep the core model and pipeline deterministic and testable
+* Allow independent development of encoders
+* Support safe execution through process isolation
+* Provide a clear contract between the host and plugins
+
+---
+
+## Non-Goals
+
+* In-process plugins or shared library loading
+* Plugin-managed presentation or structural layout
+* Stateful or long-lived plugin execution
+* Automatic plugin installation or distribution
+
+---
+
+## High-Level Architecture
+
+Plugins integrate into the **materialization stage** of the Retromount pipeline:
+
+```text
+NormalizedContent
+        ↓
+    Presenter
+        ↓
+ PresentationPlan
+        ↓
+ CapabilityResolver
+        ↓
+ SelectedCapability
+        ↓
+ Encoder (built-in or plugin)
+        ↓
+ MaterializedArtifact
+        ↓
+        VFS
+```
+
+* Presenters define *what* should be produced
+* Capability resolution selects *how* it should be produced
+* Plugins participate as **encoders** that implement specific capabilities
+
+---
+
+## Plugin Lifecycle
+
+At runtime, plugins follow a strict lifecycle:
+
+### 1. Discovery
+
+* Retromount scans the configured plugin directory
+* All executable files are considered candidates
+* Non-executable files are ignored
+
+### 2. Manifest Retrieval
+
+Each plugin is invoked with a `GetManifest` request:
+
+```json
+{ "type": "get_manifest" }
+```
+
+The plugin must respond with:
+
+```json
+{
+  "type": "manifest",
+  "manifest": { ... }
+}
+```
+
+### 3. Validation
+
+The manifest is validated to ensure:
+
+* Required fields are present
+* Capability definitions are valid
+* Protocol version matches the host
+
+Invalid plugins are rejected and excluded from the registry.
+
+### 4. Registration
+
+Valid plugins are registered as encoder providers.
+
+Each declared capability becomes available to the capability resolver.
+
+### 5. Resolution
+
+During materialization:
+
+* The capability resolver evaluates all available encoders
+* This includes both built-in encoders and plugin-provided capabilities
+* The best match is selected deterministically
+
+### 6. Materialization
+
+The selected plugin is invoked with a `Materialize` request:
+
+```json
+{
+  "type": "materialize",
+  "request": { ... }
+}
+```
+
+The plugin must respond with:
+
+```json
+{
+  "type": "materialized",
+  "response": { ... }
+}
+```
+
+---
+
+## Execution Model
+
+Plugins are executed as subprocesses:
+
+* One process per request
+* Communication via stdin/stdout
+* No shared memory with the host
+* No persistent state between invocations
+
+### Properties
+
+* Isolation: plugins cannot crash the host
+* Determinism: each invocation is independent
+* Simplicity: no lifecycle management required
+
+---
+
+## Protocol
+
+Plugins communicate using JSON messages defined in the plugin protocol.
+
+### Requests
+
+* `get_manifest`
+* `materialize`
+
+### Responses
+
+* `manifest`
+* `materialized`
+* `error`
+
+### Versioning
+
+Plugins must declare a protocol version:
+
+```json
+{
+  "protocol_version": { "major": 1, "minor": 0 }
+}
+```
+
+The host enforces strict compatibility.
+
+---
+
+## Capabilities
+
+Plugins declare one or more capabilities in their manifest.
+
+A capability defines:
+
+* `capability_id`
+* `content_type`
+* supported `formats`
+* supported `features`
+* optional `priority`
+
+Example:
+
+```json
+{
+  "capability_id": "disc.chd",
+  "content_type": "disc",
+  "formats": ["chd"],
+  "features": ["lossless"],
+  "priority": 100
+}
+```
+
+Capabilities are used by the resolver to select the best encoder for a given artifact.
+
+---
+
+## Artifact Types
+
+Plugins must support one or both of:
+
+### Source-backed artifacts
+
+* Derived from one or more input files
+* Example: converting `.bin` → `.chd`
+
+### Generated artifacts
+
+* Created from logical references
+* Example: playlist (`.m3u`)
+
+---
+
+## Error Handling
+
+Plugins may return structured errors:
+
+```json
+{
+  "type": "error",
+  "error": {
+    "code": "some_error",
+    "message": "Something went wrong"
+  }
+}
+```
+
+The host converts these into protocol errors and surfaces them in diagnostics.
+
+---
+
+## Example Plugin (Shell)
+
+A minimal plugin:
+
+```sh
+#!/bin/sh
+
+request="$(cat)"
+
+case "$request" in
+  *'"type":"get_manifest"'*)
+    cat <<'EOF'
+{
+  "type": "manifest",
+  "manifest": {
+    "plugin_id": "example.inline",
+    "plugin_version": "1.0.0",
+    "protocol_version": { "major": 1, "minor": 0 },
+    "capabilities": [
+      {
+        "capability_id": "text.inline",
+        "content_type": "text",
+        "formats": ["text"],
+        "features": [],
+        "priority": 0
+      }
+    ]
+  }
+}
+EOF
+    ;;
+  *)
+    cat <<'EOF'
+{
+  "type": "materialized",
+  "response": {
+    "inline": {
+      "bytes": [72, 101, 108, 108, 111]
+    }
+  }
+}
+EOF
+    ;;
+esac
+```
+
+---
+
+## Plugin Directory
+
+Plugins are loaded from a directory specified at runtime:
+
+```bash
+retromount inspect <input> --plugin-dir ./plugins
+```
+
+* All executables in the directory are considered plugins
+* Invalid plugins are skipped with diagnostics
+
+---
+
+## Test Fixtures
+
+The repository includes fixture plugins under:
+
+```text
+plugins/fixtures/
+```
+
+These are used for:
+
+* integration testing
+* protocol validation
+* development
+
+They are not intended for production use.
+
+---
+
+## Future Work
+
+Potential future enhancements include:
+
+* WASM-based plugin runtime
+* Plugin configuration support
+* Distribution and packaging model
+* Persistent plugin processes (if needed)
+
+---
+
+## Summary
+
+The plugin system provides:
+
+* A clean separation between core logic and extensible encoding
+* A deterministic, testable execution model
+* A safe and simple integration surface
+
+Plugins are first-class participants in the encoding pipeline, enabling Retromount to adapt to new formats and ecosystems without modifying its core.

--- a/docs/roadmap/phase5-runtime-plugins.md
+++ b/docs/roadmap/phase5-runtime-plugins.md
@@ -1,6 +1,6 @@
 # Phase 5 — Runtime Plugins & Adaptive Presentations
 
-This document defines the proposed scope and architectural direction for Phase 5.
+This document defines the scope and architectural direction for Phase 5.
 
 Phase 5 is the point at which Retromount begins to fully realize its original vision:
 
@@ -18,13 +18,36 @@ Phase 5 builds on that by introducing runtime-extensible plugins and multi-encod
 
 ---
 
+## Status
+
+### Implemented (Phases 5A–5E)
+
+* Declarative presentation planning
+* Capability-based encoder resolution
+* Plugin protocol definition
+* Out-of-process plugin runtime
+* Plugin discovery and registration
+* End-to-end plugin integration (validated via integration tests)
+
+### Remaining (Phase 5F+)
+
+* Plugin packaging and distribution model
+* Plugin configuration surface
+* CLI ergonomics and discovery tooling
+* Additional real-world plugins (e.g. MiSTer, Batocera)
+* Optional runtime improvements (e.g. WASM exploration)
+
+See also: `docs/architecture/plugins.md` for the runtime plugin model.
+
+---
+
 ## Goal
 
 Enable Retromount to load capability at runtime and compose it safely into the pipeline, so users can extend the system without recompiling the main binary.
 
 Specifically:
 
-> Retromount should be able to discover and use separately installed plugins that contribute presenters, encoders, and related capabilities at runtime.
+> Retromount should be able to discover and use separately installed plugins that contribute encoding capabilities at runtime.
 
 This supports the long-term product vision of installing ecosystem-specific support independently, for example:
 
@@ -40,9 +63,9 @@ Phase 5 introduces two major shifts:
 
 ### 1. Retromount becomes runtime-extensible
 
-Retromount should no longer be limited to capabilities compiled directly into the main binary.
+Retromount is no longer limited to capabilities compiled into the main binary.
 
-Instead, it should support a plugin model in which externally shipped components can be installed and discovered at runtime.
+Instead, it supports a plugin model in which externally shipped components can be installed and discovered at runtime.
 
 ### 2. Presentations may require multiple encoders
 
@@ -54,8 +77,6 @@ For example, a Batocera-oriented presentation might require:
 * ZIP encoding for some ROM content
 * passthrough encoding for already-compatible files
 
-A different presentation such as MiSTer may require a different but overlapping set of encoders.
-
 This means the architecture must support:
 
 > one presentation plan being satisfied by multiple encoders
@@ -66,27 +87,24 @@ rather than assuming a single presenter/encoder pair.
 
 ## Design Principles
 
-Phase 5 should preserve the architectural boundaries established in earlier phases.
+Phase 5 preserves the architectural boundaries established in earlier phases.
 
 ### Pipeline integrity remains mandatory
 
-Plugins must integrate into defined pipeline stages. They must not bypass or collapse the pipeline into a less structured model.
+Plugins integrate into defined pipeline stages and must not bypass or collapse the pipeline.
 
 ### The core model remains presentation-agnostic
 
-Plugins must not reintroduce filenames, filesystem concerns, or consumer-specific semantics into normalized content.
+Plugins must not introduce filenames, filesystem concerns, or consumer-specific semantics into normalized content.
 
 ### Presenter and Encoder responsibilities remain distinct
 
-Presenters define the intended structure and artifact requirements.
-
-Encoders materialize those artifacts.
-
-A presenter must not directly own or hard-code concrete encoding behaviour.
+* Presenters define structure and artifact requirements
+* Encoders (including plugins) materialize those artifacts
 
 ### Runtime extensibility must be real
 
-Phase 5 should not introduce a temporary “fake plugin” model that later needs to be discarded in favour of a true runtime mechanism.
+The plugin model is implemented as a real runtime mechanism (out-of-process), not a temporary abstraction.
 
 ---
 
@@ -96,83 +114,67 @@ Phase 5 includes the following work.
 
 ### 1. Define a runtime plugin model
 
-Retromount should define a formal plugin contract that supports runtime discovery and capability loading.
-
-At minimum, this should cover:
+A formal plugin contract is defined (see `plugins.md`) covering:
 
 * plugin identity
-* plugin type
 * supported capabilities
-* compatibility/version metadata
-* configuration surface
-* error reporting expectations
-
-This plugin model must be suitable for independently packaged plugins.
+* protocol compatibility
+* error handling
 
 ### 2. Introduce presentation planning
 
-Presenters should evolve from directly producing encoded output toward producing a declarative presentation plan.
+Presenters now produce a **declarative presentation plan** describing:
 
-A presentation plan should describe:
-
-* the intended logical output structure
-* the files/artifacts required at specific output locations
-* the source normalized content each artifact derives from
-* the required or preferred encoding characteristics for each artifact
-
-This allows the system to resolve each artifact independently against one or more available encoders.
+* logical output structure
+* required artifacts
+* source content relationships
+* encoding requirements
 
 ### 3. Add encoder capability resolution
 
-Retromount should introduce a resolution layer that matches presentation artifact requirements against available encoder capabilities.
+A resolution layer matches artifact requirements to encoder capabilities.
 
-This should support:
+Supports:
 
-* multiple encoders contributing to one presentation
-* deterministic selection behaviour
-* clear failure modes when no suitable encoder is available
-* optional preference and fallback rules
+* multiple encoders per presentation
+* deterministic selection
+* explicit failure when unsatisfied
 
 ### 4. Implement runtime plugin loading
 
-Retromount should support a real runtime loading mechanism for plugins.
+Phase 5 selects and implements:
 
-The exact implementation mechanism remains open for design evaluation.
+> **Out-of-process plugins with a JSON protocol over stdin/stdout**
 
-Candidate approaches include:
+This provides:
 
-* native shared libraries with a stable ABI
-* WebAssembly-based plugins
-* out-of-process plugins with an explicit protocol
+* strong isolation
+* language-agnostic plugin development
+* stable versioning boundary
 
-Phase 5 should choose one initial runtime model and implement it properly.
+### 5. Add plugin discovery
 
-### 5. Add plugin discovery and inspection
+Plugins are:
 
-Users should be able to inspect what plugins are installed and what capabilities they provide.
+* discovered from a directory
+* validated via manifest
+* registered into the encoder registry
 
-This includes functionality to:
+### 6. Deliver external integration proof
 
-* list installed plugins
-* inspect plugin metadata
-* inspect available presentations and encoders
-* inspect resolution decisions for a planned presentation
+A fixture plugin demonstrates:
 
-### 6. Deliver at least one real external integration
+* manifest exchange
+* capability registration
+* materialization via plugin
+* deterministic integration test coverage
 
-Phase 5 should include at least one externally installable plugin that proves the model end-to-end.
+### 7. Add configuration hooks
 
-Likely candidates:
+Initial CLI support includes:
 
-* MiSTer presentation plugin
-* Batocera presentation plugin
-* CHD encoder plugin
-
-### 7. Add configuration support for runtime capability selection
-
-Retromount should support selecting presentations and constraining or influencing encoder resolution through CLI and/or configuration.
-
-The model should reflect that multiple encoders may participate in a single presentation.
+* `--plugin-dir` for runtime loading
+* future support for encoder constraints and preferences
 
 ---
 
@@ -183,229 +185,95 @@ Phase 5 does not include:
 * metadata scraping
 * ROM management features
 * artwork acquisition
-* permanent export pipelines as a primary workflow
+* plugin marketplace/distribution
+* automatic plugin installation
 * GUI or web UI
-* plugin marketplace/distribution infrastructure
-* automatic downloading of plugins
-* solving every possible security or sandboxing concern
-* finalising every future plugin category
+* full sandboxing model
+* final plugin ecosystem design
 
 ---
 
 ## Proposed Architectural Model
 
-### Presenter output becomes declarative
+### Presenter output is declarative
 
-Move from:
-
-`normalized content -> presenter -> encoder -> VFS`
-
-to:
-
-`normalized content -> presenter -> presentation plan -> capability resolver -> multiple encoders -> VFS`
+```text
+normalized content
+    ↓
+presenter
+    ↓
+presentation plan
+    ↓
+capability resolver
+    ↓
+encoders (built-in + plugins)
+    ↓
+VFS
+```
 
 ### Presentation plan responsibilities
 
-A presentation plan should describe:
+A presentation plan describes:
 
-* directories to create
-* logical files to expose
-* normalized content backing each file
-* required artifact representation (and constraints)
-* optional preferences or constraints
-
-### Conceptual Model (Non-Normative)
-
-A presentation plan represents a declarative description of the intended output.
-
-At a high level, it consists of:
-
-* a virtual directory tree
-* a set of artifact requests attached to file nodes
-
-Each artifact request describes:
-
-* the normalized content it derives from
-* the desired output representation
-* any constraints or preferences for encoding
-
-For example (conceptually):
-
-* `/PlayStation/Game Name/Game Name.chd`
-  * source: DiscContent
-  * requirement: representation=CHD
-
-* `/NES/Game Name/Game Name.zip`
-  * source: RomParts
-  * requirement: representation=ZIP
-
-* `/Arcade/Game Name/Game Name.rom`
-  * source: SingleRom
-  * requirement: representation=Passthrough
+* directory structure
+* logical files
+* normalized content backing
+* encoding requirements
 
 ### Encoder capability model
 
-Encoders advertise capabilities rather than existing as fixed pairings.
+Encoders (including plugins) advertise capabilities:
 
-Examples:
+* content type
+* supported formats
+* supported features
+* priority
 
-* passthrough encoder → exposes existing files
-* ZIP encoder → archive-based output
-* CHD encoder → optical disc → CHD
-* ISO encoder → optical disc → ISO
+### Artifact Requirements vs Capabilities
 
-### Artifact Requirements vs Encoder Capabilities
+* Presenters define **requirements**
+* Encoders define **capabilities**
+* Resolver matches them deterministically
 
-A presentation plan expresses **artifact requirements**.
+---
 
-Encoders advertise **capabilities**.
+## Resolution Behaviour
 
-Retromount is responsible for matching requirements to capabilities.
+The resolver:
 
-For example:
+* selects exactly one encoder per artifact
+* is deterministic
+* fails explicitly when no match exists
+* does not depend on plugin load order
 
-* requirement: "optical-disc → CHD"
-* capability: "can encode optical-disc content to CHD"
+---
 
-A match occurs when an encoder can satisfy the requirement for a given artifact.
+## Plugin Runtime Model
 
-This separation ensures that:
+Phase 5 adopts:
 
-* presenters remain declarative
-* encoders remain interchangeable
-* resolution logic is centralised and inspectable
+> **Out-of-process plugins**
 
-### Resolution Behaviour (Initial Expectations)
+See `docs/architecture/plugins.md` for full details.
 
-The capability resolver should:
+### Key properties
 
-* select exactly one encoder per artifact
-* behave deterministically given the same inputs and plugin set
-* fail clearly if no suitable encoder is available
-* optionally support preference rules (e.g. prefer passthrough)
-* resolution should not depend on plugin load order
+* process-per-invocation
+* JSON protocol over stdin/stdout
+* no shared state
+* strong isolation
 
-Initial implementations do not need to support:
+---
 
-* complex scoring systems
-* cost-based optimisation
-* multi-step encoding pipelines
+## Failure Model
 
-These may be introduced in later phases.
-
-### Plugin Contract (Initial Expectations)
-
-Plugins should:
-
-* declare their type (presenter, encoder, etc.)
-* advertise capabilities or provided functionality
-* declare compatibility with a host version range
-* expose a clear entry point for invocation
-
-Plugins should not:
-
-* access internal Retromount state directly
-* assume implementation details of the host
-* bypass the defined pipeline stages
-* assume exclusive ownership of an artifact or content type
-
-### Failure Model (Initial Direction)
-
-Failures during planning or resolution should be:
+Failures are:
 
 * explicit
 * actionable
-* tied to missing capabilities or incompatible plugins
+* tied to missing capabilities or invalid plugins
 
-For example:
-
-* "No encoder available for optical-disc → CHD"
-* "Plugin X is incompatible with this Retromount version"
-
-Silent fallback behaviour should be avoided in initial implementations.
-
-### No Implicit Fallbacks (Initial Constraint)
-
-Phase 5 should avoid introducing implicit or hidden fallback behaviour.
-
-If a required artifact cannot be satisfied, the system should fail clearly rather than attempting silent alternatives.
-
-Explicit fallback strategies may be introduced later via policy or configuration.
-
----
-
-## Plugin Runtime Options
-
-### Option A: Native shared libraries (C ABI)
-
-#### Pros (Native shared libraries)
-
-* high performance
-* package-manager friendly
-* simple user model
-
-#### Cons (Native shared libraries)
-
-* requires stable ABI boundary
-* weaker isolation
-* crash risk propagates to host
-
----
-
-### Option B: WebAssembly plugins
-
-#### Pros (WebAssembly plugins)
-
-* sandboxed
-* portable
-* structured host/plugin API
-
-#### Cons (WebAssembly plugins)
-
-* runtime complexity
-* performance considerations
-* explicit host bridging required
-
----
-
-### Option C: Out-of-process plugins
-
-#### Pros (Out-of-process plugins)
-
-* strong isolation
-* no ABI issues
-* language-agnostic
-* robust versioning
-
-#### Cons (Out-of-process plugins)
-
-* IPC overhead
-* protocol complexity
-* streaming considerations
-
----
-
-## Initial Recommendation
-
-### Critical Architectural Decision
-
-The most important architectural change in Phase 5 is:
-
-> presenters must emit a declarative plan that can be satisfied by multiple encoders
-
-This decision is independent of the chosen plugin runtime mechanism and should be implemented first.
-
-If this is done correctly:
-
-* plugin runtime can evolve independently
-* encoder implementations remain interchangeable
-* ecosystem-specific presentations become straightforward to express
-
-If this is done incorrectly:
-
-* presentations will remain tightly coupled to encoders
-* multi-encoder scenarios will be difficult or fragile
-* future plugin support will be constrained
+No implicit fallbacks are introduced in Phase 5.
 
 ---
 
@@ -420,34 +288,20 @@ Optional controls:
 
 ```bash
 --allow-encoder chd
---allow-encoder zip
 --prefer-encoder passthrough
---plugin-dir /usr/lib/retromount/plugins
-```
-
-Diagnostics:
-
-```bash
-retromount plugins list
-retromount plugins inspect mister
-retromount plan inspect <input> --presentation batocera
+--plugin-dir ./plugins
 ```
 
 ---
 
 ## Suggested Sub-Phases
 
-### Phase 5A — Presentation Planning Model
-
-### Phase 5B — Capability Resolution
-
-### Phase 5C — Plugin Runtime Selection
-
-### Phase 5D — Plugin Runtime Implementation
-
-### Phase 5E — External Plugin Proof
-
-### Phase 5F — Packaging & UX
+* 5A — Presentation Planning
+* 5B — Capability Resolution
+* 5C — Plugin Protocol
+* 5D — Plugin Runtime
+* 5E — Integration Proof
+* 5F — Packaging & UX
 
 ---
 
@@ -456,25 +310,9 @@ retromount plan inspect <input> --presentation batocera
 * runtime plugin discovery works
 * presenters emit declarative plans
 * multiple encoders satisfy one presentation
-* resolution is deterministic and inspectable
-* clear errors for missing capabilities
-* at least one external plugin works end-to-end
+* resolution is deterministic
+* plugin integration works end-to-end
 * architectural boundaries remain intact
-
----
-
-## Open Questions
-
-1. Which runtime model to choose?
-2. Plugin manifest format?
-3. Version compatibility strategy?
-4. Capability description model?
-5. Plugin configuration approach?
-6. Preference vs requirement handling?
-7. Failure model?
-8. Observability/debugging?
-9. Sandbox requirements?
-10. First integration target?
 
 ---
 
@@ -486,13 +324,12 @@ Phase 5 transforms Retromount from:
 
 into:
 
-> a platform that adapts ROM collections to any ecosystem
+> a platform that adapts ROM collections to different ecosystems
 
 This is achieved through:
 
 * runtime plugins
 * declarative presentation planning
 * multi-encoder resolution
-* strict adherence to architectural boundaries
 
-This phase is the foundation for everything that comes next.
+Phase 5 establishes the extensibility foundation for the system.

--- a/docs/roadmap/phase5e-plugin-integration.md
+++ b/docs/roadmap/phase5e-plugin-integration.md
@@ -20,6 +20,8 @@ Plugins are now:
 
 This phase establishes a complete end-to-end path from input content to plugin-driven output artifacts.
 
+See also: `docs/architecture/plugins.md` for the runtime plugin model.
+
 ---
 
 ## Key Outcomes
@@ -80,7 +82,7 @@ This plugin:
 * Supports multiple formats (e.g. Bin, Iso, Chd)
 * Returns a fixed inline payload (`"PLUGIN"`) for all materialization requests
 
-This allows:
+This enables:
 
 * Clear verification of plugin selection
 * Deterministic assertions in automated tests
@@ -100,7 +102,9 @@ This test:
 
 * Uses real decoded and normalized content (CUE/BIN disc)
 * Loads the fixture plugin from a temporary plugin directory
-* Runs the full pipeline (identify → decode → normalize → present → resolve → materialize)
+* Runs the full pipeline:
+
+  * identify → decode → normalize → present → resolve → materialize
 * Forces a plugin-resolved capability via a controlled presenter
 * Asserts that:
 
@@ -130,6 +134,20 @@ The same applies to:
 * `mount`
 
 If no plugin directory is provided, only built-in encoders are used.
+
+---
+
+## Guarantees Established by Phase 5E
+
+Phase 5E proves that:
+
+* Plugins are first-class encoder implementations
+* The pipeline remains intact and deterministic with external components
+* Capability resolution works uniformly across built-in and plugin encoders
+* The plugin protocol is stable and enforceable
+* End-to-end execution is testable and reproducible
+
+These guarantees form the foundation for future extensibility work.
 
 ---
 


### PR DESCRIPTION
# docs(phase5f): align documentation with runtime plugin integration

---

## **Description**

This PR merges documentation updates from `feature/phase5f-documentation` into `feature/phase5-integration`.

### Summary

Following completion of Phase 5E (runtime plugin integration), several documentation updates were required to bring the architecture and plugin docs in line with the implemented system.

This PR ensures that documentation accurately reflects:

* runtime plugin discovery and execution
* capability-based encoder resolution
* the updated Presenter → Encoder relationship
* the role of plugins within the pipeline

---

### Key Changes

#### Architecture updates

* Updated `docs/architecture/boundaries.md` to:

  * clarify that encoder selection is resolved via capabilities
  * document plugin-provided encoders alongside built-ins
  * refine Presenter → Encoder contract to reflect resolution step
  * strengthen extensibility principles to include runtime plugins

#### Plugin documentation fixes

* Resolved markdownlint issues in `docs/architecture/plugins.md`

  * added missing fenced code block languages
* General consistency improvements across plugin-related documentation

---

### Scope

* Documentation only
* No functional changes

---

### Context

Phase 5 introduces a key architectural shift:

> Encoding is resolved dynamically via capabilities (built-in or plugin), rather than being statically defined.

These updates ensure that the documentation matches the current implementation before merging the full Phase 5 integration branch.

---

### Next Step

Merge `feature/phase5-integration` into `develop` to complete Phase 5.
