### PR TITLE
Post-Phase-5 stabilisation: harden runtime plugin mount and failure paths

### DIFF
--- a/plugins/fixtures/test-failing-encoder.sh
+++ b/plugins/fixtures/test-failing-encoder.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Retromount failing fixture plugin:
+# - valid protocol v1 manifest
+# - high-priority disc encoder
+# - discovery succeeds
+# - materialization fails deterministically
+# - intended for integration testing of runtime failure handling
+
+request="$(cat)"
+
+case "$request" in
+*'"type":"get_manifest"'*)
+    cat <<'EOF'
+{
+  "type": "manifest",
+  "manifest": {
+    "plugin_id": "plugin.fixture.failing",
+    "plugin_version": "1.0.0",
+    "protocol_version": {
+      "major": 1,
+      "minor": 0
+    },
+    "display_name": "Fixture Failing Encoder",
+    "description": "Deterministic failing fixture plugin for Retromount integration testing",
+    "capabilities": [
+      {
+        "capability_id": "fixture.disc.failing",
+        "content_type": "Disc",
+        "formats": ["Bin", "Iso", "Chd"],
+        "features": [],
+        "priority": 1000
+      }
+    ]
+  }
+}
+EOF
+    ;;
+*)
+    echo "fixture plugin forced materialization failure" >&2
+    exit 42
+    ;;
+esac

--- a/plugins/fixtures/test-invalid-manifest-encoder.sh
+++ b/plugins/fixtures/test-invalid-manifest-encoder.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Retromount invalid manifest fixture plugin:
+# - executable so discovery inspects it
+# - returns an invalid manifest on get_manifest
+# - intended for integration testing of plugin discovery/load failures
+
+request="$(cat)"
+
+case "$request" in
+*'"type":"get_manifest"'*)
+    cat <<'EOF'
+{
+  "type": "manifest",
+  "manifest": {
+    "plugin_id": "",
+    "plugin_version": "1.0.0",
+    "protocol_version": {
+      "major": 1,
+      "minor": 0
+    },
+    "display_name": "Fixture Invalid Manifest Encoder",
+    "description": "Deterministic invalid-manifest fixture plugin for Retromount integration testing",
+    "capabilities": [
+      {
+        "capability_id": "fixture.invalid",
+        "content_type": "Disc",
+        "formats": ["Bin", "Iso", "Chd"],
+        "features": [],
+        "priority": 1000
+      }
+    ]
+  }
+}
+EOF
+    ;;
+*)
+    cat <<'EOF'
+{
+  "type": "materialized",
+  "response": {
+    "Inline": {
+      "bytes": [73, 78, 86, 65, 76, 73, 68]
+    }
+  }
+}
+EOF
+    ;;
+esac

--- a/plugins/fixtures/test-malformed-response-encoder.sh
+++ b/plugins/fixtures/test-malformed-response-encoder.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Retromount malformed response fixture plugin:
+# - valid protocol v1 manifest
+# - high-priority disc encoder
+# - discovery succeeds and capability selection succeeds
+# - materialization returns malformed JSON
+# - intended for integration testing of runtime response failures
+
+request="$(cat)"
+
+case "$request" in
+*'"type":"get_manifest"'*)
+    cat <<'EOF'
+{
+  "type": "manifest",
+  "manifest": {
+    "plugin_id": "plugin.fixture.malformed",
+    "plugin_version": "1.0.0",
+    "protocol_version": {
+      "major": 1,
+      "minor": 0
+    },
+    "display_name": "Fixture Malformed Response Encoder",
+    "description": "Deterministic malformed-response fixture plugin for Retromount integration testing",
+    "capabilities": [
+      {
+        "capability_id": "fixture.disc.malformed",
+        "content_type": "Disc",
+        "formats": ["Bin", "Iso", "Chd"],
+        "features": [],
+        "priority": 1000
+      }
+    ]
+  }
+}
+EOF
+    ;;
+*)
+    printf '%s\n' 'not-json'
+    ;;
+esac

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -6,8 +6,13 @@ use crate::engine::components::pipeline_components_for_presenter;
 use crate::engine::pipeline::{run_pipeline, run_pipeline_with_options, PipelineOptions};
 use crate::engine::preview::build_input_source;
 use crate::error::RetromountError;
