### PR TITLE
docs(architecture): define Phase 6 direction with declarative presentations and encoder plugins

### DIFF
--- a/docs/architecture/adr-007-declarative-presentation-specifications.md
+++ b/docs/architecture/adr-007-declarative-presentation-specifications.md
@@ -1,0 +1,74 @@
+# ADR-007: Declarative Presentation Specifications
+
+## Status
+
+Accepted
+
+## Context
+
+Retromount now has a stable output-side architecture built around:
+
+1. normalized content as the canonical input to presentation
+2. `PresentationPlan` as the declarative description of intended output
+3. capability-based encoder resolution
+4. materialization through built-in and runtime encoder plugins
+
+Phase 5 and the subsequent stabilization pass confirmed that runtime encoder plugins are viable in real execution paths, including mount preparation and failure handling.
+
+The next architectural question is how presentation itself should be extended.
+
+One possible direction is to implement presentation as code-only presenter plugins. Another is to define presentation declaratively and interpret those declarations into `PresentationPlan`.
+
+Review of target output ecosystems such as MiSTer, Batocera, PS2 OPL, RetroArch, Analogue Pocket, PlusCart, and others suggests that most desired output views are primarily defined by:
+
+* structure and grouping
+* naming rules
+* artifact requirements
+* conditional emission rules
+* conflict handling
+
+These are better described as desired output shape than as arbitrary procedural logic.
+
+At the same time, some future targets may require richer rules than a minimal first declarative model can express.
+
+## Decision
+
+Retromount will adopt a **declarative presentation model** as the primary way to define output views.
+
+Presentation specifications will describe desired output shape over normalized content and will be interpreted into `PresentationPlan`.
+
+This means that:
+
+* presentation is treated as a planning problem, not primarily as arbitrary code
+* declarative presentation specifications become the main extension model for views
+* the declarative model may be enriched over time when real target views require additional expressiveness
+* presentation specifications describe output requirements against normalized content, not against original input formats
+
+The concrete serialization format for presentation specifications may be YAML, but the architectural decision is about the **declarative model**, not YAML specifically.
+
+## Consequences
+
+### Positive
+
+* aligns presentation with the existing `PresentationPlan` boundary
+* keeps output intent explicit and inspectable
+* makes views easier to define, review, share, and test
+* allows presentation logic to remain independent from output materialization
+* matches the dominant shape of expected consumer views
+* supports gradual enrichment of the model based on real requirements
+
+### Negative
+
+* Phase 6 must define and validate a declarative presentation model before broad implementation can proceed
+* a first version of the model may not immediately express every future target
+* care is required to avoid turning the declarative model into an ad hoc programming language
+
+### Constraints introduced by this decision
+
+* presentation declarations must operate over normalized content
+* presentation declarations should not encode input-format-specific assumptions
+* when the model is insufficient, it should be enriched deliberately based on concrete use cases rather than speculative design
+
+## Notes
+
+This decision does not require all desired views to be implemented immediately. Phase 6 will begin by expressing simple existing and target views declaratively, then expand the model only where real consumer requirements demand it.

--- a/docs/architecture/adr-008-runtime-encoder-plugins-as-output-mechanism.md
+++ b/docs/architecture/adr-008-runtime-encoder-plugins-as-output-mechanism.md
@@ -1,0 +1,62 @@
+# ADR-008: Runtime Encoder Plugins as the Primary Output Materialization Mechanism
+
+## Status
+
+Accepted
+
+## Context
+
+Retromount’s output pipeline now consists of:
+
+1. normalized content
+2. presentation planning
+3. capability resolution
+4. artifact materialization
+
+Phase 5 introduced runtime encoder plugins and capability-based resolution. The stabilization pass confirmed that this mechanism works through mount preparation as well as direct pipeline execution, and that meaningful failure modes are surfaced with usable diagnostics.
+
+This establishes a clean separation:
+
+* presentation determines **what** artifacts and structure are desired
+* encoders determine **how** those artifacts are materialized
+
+As Retromount moves toward declarative presentation specifications, it must also clarify the role of real encoder plugins in the architecture.
+
+## Decision
+
+Retromount will use **runtime encoder plugins as the primary extensibility mechanism for output materialization**.
+
+Declarative presentation specifications will express artifact requirements such as content type, format, and features. Capability resolution will then select the most appropriate encoder from the available built-in and runtime plugins.
+
+This means that:
+
+* presentation specifications remain declarative and do not contain encoder implementation logic
+* real-world output support is added primarily by implementing encoder plugins
+* built-in encoders may remain for core functionality, but the architecture is centered on capability-driven resolution across both built-in and runtime encoders
+* Phase 6 should include at least one real encoder plugin to validate the model against practical usage rather than fixtures alone
+
+## Consequences
+
+### Positive
+
+* preserves the Presenter/Encoder separation established earlier
+* keeps output materialization extensible without coupling it to presentation definitions
+* allows declarative presentation specifications to remain consumer-focused
+* supports deterministic resolution with diagnostics
+* provides a clear path for adding real ecosystem support incrementally
+
+### Negative
+
+* real-world usefulness depends on building actual encoder plugins, not only fixtures
+* encoder plugin quality and capability modelling become important parts of platform evolution
+* some consumer support may require multiple encoder plugins over time
+
+### Constraints introduced by this decision
+
+* presentation specifications should request desired artifacts, not name specific implementations by default
+* encoder plugins must advertise capabilities clearly enough for deterministic resolution
+* runtime encoder plugins must remain compatible with the existing materialization boundary and protocol
+
+## Notes
+
+For Phase 6, a real ISO encoder plugin is a strong candidate because it aligns naturally with a simple target presentation such as PS2 OPL, where the desired output is a flat set of ISO images.

