### PR TITLE
test(output): validate flat presentation parity for simple cases

### DIFF
--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -73,7 +73,7 @@ fn try_compile_rule(
         SelectSpec::Text => match_text(item),
     }?;
 
-    let proposed_name = build_name(&rule.naming, item, &rule.artifact)?;
+    let proposed_name = build_name(&rule.naming, item, &rule.artifact, policy)?;
     let proposed_name = apply_extension(proposed_name, rule.artifact.format);
     let allocated_name = policy.resolve_name_conflict(&proposed_name, root_names);
     root_names.push(allocated_name.clone());
@@ -166,12 +166,27 @@ fn build_name(
     naming: &NamingSpec,
     item: &NormalizedContent,
     artifact: &ArtifactSpec,
+    policy: &PolicySet,
 ) -> Option<String> {
     match naming {
         NamingSpec::GameTitle => game_title(item),
+        NamingSpec::PartName => part_name(item, policy),
         NamingSpec::SourceName => source_name(item, artifact),
         NamingSpec::Literal(value) => Some(value.clone()),
     }
+}
+
+fn part_name(item: &NormalizedContent, policy: &PolicySet) -> Option<String> {
+    let NormalizedContent::Game(game) = item else {
+        return None;
+    };
+
+    if game.parts.len() != 1 {
+        return None;
+    }
+
+    let part = &game.parts[0];
+    Some(policy.naming().part_name(game, part))
 }
 
 fn game_title(item: &NormalizedContent) -> Option<String> {
@@ -215,10 +230,21 @@ fn strip_known_extension(file_name: &str, format: Option<Format>) -> String {
 }
 
 fn apply_extension(name: String, format: Option<Format>) -> String {
-    match extension_for_format(format) {
-        Some(ext) if !name.ends_with(&format!(".{ext}")) => format!("{name}.{ext}"),
-        _ => name,
+    if has_extension(&name) {
+        return name;
     }
+
+    match extension_for_format(format) {
+        Some(ext) => format!("{name}.{ext}"),
+        None => name,
+    }
+}
+
+fn has_extension(name: &str) -> bool {
+    std::path::Path::new(name)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some()
 }
 
 fn extension_for_format(format: Option<Format>) -> Option<&'static str> {

--- a/src/output/presentation_spec.rs
+++ b/src/output/presentation_spec.rs
@@ -77,12 +77,10 @@ pub enum NamingSpec {
     /// Use the game title, with any file extension supplied later by
     /// compilation/materialization rules.
     GameTitle,
-
     /// Use the source-derived or content-derived name.
-    ///
     /// The exact resolution of this name is deferred to the compiler.
+    PartName,
     SourceName,
-
     /// Use a fixed literal file name.
     Literal(String),
 }

--- a/tests/presentation_compile_flat.rs
+++ b/tests/presentation_compile_flat.rs
@@ -1,0 +1,167 @@
+#[cfg(test)]
+mod flat_parity_tests {
+    use retromount::core::content::{
+        BytesContent, ContentId, DiscPart, GameContent, GamePart, NormalizedContent, Platform,
+        TextContent,
+    };
+    use retromount::core::source::SourceRef;
+    use retromount::output::capabilities::{ContentType, Format};
+    use retromount::output::flat_presenter::FlatPresenter;
+    use retromount::output::plan::{PlanEntry, PresentationPlan};
+    use retromount::output::present::OutputPresenter;
+    use retromount::output::presentation_compile::compile_presentation_spec;
+    use retromount::output::presentation_spec::{
+        ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
+    };
+    use retromount::policy::{
+        default::{DefaultConflictPolicy, DefaultFormattingPolicy, DefaultNamingPolicy},
+        PolicySet,
+    };
+
+    fn test_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(DefaultNamingPolicy),
+            Box::new(DefaultFormattingPolicy),
+            Box::new(DefaultConflictPolicy),
+        )
+    }
+
+    fn flat_spec_for_single_disc() -> PresentationSpec {
+        PresentationSpec::new(
+            LayoutSpec::Flat,
+            vec![FileRuleSpec::new(
+                SelectSpec::SingleDiscGames,
+                NamingSpec::PartName,
+                ArtifactSpec::new(ContentType::Disc).with_format(Format::Bin),
+            )],
+        )
+    }
+
+    fn flat_spec_for_bytes() -> PresentationSpec {
+        PresentationSpec::new(
+            LayoutSpec::Flat,
+            vec![FileRuleSpec::new(
+                SelectSpec::Bytes,
+                NamingSpec::SourceName,
+                ArtifactSpec::new(ContentType::Bytes).with_format(Format::Bin),
+            )],
+        )
+    }
+
+    fn flat_spec_for_text() -> PresentationSpec {
+        PresentationSpec::new(
+            LayoutSpec::Flat,
+            vec![FileRuleSpec::new(
+                SelectSpec::Text,
+                NamingSpec::SourceName,
+                ArtifactSpec::new(ContentType::Text).with_format(Format::Text),
+            )],
+        )
+    }
+
+    #[test]
+    fn single_disc_game_matches_flat_presenter() {
+        let content = vec![NormalizedContent::Game(GameContent {
+            id: ContentId::new("ps2:ico"),
+            source: SourceRef::new("file:/roms/ico.chd"),
+            title: "ICO".to_string(),
+            platform: Platform::Unknown,
+            parts: vec![GamePart::Disc(DiscPart {
+                source: SourceRef::new("file:/roms/ico.chd"),
+                disc_number: 1,
+                consumed_sources: vec![],
+            })],
+            consumed_sources: vec![],
+        })];
+
+        let policy = test_policy();
+
+        // Old path
+        let presenter_plan = FlatPresenter::new().present(&content, &policy);
+
+        // New path
+        let spec = flat_spec_for_single_disc();
+        let compiled_plan = compile_presentation_spec(&spec, &content, &policy);
+
+        assert_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
+    fn assert_plan_equivalent(expected: &PresentationPlan, actual: &PresentationPlan) {
+        assert_eq!(expected.entries.len(), actual.entries.len());
+
+        for (expected_entry, actual_entry) in expected.entries.iter().zip(actual.entries.iter()) {
+            match (expected_entry, actual_entry) {
+                (PlanEntry::File(expected_file), PlanEntry::File(actual_file)) => {
+                    println!("expected name: {}", expected_file.name);
+                    println!(
+                        "expected content_type: {:?}",
+                        expected_file.artifact.requirements.content_type
+                    );
+                    println!(
+                        "expected format: {:?}",
+                        expected_file.artifact.requirements.format
+                    );
+
+                    println!("actual name: {}", actual_file.name);
+                    println!(
+                        "actual content_type: {:?}",
+                        actual_file.artifact.requirements.content_type
+                    );
+                    println!(
+                        "actual format: {:?}",
+                        actual_file.artifact.requirements.format
+                    );
+
+                    assert_eq!(expected_file.name, actual_file.name);
+
+                    assert_eq!(
+                        expected_file.artifact.requirements.content_type,
+                        actual_file.artifact.requirements.content_type
+                    );
+
+                    assert_eq!(
+                        expected_file.artifact.requirements.format,
+                        actual_file.artifact.requirements.format
+                    );
+                }
+                _ => panic!("expected matching file entries"),
+            }
+        }
+    }
+
+    #[test]
+    fn bytes_content_matches_flat_presenter() {
+        let content = vec![NormalizedContent::Bytes(BytesContent {
+            id: ContentId::new("bytes:manual"),
+            source: SourceRef::new("file:/roms/manual"),
+            size: 123,
+        })];
+
+        let policy = test_policy();
+
+        let presenter_plan = FlatPresenter::new().present(&content, &policy);
+
+        let spec = flat_spec_for_bytes();
+        let compiled_plan = compile_presentation_spec(&spec, &content, &policy);
+
+        assert_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
+    #[test]
+    fn text_content_matches_flat_presenter() {
+        let content = vec![NormalizedContent::Text(TextContent {
+            id: ContentId::new("text:readme"),
+            source: SourceRef::new("file:/roms/readme"),
+            size: 42,
+        })];
+
+        let policy = test_policy();
+
+        let presenter_plan = FlatPresenter::new().present(&content, &policy);
+
+        let spec = flat_spec_for_text();
+        let compiled_plan = compile_presentation_spec(&spec, &content, &policy);
+
+        assert_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+}


### PR DESCRIPTION
## Summary

Adds integration tests comparing simple `FlatPresenter` output against the new declarative presentation path.

This validates that `PresentationSpec` + `compile_presentation_spec(...)` can reproduce a small but real subset of current flat presentation behavior.

The covered cases are:

* single-disc game output
* bytes content output
* text content output

## Why

Phase 6 is about replacing presenter implementations with presentations as declarative data.

To make that migration safe, the new path needs to be compared directly against the existing presenter behavior rather than only tested in isolation.

This PR provides that first parity proof for simple flat cases.

## Scope

This PR includes:

* integration tests under `tests/`
* comparison of `FlatPresenter` output with spec-compiled output
* minimal supporting refinements needed to align the new path with current flat semantics

In particular, this work surfaced and codified an important flat behavior:

* single-disc flat output uses part-based naming
* disc artifact requirements remain `Disc + Bin`
* presented file naming is not always derived directly from artifact format

## Design notes

The parity scope is intentionally narrow.

This PR does **not** attempt to cover:

* multi-disc output
* playlist generation
* grouped presentation parity
* presenter removal
* CLI or engine migration

Those should follow in later Phase 6 steps.

## Result

The new declarative path now matches existing flat presenter behavior for:

* simple single-disc games
* bytes content
* text content

This provides a concrete migration checkpoint and validates that the compiler/spec model is capable of reproducing real legacy semantics.

## Follow-up

Expected next steps after this PR:

1. Decide the next migration slice (for example grouped parity or a real target spec such as PS2 / OPL)
2. Extend the spec only where real behavior requires it
3. Continue replacing presenter-based behavior incrementally rather than through a big-bang rewrite