+use crate::input::decode::InputDecoder;
+use crate::input::identify::InputIdentifier;
+use crate::input::source::InputSource;
 use crate::mount::session::MountSession;
 use crate::output::plugin_registry::PluginRegistry;
+use crate::output::present::OutputPresenter;
+use crate::policy::PolicySet;
 
 #[cfg(target_os = "linux")]
 use crate::mount::adapter::FilesystemAdapter;
@@ -28,34 +33,7 @@ pub fn run_mount_command_with_plugins(
     presenter_name: &str,
     plugin_registry: Option<&PluginRegistry>,
 ) -> Result<(), RetromountError> {
-    let source = build_input_source(input)?;
-    let components = pipeline_components_for_presenter(presenter_name)?;
-
-    let root = match plugin_registry {
-        Some(plugin_registry) => {
-            run_pipeline_with_options(
-                source.as_ref(),
-                components.identifier.as_ref(),
-                components.decoder.as_ref(),
-                components.presenter.as_ref(),
-                &components.policy,
-                &PipelineOptions {
-                    normalization: Default::default(),
-                    plugin_registry: Some(plugin_registry),
-                },
-            )?
-            .output_vfs
-        }
-        None => run_pipeline(
-            source.as_ref(),
-            components.identifier.as_ref(),
-            components.decoder.as_ref(),
-            components.presenter.as_ref(),
-            &components.policy,
-        )?,
-    };
-
-    let session = MountSession::from_root(&root);
+    let session = prepare_mount_session_with_plugins(input, presenter_name, plugin_registry)?;
     let root_children = session
         .children(session.root_inode())
         .map(|children| children.len())
@@ -69,6 +47,60 @@ pub fn run_mount_command_with_plugins(
     info!("Root child entries: {}", root_children);
 
     mount_session(session, mountpoint)
+}
+
+pub fn prepare_mount_session(
+    input: &Path,
+    presenter_name: &str,
+) -> Result<MountSession, RetromountError> {
+    prepare_mount_session_with_plugins(input, presenter_name, None)
+}
+
+pub fn prepare_mount_session_with_plugins(
+    input: &Path,
+    presenter_name: &str,
+    plugin_registry: Option<&PluginRegistry>,
+) -> Result<MountSession, RetromountError> {
+    let source = build_input_source(input)?;
+    let components = pipeline_components_for_presenter(presenter_name)?;
+
+    prepare_mount_session_from_pipeline(
+        source.as_ref(),
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        components.presenter.as_ref(),
+        &components.policy,
+        plugin_registry,
+    )
+}
+
+pub fn prepare_mount_session_from_pipeline(
+    source: &dyn InputSource,
+    identifier: &dyn InputIdentifier,
+    decoder: &dyn InputDecoder,
+    presenter: &dyn OutputPresenter,
+    policy: &PolicySet,
+    plugin_registry: Option<&PluginRegistry>,
+) -> Result<MountSession, RetromountError> {
+    let root = match plugin_registry {
+        Some(plugin_registry) => {
+            run_pipeline_with_options(
+                source,
+                identifier,
+                decoder,
+                presenter,
+                policy,
+                &PipelineOptions {
+                    normalization: Default::default(),
+                    plugin_registry: Some(plugin_registry),
+                },
+            )?
+            .output_vfs
+        }
+        None => run_pipeline(source, identifier, decoder, presenter, policy)?,
+    };
+
+    Ok(MountSession::from_root(&root))
 }
 
 #[cfg(target_os = "linux")]

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -94,10 +94,12 @@ pub fn prepare_mount_session_from_pipeline(
                     normalization: Default::default(),
                     plugin_registry: Some(plugin_registry),
                 },
-            )?
+            )
+            .map_err(|err| RetromountError::LoadError(err.to_string()))?
             .output_vfs
         }