--- a/docs/architecture/adr-009-defer-input-plugin-architecture.md
+++ b/docs/architecture/adr-009-defer-input-plugin-architecture.md
@@ -1,0 +1,63 @@
+# ADR-009: Defer Input Plugin Architecture Until After Declarative Presentations
+
+## Status
+
+Accepted
+
+## Context
+
+Retromount is expected to require extensibility on the input side as well as the output side. Future support may include:
+
+* additional source or container mechanisms
+* additional format decoders
+* extensible handling for containers such as archives
+* format-specific decoding for disc and ROM inputs
+
+Examples discussed include ISO, CHD, and ZIP-based inputs. Importantly, these do not all belong to the same conceptual layer:
+
+* ZIP is primarily a container/source concern
+* ISO and CHD are format/decode concerns
+
+This means “input plugins” are not a single flat category and likely require deliberate architecture across source/container and decoder responsibilities.
+
+At the same time, Retromount is at a point where it must choose a clear next implementation focus. Declarative presentation specifications are the more immediate continuation of the current architecture because they build directly on the normalized-content-to-`PresentationPlan` output pipeline that already exists.
+
+Attempting to design declarative presentations and input plugins in the same phase would open two significant architectural fronts at once.
+
+## Decision
+
+Retromount will **defer input plugin architecture until after Phase 6 declarative presentation work**.
+
+Phase 6 will focus on declarative presentation specifications and real encoder plugin validation. Input extensibility will be addressed in a later phase with dedicated architectural work.
+
+This means that:
+
+* input extensibility is recognized as important, but not part of the current phase focus
+* Retromount will not yet introduce a generalized input plugin system
+* future input extensibility work should distinguish between source/container plugins and decoder plugins
+* current built-in input handling remains in place while the presentation model is developed
+
+## Consequences
+
+### Positive
+
+* keeps Phase 6 focused and achievable
+* avoids mixing two separate extensibility problems in one phase
+* allows the declarative presentation model to stabilize before new input abstractions are introduced
+* makes later input-plugin design easier because the output side will no longer be in flux
+
+### Negative
+
+* input extensibility remains limited in the short term
+* some desired end-to-end ecosystem support may need to wait for a later input-focused phase
+* current built-in input support continues to carry responsibility for supported formats and containers
+
+### Constraints introduced by this decision
+
+* Phase 6 should not expand into generalized source/container or decoder plugin architecture
+* discussions of input plugins during Phase 6 should be treated as future-facing design notes, not implementation scope
+* later input extensibility work must model source/container and decoder concerns explicitly rather than collapsing them into one plugin type
+
+## Notes
+
+This decision is about sequencing, not rejection. Input extensibility remains an expected future capability of Retromount, but it will be addressed after declarative presentation specifications are established.


### PR DESCRIPTION
## Summary

This PR introduces a set of Architecture Decision Records (ADRs) that define the direction for Phase 6 of Retromount.

The key decisions are:

* adopt a **declarative presentation model** as the primary way to define output views
* establish **runtime encoder plugins** as the core output materialization mechanism
* explicitly **defer input plugin architecture** to a later phase

---

## ADRs added

* **ADR-007: Declarative Presentation Specifications**

  * Presentation is defined declaratively and compiled into `PresentationPlan`
  * Declarative model is the primary extension mechanism for views

* **ADR-008: Runtime Encoder Plugins as the Primary Output Mechanism**

  * Output materialization is driven by capability-based encoder resolution
  * Real encoder plugins are expected and form the basis for ecosystem support

* **ADR-009: Defer Input Plugin Architecture**

  * Input extensibility (source/container + decoder plugins) is acknowledged but deferred
  * Phase 6 remains focused on presentation and output

---

## Rationale

This PR formalizes conclusions reached during Phase 5 stabilization:

* most target output ecosystems are naturally described as **desired output shape**
* declarative presentation aligns cleanly with the existing `PresentationPlan` boundary
* encoder plugins provide a clean separation between **what** is requested and **how** it is materialized
* attempting to design input plugins and declarative presentations together would introduce unnecessary complexity

---

## Impact

* establishes a clear architectural direction for Phase 6
* enables work on declarative presentation specifications to begin
* clarifies that input plugin architecture will be addressed in a future phase

No functional changes are introduced in this PR.

---

## Next steps

* implement a declarative presentation model and interpreter
* express existing/simple views declaratively
* introduce a real encoder plugin (likely ISO) to validate end-to-end behaviour