-        None => run_pipeline(source, identifier, decoder, presenter, policy)?,
+        None => run_pipeline(source, identifier, decoder, presenter, policy)
+            .map_err(|err| RetromountError::LoadError(err.to_string()))?,
     };
 
     Ok(MountSession::from_root(&root))

--- a/src/output/materialize.rs
+++ b/src/output/materialize.rs
@@ -124,14 +124,28 @@ fn materialize_file(
             )
         })?;
 
-    let materialized = encoder.materialize(
-        &file.name,
-        &file.artifact,
-        &selected.capability_id,
-        &MaterializationContext {
-            artifact_names: artifact_names.clone(),
-        },
-    )?;
+    let materialized = encoder
+        .materialize(
+            &file.name,
+            &file.artifact,
+            &selected.capability_id,
+            &MaterializationContext {
+                artifact_names: artifact_names.clone(),
+            },
+        )
+        .map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!(
+                    "failed to materialize artifact '{}' (id '{}') using encoder '{}' capability '{}': {}",
+                    file.name,
+                    file.artifact.id.0,
+                    selected.plugin_id,
+                    selected.capability_id,
+                    err
+                ),
+            )
+        })?;
 
     Ok(materialized.to_vfs_file(&file.name))
 }

--- a/src/output/presentation_expansion.rs
+++ b/src/output/presentation_expansion.rs
@@ -20,7 +20,7 @@ pub fn sorted_disc_parts(game: &GameContent) -> Vec<&DiscPart> {
         })
         .collect();
 
-    parts.sort_by(|a, b| a.disc_number.cmp(&b.disc_number));
+    parts.sort_by_key(|a| a.disc_number);
     parts
 }
 

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -332,3 +332,92 @@ fn mount_preparation_fails_when_selected_plugin_materialization_fails() {
         "expected mount preparation failure to preserve runtime plugin context, got: {message}"
     );
 }
+
+#[test]
+fn load_plugin_registry_fails_for_invalid_discovered_plugin() {
+    let temp = TempDir::new().unwrap();
+    let plugin_dir = temp.path().join("plugins");
+    fs::create_dir_all(&plugin_dir).unwrap();
+
+    let _plugin_path =
+        copy_named_fixture_plugin_to_tempdir("test-invalid-manifest-encoder.sh", &plugin_dir);
+
+    let error = match load_plugin_registry(&plugin_dir) {
+        Ok(_) => panic!("expected invalid discovered plugin to fail registry loading"),
+        Err(error) => error,
+    };
+
+    let message = error.to_string();
+
+    assert!(
+        message.contains("plugin")
+            || message.contains("manifest")
+            || message.contains("rejected")
+            || message.contains("invalid"),
+        "expected discovery/load failure context, got: {message}"
+    );
+    assert!(
+        message.contains("test-invalid-manifest-encoder.sh")
+            || message.contains("plugin_id")
+            || message.contains("empty"),
+        "expected invalid plugin details in error, got: {message}"
+    );
+}
+
+#[test]
+fn mount_preparation_fails_when_selected_plugin_returns_malformed_response() {
+    let temp = TempDir::new().unwrap();
+
+    let input_dir = temp.path().join("input");
+    let plugin_dir = temp.path().join("plugins");
+    fs::create_dir_all(&input_dir).unwrap();
+    fs::create_dir_all(&plugin_dir).unwrap();
+
+    let cue_path = write_test_disc(&input_dir);
+    let _plugin_path =
+        copy_named_fixture_plugin_to_tempdir("test-malformed-response-encoder.sh", &plugin_dir);
+
+    let plugin_registry = load_plugin_registry(&plugin_dir).unwrap();
+    assert!(
+        !plugin_registry.is_empty(),
+        "expected malformed-response fixture plugin registry to contain at least one plugin"
+    );
+
+    let source = FileInputSource::new(&cue_path);
+    let components = default_pipeline_components().unwrap();
+    let presenter = PluginOnlyDiscPresenter;
+
+    let error = prepare_mount_session_from_pipeline(
+        &source,
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &presenter,
+        &components.policy,
+        Some(&plugin_registry),
+    )
+    .unwrap_err();
+
+    let message = error.to_string();
+
+    assert!(
+        message.contains("Plugin Test.chd") || message.contains("plugin-test-disc"),
+        "expected error to mention requested artifact, got: {message}"
+    );
+    assert!(
+        message.contains("plugin.fixture.malformed")
+            || message.contains("fixture.disc.malformed")
+            || message.contains("test-malformed-response-encoder.sh"),
+        "expected error to mention selected plugin context, got: {message}"
+    );
+    assert!(
+        message.contains("invalid")
+            || message.contains("json")
+            || message.contains("unexpected")
+            || message.contains("response"),
+        "expected error to describe malformed runtime response, got: {message}"
+    );
+    assert!(
+        !message.contains("Failed to open config file"),
+        "expected mount preparation failure to preserve runtime plugin context, got: {message}"
+    );
+}

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -92,10 +92,14 @@ fn write_test_disc(dir: &Path) -> PathBuf {
 }
 
 fn copy_fixture_plugin_to_tempdir(dir: &Path) -> PathBuf {
+    copy_named_fixture_plugin_to_tempdir("test-inline-encoder.sh", dir)
+}
+
+fn copy_named_fixture_plugin_to_tempdir(file_name: &str, dir: &Path) -> PathBuf {
     let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("plugins")
         .join("fixtures")
-        .join("test-inline-encoder.sh");
+        .join(file_name);
 
     assert!(
         source.exists(),
@@ -103,7 +107,7 @@ fn copy_fixture_plugin_to_tempdir(dir: &Path) -> PathBuf {
         source.display()
     );
 
-    let destination = dir.join("test-inline-encoder.sh");
+    let destination = dir.join(file_name);
     fs::copy(&source, &destination).unwrap();
 
     let mut permissions = fs::metadata(&destination).unwrap().permissions();
@@ -271,5 +275,60 @@ fn mount_preparation_fails_when_no_encoder_matches() {
     assert!(
         !message.contains("Failed to open config file"),
         "expected mount preparation failure to preserve pipeline context, got: {message}"
+    );
+}
+
+#[test]
+fn mount_preparation_fails_when_selected_plugin_materialization_fails() {
+    let temp = TempDir::new().unwrap();
+
+    let input_dir = temp.path().join("input");
+    let plugin_dir = temp.path().join("plugins");
+    fs::create_dir_all(&input_dir).unwrap();
+    fs::create_dir_all(&plugin_dir).unwrap();
+
+    let cue_path = write_test_disc(&input_dir);
+    let _plugin_path = copy_named_fixture_plugin_to_tempdir("test-failing-encoder.sh", &plugin_dir);
+
+    let plugin_registry = load_plugin_registry(&plugin_dir).unwrap();
+    assert!(
+        !plugin_registry.is_empty(),
+        "expected failing fixture plugin registry to contain at least one plugin"
+    );
+
+    let source = FileInputSource::new(&cue_path);
+    let components = default_pipeline_components().unwrap();
+    let presenter = PluginOnlyDiscPresenter;
+
+    let error = prepare_mount_session_from_pipeline(
+        &source,
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &presenter,
+        &components.policy,
+        Some(&plugin_registry),
+    )
+    .unwrap_err();
+
+    let message = error.to_string();
+
+    assert!(
+        message.contains("Plugin Test.chd") || message.contains("plugin-test-disc"),
+        "expected error to mention requested artifact, got: {message}"
+    );
+    assert!(
+        message.contains("plugin.fixture.failing")
+            || message.contains("fixture.disc.failing")
+            || message.contains("test-failing-encoder.sh"),
+        "expected error to mention selected plugin context, got: {message}"
+    );
+    assert!(
+        message.contains("fixture plugin forced materialization failure")
+            || message.contains("non-zero status 42"),
+        "expected error to describe plugin runtime failure, got: {message}"
+    );
+    assert!(
+        !message.contains("Failed to open config file"),
+        "expected mount preparation failure to preserve runtime plugin context, got: {message}"
     );
 }

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -268,4 +268,8 @@ fn mount_preparation_fails_when_no_encoder_matches() {
             || message.contains("ContentTypeMismatch"),
         "expected error to describe encoder resolution failure, got: {message}"
     );
+    assert!(
+        !message.contains("Failed to open config file"),
+        "expected mount preparation failure to preserve pipeline context, got: {message}"
+    );
 }

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -47,6 +47,32 @@ impl OutputPresenter for PluginOnlyDiscPresenter {
     }
 }
 
+struct UnmatchedDiscPresenter;
+
+impl OutputPresenter for UnmatchedDiscPresenter {
+    fn present(&self, content: &[NormalizedContent], _policy: &PolicySet) -> PresentationPlan {
+        let disc_source = content
+            .iter()
+            .find_map(|item| match item {
+                NormalizedContent::Game(game) => game.parts.iter().find_map(|part| match part {
+                    GamePart::Disc(disc) => Some(disc.source.clone()),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("expected at least one normalized disc game");
+
+        PresentationPlan::new(vec![PlanEntry::File(PlanFile::new(
+            "Unmatched.m3u",
+            ArtifactRequest::new(
+                ArtifactId::new("unmatched-disc"),
+                PlannedArtifactKind::SourceBacked(SourceArtifact::single(disc_source, 0)),
+                CapabilityRequirements::new(ContentType::Disc).with_format(Format::M3u),
+            ),
+        ))])
+    }
+}
+
 fn write_test_disc(dir: &Path) -> PathBuf {
     let bin_path = dir.join("Crash Bandicoot.bin");
     let cue_path = dir.join("Crash Bandicoot.cue");
@@ -195,4 +221,51 @@ fn mount_preparation_uses_runtime_plugin_materialization() {
         }
         other => panic!("expected inline-backed file from fixture plugin, got {other:?}"),
     }
+}
+
+#[test]
+fn mount_preparation_fails_when_no_encoder_matches() {
+    let temp = TempDir::new().unwrap();
+
+    let input_dir = temp.path().join("input");
+    let plugin_dir = temp.path().join("plugins");
+    fs::create_dir_all(&input_dir).unwrap();
+    fs::create_dir_all(&plugin_dir).unwrap();
+
+    let cue_path = write_test_disc(&input_dir);
+    let _plugin_path = copy_fixture_plugin_to_tempdir(&plugin_dir);
+
+    let plugin_registry = load_plugin_registry(&plugin_dir).unwrap();
+    assert!(
+        !plugin_registry.is_empty(),
+        "expected fixture plugin registry to contain at least one plugin"
+    );
+
+    let source = FileInputSource::new(&cue_path);
+    let components = default_pipeline_components().unwrap();
+    let presenter = UnmatchedDiscPresenter;
+
+    let error = prepare_mount_session_from_pipeline(
+        &source,
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &presenter,
+        &components.policy,
+        Some(&plugin_registry),
+    )
+    .unwrap_err();
+
+    let message = error.to_string();
+
+    assert!(
+        message.contains("unmatched-disc") || message.contains("Unmatched.m3u"),
+        "expected error to mention artifact identity, got: {message}"
+    );
+    assert!(
+        message.contains("no encoder could materialize artifact")
+            || message.contains("ResolutionDiagnostic")
+            || message.contains("FormatMismatch")
+            || message.contains("ContentTypeMismatch"),
+        "expected error to describe encoder resolution failure, got: {message}"
+    );
 }

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -7,9 +7,11 @@ use std::path::{Path, PathBuf};
 use retromount::core::content::{GamePart, NormalizedContent};
 use retromount::core::vfs::VfsNode;
 use retromount::engine::components::default_pipeline_components;
+use retromount::engine::mount::prepare_mount_session_from_pipeline;
 use retromount::engine::pipeline::{run_pipeline_with_options, PipelineOptions};
 use retromount::engine::plugins::load_plugin_registry;
 use retromount::input::file_source::FileInputSource;
+use retromount::mount::session::MountNodeKind;
 use retromount::output::capabilities::{CapabilityRequirements, ContentType, Format};
 use retromount::output::plan::{
     ArtifactId, ArtifactRequest, PlanEntry, PlanFile, PlannedArtifactKind, PresentationPlan,
@@ -133,6 +135,63 @@ fn pipeline_materializes_disc_via_fixture_plugin() {
         retromount::core::vfs::FileBacking::Inline(bytes) => {
             assert_eq!(bytes, b"PLUGIN");
             assert_eq!(file.size, 6);
+        }
+        other => panic!("expected inline-backed file from fixture plugin, got {other:?}"),
+    }
+}
+
+#[test]
+fn mount_preparation_uses_runtime_plugin_materialization() {
+    let temp = TempDir::new().unwrap();
+
+    let input_dir = temp.path().join("input");
+    let plugin_dir = temp.path().join("plugins");
+    fs::create_dir_all(&input_dir).unwrap();
+    fs::create_dir_all(&plugin_dir).unwrap();
+
+    let cue_path = write_test_disc(&input_dir);
+    let _plugin_path = copy_fixture_plugin_to_tempdir(&plugin_dir);
+
+    let plugin_registry = load_plugin_registry(&plugin_dir).unwrap();
+    assert!(
+        !plugin_registry.is_empty(),
+        "expected fixture plugin registry to contain at least one plugin"
+    );
+
+    let source = FileInputSource::new(&cue_path);
+    let components = default_pipeline_components().unwrap();
+    let presenter = PluginOnlyDiscPresenter;
+
+    let session = prepare_mount_session_from_pipeline(
+        &source,
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &presenter,
+        &components.policy,
+        Some(&plugin_registry),
+    )
+    .unwrap();
+
+    let root_children = session
+        .children(session.root_inode())
+        .expect("expected root inode to have children");
+
+    assert_eq!(root_children.len(), 1);
+
+    let file_node = root_children[0];
+    assert_eq!(file_node.name, "Plugin Test.chd");
+
+    let file = match &file_node.kind {
+        MountNodeKind::File { file } => file,
+        other => panic!("expected mounted file node, got {other:?}"),
+    };
+
+    assert_eq!(file.name, "Plugin Test.chd");
+    assert_eq!(file.size, 6);
+
+    match &file.backing {
+        retromount::core::vfs::FileBacking::Inline(bytes) => {
+            assert_eq!(bytes, b"PLUGIN");
         }
         other => panic!("expected inline-backed file from fixture plugin, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

This change performs a focused post-Phase-5 stabilisation pass for runtime plugins.

It validates that mount preparation exercises the shared plugin-aware materialization path, and hardens the key failure modes across plugin discovery, capability resolution, and runtime execution.

## What changed

* extracted mount-session preparation from mount execution so the mount-oriented path can be tested directly
* added mount-path integration coverage for plugin-backed materialization
* added coverage for unresolved encoder selection during mount preparation
* added coverage for selected plugin runtime failure during materialization
* added coverage for malformed runtime responses after successful plugin selection
* added coverage for invalid plugin discovery/load failures
* improved error propagation so mount/materialization failures no longer surface as unrelated config-file errors
* preserved artifact and selected-plugin context in runtime materialization failure messages
* added fixture plugins to exercise deterministic failing, invalid-manifest, and malformed-response scenarios
* applied the small Clippy cleanup required for green CI

## Why

Phase 5 established the runtime plugin architecture and end-to-end integration. This follow-up pass increases confidence that the same architecture behaves correctly through mount-oriented execution paths and fails clearly in the most important real-world error scenarios.

## Validation

* `cargo test`
* `cargo clippy --all-targets --all-features -- -D warnings`
