### PR TITLE
feat(output): complete declarative presentation parity

### DIFF
--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -1,8 +1,9 @@
 use crate::core::content::{ContentMeta, GameContent, GamePart, NormalizedContent};
+use crate::core::source::SourceRef;
 use crate::output::capabilities::{CapabilityRequirements, Format};
 use crate::output::plan::{
-    ArtifactId, ArtifactRequest, PlanEntry, PlanFile, PlannedArtifactKind, PresentationPlan,
-    SourceArtifact,
+    ArtifactId, ArtifactRequest, PlanDirectory, PlanEntry, PlanFile, PlannedArtifactKind,
+    PresentationPlan, SourceArtifact,
 };
 use crate::output::presentation_spec::{
     ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
@@ -13,10 +14,10 @@ use crate::policy::PolicySet;
 ///
 /// This initial compiler is intentionally minimal:
 ///
-/// - supports flat layout only
-/// - emits files only
+/// - supports flat layout and a minimal grouped layout
+/// - emits files and simple directories only
 /// - supports single-source artifacts only
-/// - does not yet handle grouped layouts, playlists, or generated artifacts
+/// - does not yet handle playlists or generated artifacts
 pub fn compile_presentation_spec(
     spec: &PresentationSpec,
     content: &[NormalizedContent],
@@ -24,6 +25,9 @@ pub fn compile_presentation_spec(
 ) -> PresentationPlan {
     match spec.layout {
         LayoutSpec::Flat => compile_flat(spec, content, policy),
+        LayoutSpec::GroupedByPlatformAndGame => {
+            compile_grouped_by_platform_and_game(spec, content, policy)
+        }
     }
 }
 
@@ -44,6 +48,34 @@ fn compile_flat(
     PresentationPlan::new(entries)
 }
 
+fn compile_grouped_by_platform_and_game(
+    spec: &PresentationSpec,
+    content: &[NormalizedContent],
+    policy: &PolicySet,
+) -> PresentationPlan {
+    let mut root_entries = Vec::new();
+
+    for item in content {
+        let NormalizedContent::Game(game) = item else {
+            continue;
+        };
+
+        let Some(file) = compile_item_to_file(spec, item, policy) else {
+            continue;
+        };
+
+        let platform_name = policy.format_name(&policy.naming().platform_name(&game.platform));
+        let game_dir_name = policy.format_name(&policy.naming().game_name(game));
+
+        let game_dir = PlanDirectory::new(game_dir_name, vec![PlanEntry::File(file)]);
+        let platform_dir = PlanDirectory::new(platform_name, vec![PlanEntry::Directory(game_dir)]);
+
+        root_entries.push(PlanEntry::Directory(platform_dir));
+    }
+
+    PresentationPlan::new(root_entries)
+}
+
 fn compile_item(
     spec: &PresentationSpec,
     item: &NormalizedContent,
@@ -52,6 +84,22 @@ fn compile_item(
 ) -> Option<PlanFile> {
     for rule in &spec.files {
         if let Some(file) = try_compile_rule(rule, item, policy, root_names) {
+            return Some(file);
+        }
+    }
+
+    None
+}
+
+fn compile_item_to_file(
+    spec: &PresentationSpec,
+    item: &NormalizedContent,
+    policy: &PolicySet,
+) -> Option<PlanFile> {
+    let mut names = Vec::new();
+
+    for rule in &spec.files {
+        if let Some(file) = try_compile_rule(rule, item, policy, &mut names) {
             return Some(file);
         }
     }
@@ -91,7 +139,7 @@ fn try_compile_rule(
 }
 
 struct SourceMatch {
-    source: crate::core::source::SourceRef,
+    source: SourceRef,
     size: u64,
 }
 
@@ -117,7 +165,6 @@ fn match_single_disc_game(item: &NormalizedContent) -> Option<SourceMatch> {
     match &game.parts[0] {
         GamePart::Disc(disc) => Some(SourceMatch {
             source: disc.source.clone(),
-            // Current presenter code also lacks authoritative disc size here.
             size: 0,
         }),
         GamePart::Rom(_) => None,
@@ -176,6 +223,13 @@ fn build_name(
     }
 }
 
+fn game_title(item: &NormalizedContent) -> Option<String> {
+    match item {
+        NormalizedContent::Game(game) => Some(game.title.clone()),
+        _ => None,
+    }
+}
+
 fn part_name(item: &NormalizedContent, policy: &PolicySet) -> Option<String> {
     let NormalizedContent::Game(game) = item else {
         return None;
@@ -187,13 +241,6 @@ fn part_name(item: &NormalizedContent, policy: &PolicySet) -> Option<String> {
 
     let part = &game.parts[0];
     Some(policy.naming().part_name(game, part))
-}
-
-fn game_title(item: &NormalizedContent) -> Option<String> {
-    match item {
-        NormalizedContent::Game(game) => Some(game.title.clone()),
-        _ => None,
-    }
 }
 
 fn source_name(item: &NormalizedContent, artifact: &ArtifactSpec) -> Option<String> {
@@ -307,12 +354,11 @@ fn build_requirements(spec: &ArtifactSpec) -> CapabilityRequirements {
 mod tests {
     use super::*;
     use crate::core::content::{
-        BytesContent, ContentId, GameContent, GamePart, Platform, TextContent,
+        BytesContent, ContentId, DiscPart, GameContent, GamePart, Platform, TextContent,
     };
-    use crate::core::source::SourceRef;
     use crate::policy::{
-        default::DefaultConflictPolicy, default::DefaultFormattingPolicy,
-        default::DefaultNamingPolicy, PolicySet,
+        default::{DefaultConflictPolicy, DefaultFormattingPolicy, DefaultNamingPolicy},
+        PolicySet,
     };
 
     fn test_policy() -> PolicySet {
@@ -329,9 +375,9 @@ mod tests {
             LayoutSpec::Flat,
             vec![FileRuleSpec::new(
                 SelectSpec::SingleDiscGames,
-                NamingSpec::GameTitle,
+                NamingSpec::PartName,
                 ArtifactSpec::new(crate::output::capabilities::ContentType::Disc)
-                    .with_format(Format::Iso),
+                    .with_format(Format::Bin),
             )],
         );
 
@@ -340,7 +386,7 @@ mod tests {
             source: SourceRef::new("file:/roms/Shadow of the Colossus.chd"),
             title: "Shadow of the Colossus".to_string(),
             platform: Platform::Unknown,
-            parts: vec![GamePart::Disc(crate::core::content::DiscPart {
+            parts: vec![GamePart::Disc(DiscPart {
                 source: SourceRef::new("file:/roms/Shadow of the Colossus.chd"),
                 disc_number: 1,
                 consumed_sources: vec![],
@@ -356,12 +402,12 @@ mod tests {
             panic!("expected file entry");
         };
 
-        assert_eq!(file.name, "Shadow of the Colossus.iso");
+        assert_eq!(file.name, "Shadow of the Colossus (Disc 1).cue");
         assert_eq!(
             file.artifact.requirements.content_type,
             crate::output::capabilities::ContentType::Disc
         );
-        assert_eq!(file.artifact.requirements.format, Some(Format::Iso));
+        assert_eq!(file.artifact.requirements.format, Some(Format::Bin));
     }
 
     #[test]

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -1,10 +1,11 @@
 use crate::core::content::{ContentMeta, GameContent, GamePart, NormalizedContent};
 use crate::core::source::SourceRef;
-use crate::output::capabilities::{CapabilityRequirements, Format};
+use crate::output::capabilities::{CapabilityRequirements, ContentType, Format};
 use crate::output::plan::{
-    ArtifactId, ArtifactRequest, PlanDirectory, PlanEntry, PlanFile, PlannedArtifactKind,
-    PresentationPlan, SourceArtifact,
+    ArtifactId, ArtifactReference, ArtifactRequest, GeneratedArtifact, PlanDirectory, PlanEntry,
+    PlanFile, PlannedArtifactKind, PlaylistArtifact, PresentationPlan, SourceArtifact,
 };
+use crate::output::presentation_expansion::{is_multi_disc_game, sorted_disc_parts};
 use crate::output::presentation_spec::{
     ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
 };
@@ -17,7 +18,7 @@ use crate::policy::PolicySet;
 /// - supports flat layout and a minimal grouped layout
 /// - emits files and simple directories only
 /// - supports single-source artifacts only
-/// - does not yet handle playlists or generated artifacts
+/// - supports generated playlists for multi-disc games
 pub fn compile_presentation_spec(
     spec: &PresentationSpec,
     content: &[NormalizedContent],
@@ -40,7 +41,7 @@ fn compile_flat(
     let mut root_names = Vec::new();
 
     for item in content {
-        if let Some(file) = compile_item(spec, item, policy, &mut root_names) {
+        for file in compile_item(spec, item, policy, &mut root_names) {
             entries.push(PlanEntry::File(file));
         }
     }
@@ -60,14 +61,18 @@ fn compile_grouped_by_platform_and_game(
             continue;
         };
 
-        let Some(file) = compile_item_to_file(spec, item, policy) else {
+        let files = compile_item_to_files(spec, item, policy);
+        if files.is_empty() {
             continue;
-        };
+        }
 
         let platform_name = policy.format_name(&policy.naming().platform_name(&game.platform));
         let game_dir_name = policy.format_name(&policy.naming().game_name(game));
 
-        let game_dir = PlanDirectory::new(game_dir_name, vec![PlanEntry::File(file)]);
+        let game_dir = PlanDirectory::new(
+            game_dir_name,
+            files.into_iter().map(PlanEntry::File).collect(),
+        );
         let platform_dir = PlanDirectory::new(platform_name, vec![PlanEntry::Directory(game_dir)]);
 
         root_entries.push(PlanEntry::Directory(platform_dir));
@@ -81,30 +86,23 @@ fn compile_item(
     item: &NormalizedContent,
     policy: &PolicySet,
     root_names: &mut Vec<String>,
-) -> Option<PlanFile> {
+) -> Vec<PlanFile> {
+    let mut files = Vec::new();
+
     for rule in &spec.files {
-        if let Some(file) = try_compile_rule(rule, item, policy, root_names) {
-            return Some(file);
-        }
+        files.extend(try_compile_rule(rule, item, policy, root_names));
     }
 
-    None
+    files
 }
 
-fn compile_item_to_file(
+fn compile_item_to_files(
     spec: &PresentationSpec,
     item: &NormalizedContent,
     policy: &PolicySet,
-) -> Option<PlanFile> {
+) -> Vec<PlanFile> {
     let mut names = Vec::new();
-
-    for rule in &spec.files {
-        if let Some(file) = try_compile_rule(rule, item, policy, &mut names) {
-            return Some(file);
-        }
-    }
-
-    None
+    compile_item(spec, item, policy, &mut names)
 }
 
 fn try_compile_rule(
@@ -112,16 +110,27 @@ fn try_compile_rule(
     item: &NormalizedContent,
     policy: &PolicySet,
     root_names: &mut Vec<String>,
-) -> Option<PlanFile> {
+) -> Vec<PlanFile> {
+    if rule.select == SelectSpec::MultiDiscGames {
+        return try_compile_multi_disc_rule(rule, item, policy, root_names);
+    }
+
     let match_result = match rule.select {
         SelectSpec::Games => match_game(item),
         SelectSpec::SingleDiscGames => match_single_disc_game(item),
+        SelectSpec::MultiDiscGames => unreachable!("handled above"),
         SelectSpec::SingleRomGames => match_single_rom_game(item),
         SelectSpec::Bytes => match_bytes(item),
         SelectSpec::Text => match_text(item),
-    }?;
+    };
 
-    let proposed_name = build_name(&rule.naming, item, &rule.artifact, policy)?;
+    let Some(match_result) = match_result else {
+        return Vec::new();
+    };
+
+    let Some(proposed_name) = build_name(&rule.naming, item, &rule.artifact, policy) else {
+        return Vec::new();
+    };
     let proposed_name = apply_extension(proposed_name, rule.artifact.format);
     let allocated_name = policy.resolve_name_conflict(&proposed_name, root_names);
     root_names.push(allocated_name.clone());
@@ -135,7 +144,83 @@ fn try_compile_rule(
         build_requirements(&rule.artifact),
     );
 
-    Some(PlanFile::new(allocated_name, artifact))
+    vec![PlanFile::new(allocated_name, artifact)]
+}
+
+fn try_compile_multi_disc_rule(
+    rule: &FileRuleSpec,
+    item: &NormalizedContent,
+    policy: &PolicySet,
+    names: &mut Vec<String>,
+) -> Vec<PlanFile> {
+    let NormalizedContent::Game(game) = item else {
+        return Vec::new();
+    };
+
+    if !is_multi_disc_game(game) {
+        return Vec::new();
+    }
+
+    match rule.artifact.content_type {
+        ContentType::Disc => sorted_disc_parts(game)
+            .into_iter()
+            .filter_map(|disc| {
+                let proposed_name = match &rule.naming {
+                    NamingSpec::PartName => policy
+                        .naming()
+                        .part_name(game, &GamePart::Disc(disc.clone())),
+                    _ => build_name(&rule.naming, item, &rule.artifact, policy)?,
+                };
+                let proposed_name = apply_extension(proposed_name, rule.artifact.format);
+                let allocated_name = policy.resolve_name_conflict(&proposed_name, names);
+                names.push(allocated_name.clone());
+
+                let artifact_id =
+                    ArtifactId::new(format!("game:{}:disc:{}", game.id, disc.disc_number));
+                Some(PlanFile::new(
+                    allocated_name,
+                    ArtifactRequest::new(
+                        artifact_id,
+                        PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                            disc.source.clone(),
+                            0,
+                        )),
+                        build_requirements(&rule.artifact),
+                    ),
+                ))
+            })
+            .collect(),
+        ContentType::Playlist => {
+            let Some(proposed_name) = build_name(&rule.naming, item, &rule.artifact, policy) else {
+                return Vec::new();
+            };
+            let proposed_name = apply_extension(proposed_name, rule.artifact.format);
+            let allocated_name = policy.resolve_name_conflict(&proposed_name, names);
+            names.push(allocated_name.clone());
+
+            let references = sorted_disc_parts(game)
+                .into_iter()
+                .map(|disc| {
+                    ArtifactReference::new(ArtifactId::new(format!(
+                        "game:{}:disc:{}",
+                        game.id, disc.disc_number
+                    )))
+                })
+                .collect();
+
+            vec![PlanFile::new(
+                allocated_name,
+                ArtifactRequest::new(
+                    ArtifactId::new(format!("game:{}:playlist", game.id)),
+                    PlannedArtifactKind::Generated(GeneratedArtifact::Playlist(
+                        PlaylistArtifact::new(references),
+                    )),
+                    build_requirements(&rule.artifact),
+                ),
+            )]
+        }
+        _ => Vec::new(),
+    }
 }
 
 struct SourceMatch {
@@ -218,8 +303,16 @@ fn build_name(
     match naming {
         NamingSpec::GameTitle => game_title(item),
         NamingSpec::PartName => part_name(item, policy),
+        NamingSpec::PlaylistName => playlist_name(item, policy),
         NamingSpec::SourceName => source_name(item, artifact),
         NamingSpec::Literal(value) => Some(value.clone()),
+    }
+}
+
+fn playlist_name(item: &NormalizedContent, policy: &PolicySet) -> Option<String> {
+    match item {
+        NormalizedContent::Game(game) => Some(policy.naming().playlist_name(game)),
+        _ => None,
     }
 }
 
@@ -313,10 +406,13 @@ fn build_artifact_id(select: &SelectSpec, item: &NormalizedContent) -> ArtifactI
             ArtifactId::new(format!("game:{}", game.id))
         }
         (SelectSpec::SingleDiscGames, NormalizedContent::Game(game)) => {
-            ArtifactId::new(format!("game:{}:disc", game.id))
+            ArtifactId::new(format!("game:{}", game.id))
+        }
+        (SelectSpec::MultiDiscGames, NormalizedContent::Game(game)) => {
+            ArtifactId::new(format!("game:{}", game.id))
         }
         (SelectSpec::SingleRomGames, NormalizedContent::Game(game)) => {
-            ArtifactId::new(format!("game:{}:rom", game.id))
+            ArtifactId::new(format!("game:{}", game.id))
         }
         (SelectSpec::Bytes, NormalizedContent::Bytes(bytes)) => {
             ArtifactId::new(format!("bytes:{}", bytes.id))

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -54,31 +54,37 @@ fn compile_grouped_by_platform_and_game(
     content: &[NormalizedContent],
     policy: &PolicySet,
 ) -> PresentationPlan {
-    let mut root_entries = Vec::new();
+    let mut root = PlanDirectory::new("", Vec::new());
 
     for item in content {
-        let NormalizedContent::Game(game) = item else {
-            continue;
-        };
+        match item {
+            NormalizedContent::Game(game) => {
+                let platform_name =
+                    policy.format_name(&policy.naming().platform_name(&game.platform));
+                let game_dir_name = policy.format_name(&policy.naming().game_name(game));
 
-        let files = compile_item_to_files(spec, item, policy);
-        if files.is_empty() {
-            continue;
+                let platform_dir = ensure_directory(&mut root, &[platform_name], policy);
+                let game_dir =
+                    ensure_distinct_child_directory(platform_dir, &game_dir_name, policy);
+                let mut names = child_names(game_dir);
+
+                for file in compile_item(spec, item, policy, &mut names) {
+                    game_dir.entries.push(PlanEntry::File(file));
+                }
+            }
+            NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
+                let (parents, _) = split_parent_dirs(&item.id().to_string());
+                let directory = ensure_directory(&mut root, &parents, policy);
+                let mut names = child_names(directory);
+
+                for file in compile_item(spec, item, policy, &mut names) {
+                    directory.entries.push(PlanEntry::File(file));
+                }
+            }
         }
-
-        let platform_name = policy.format_name(&policy.naming().platform_name(&game.platform));
-        let game_dir_name = policy.format_name(&policy.naming().game_name(game));
-
-        let game_dir = PlanDirectory::new(
-            game_dir_name,
-            files.into_iter().map(PlanEntry::File).collect(),
-        );
-        let platform_dir = PlanDirectory::new(platform_name, vec![PlanEntry::Directory(game_dir)]);
-
-        root_entries.push(PlanEntry::Directory(platform_dir));
     }
 
-    PresentationPlan::new(root_entries)
+    PresentationPlan::new(root.entries)
 }
 
 fn compile_item(
@@ -94,15 +100,6 @@ fn compile_item(
     }
 
     files
-}
-
-fn compile_item_to_files(
-    spec: &PresentationSpec,
-    item: &NormalizedContent,
-    policy: &PolicySet,
-) -> Vec<PlanFile> {
-    let mut names = Vec::new();
-    compile_item(spec, item, policy, &mut names)
 }
 
 fn try_compile_rule(
@@ -221,6 +218,96 @@ fn try_compile_multi_disc_rule(
         }
         _ => Vec::new(),
     }
+}
+
+fn normalize_path(path: &str) -> String {
+    path.replace('\\', "/").trim_matches('/').to_string()
+}
+
+fn split_parent_dirs(path: &str) -> (Vec<String>, String) {
+    let normalized = normalize_path(path);
+
+    match normalized.rsplit_once('/') {
+        Some((parent, file_name)) => (
+            parent
+                .split('/')
+                .filter(|segment| !segment.is_empty())
+                .map(str::to_string)
+                .collect(),
+            file_name.to_string(),
+        ),
+        None => (Vec::new(), normalized),
+    }
+}
+
+fn ensure_directory<'a>(
+    root: &'a mut PlanDirectory,
+    parents: &[String],
+    policy: &PolicySet,
+) -> &'a mut PlanDirectory {
+    let mut current = root;
+
+    for segment in parents {
+        let existing_index = current
+            .entries
+            .iter()
+            .position(|entry| matches!(entry, PlanEntry::Directory(dir) if dir.name == *segment));
+
+        let index = match existing_index {
+            Some(index) => index,
+            None => {
+                let resolved_name = policy.resolve_name_conflict(segment, &child_names(current));
+                current
+                    .entries
+                    .push(PlanEntry::Directory(PlanDirectory::new(
+                        &resolved_name,
+                        Vec::new(),
+                    )));
+                current
+                    .entries
+                    .iter()
+                    .position(
+                        |entry| matches!(entry, PlanEntry::Directory(dir) if dir.name == resolved_name),
+                    )
+                    .expect("inserted directory should be present")
+            }
+        };
+
+        current = match current.entries.get_mut(index) {
+            Some(PlanEntry::Directory(directory)) => directory,
+            _ => unreachable!("directory entry should be a directory"),
+        };
+    }
+
+    current
+}
+
+fn ensure_distinct_child_directory<'a>(
+    parent: &'a mut PlanDirectory,
+    proposed: &str,
+    policy: &PolicySet,
+) -> &'a mut PlanDirectory {
+    let resolved_name = policy.resolve_name_conflict(proposed, &child_names(parent));
+    parent.entries.push(PlanEntry::Directory(PlanDirectory::new(
+        &resolved_name,
+        Vec::new(),
+    )));
+
+    match parent.entries.last_mut() {
+        Some(PlanEntry::Directory(directory)) => directory,
+        _ => unreachable!("inserted child should be a directory"),
+    }
+}
+
+fn child_names(directory: &PlanDirectory) -> Vec<String> {
+    directory
+        .entries
+        .iter()
+        .map(|entry| match entry {
+            PlanEntry::Directory(directory) => directory.name.clone(),
+            PlanEntry::File(file) => file.name.clone(),
+        })
+        .collect()
 }
 
 struct SourceMatch {

--- a/src/output/presentation_spec.rs
+++ b/src/output/presentation_spec.rs
@@ -52,6 +52,9 @@ pub enum SelectSpec {
     /// Match games with exactly one disc part.
     SingleDiscGames,
 
+    /// Match games consisting entirely of multiple disc parts.
+    MultiDiscGames,
+
     /// Match games with exactly one ROM part.
     SingleRomGames,
 
@@ -69,6 +72,9 @@ pub enum NamingSpec {
 
     /// Use the policy-derived part name for a single-part game.
     PartName,
+
+    /// Use the policy-derived playlist name for a game.
+    PlaylistName,
 
     /// Use a source-derived/content-derived name.
     SourceName,

--- a/src/output/presentation_spec.rs
+++ b/src/output/presentation_spec.rs
@@ -7,16 +7,8 @@ use crate::output::capabilities::{CapabilityFeature, ContentType, Format};
 /// A `PresentationSpec` describes desired output structure and artifact
 /// requirements as data. Specs are later compiled into `PresentationPlan`.
 ///
-/// This initial model is intentionally minimal:
-///
-/// - one top-level layout choice
-/// - a flat list of file rules
-/// - simple content selection
-/// - simple naming
-/// - artifact requirements that align with encoder capability resolution
-///
-/// It is expected to evolve incrementally as real presentation use cases
-/// require more expressive power.
+/// This initial model is intentionally minimal and will be extended only as
+/// real presentation use cases require it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PresentationSpec {
     pub layout: LayoutSpec,
@@ -32,6 +24,7 @@ impl PresentationSpec {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LayoutSpec {
     Flat,
+    GroupedByPlatformAndGame,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,9 +47,6 @@ impl FileRuleSpec {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SelectSpec {
     /// Match any normalized game.
-    ///
-    /// This is deliberately broad and may later be refined or replaced by a
-    /// richer matching model once compilation needs make that necessary.
     Games,
 
     /// Match games with exactly one disc part.
@@ -74,13 +64,15 @@ pub enum SelectSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NamingSpec {
-    /// Use the game title, with any file extension supplied later by
-    /// compilation/materialization rules.
+    /// Use the game title.
     GameTitle,
-    /// Use the source-derived or content-derived name.
-    /// The exact resolution of this name is deferred to the compiler.
+
+    /// Use the policy-derived part name for a single-part game.
     PartName,
+
+    /// Use a source-derived/content-derived name.
     SourceName,
+
     /// Use a fixed literal file name.
     Literal(String),
 }
@@ -136,17 +128,17 @@ mod tests {
             LayoutSpec::Flat,
             vec![FileRuleSpec::new(
                 SelectSpec::SingleDiscGames,
-                NamingSpec::GameTitle,
-                ArtifactSpec::new(ContentType::Disc).with_format(Format::Iso),
+                NamingSpec::PartName,
+                ArtifactSpec::new(ContentType::Disc).with_format(Format::Bin),
             )],
         );
 
         assert_eq!(spec.layout, LayoutSpec::Flat);
         assert_eq!(spec.files.len(), 1);
         assert_eq!(spec.files[0].select, SelectSpec::SingleDiscGames);
-        assert_eq!(spec.files[0].naming, NamingSpec::GameTitle);
+        assert_eq!(spec.files[0].naming, NamingSpec::PartName);
         assert_eq!(spec.files[0].artifact.content_type, ContentType::Disc);
-        assert_eq!(spec.files[0].artifact.format, Some(Format::Iso));
+        assert_eq!(spec.files[0].artifact.format, Some(Format::Bin));
     }
 
     #[test]

--- a/tests/presentation_compile_flat.rs
+++ b/tests/presentation_compile_flat.rs
@@ -15,14 +15,41 @@ mod flat_parity_tests {
     };
     use retromount::policy::{
         default::{DefaultConflictPolicy, DefaultFormattingPolicy, DefaultNamingPolicy},
-        PolicySet,
+        ConflictPolicy, PolicySet,
     };
+
+    struct SuffixConflictPolicy;
+
+    impl ConflictPolicy for SuffixConflictPolicy {
+        fn resolve_name_conflict(&self, proposed: &str, existing: &[String]) -> String {
+            if !existing.iter().any(|name| name == proposed) {
+                return proposed.to_string();
+            }
+
+            let mut suffix = 1;
+            loop {
+                let candidate = format!("{proposed} ({suffix})");
+                if !existing.iter().any(|name| name == &candidate) {
+                    return candidate;
+                }
+                suffix += 1;
+            }
+        }
+    }
 
     fn test_policy() -> PolicySet {
         PolicySet::new(
             Box::new(DefaultNamingPolicy),
             Box::new(DefaultFormattingPolicy),
             Box::new(DefaultConflictPolicy),
+        )
+    }
+
+    fn suffix_conflict_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(DefaultNamingPolicy),
+            Box::new(DefaultFormattingPolicy),
+            Box::new(SuffixConflictPolicy),
         )
     }
 
@@ -59,6 +86,46 @@ mod flat_parity_tests {
         )
     }
 
+    fn flat_spec_for_multi_disc() -> PresentationSpec {
+        PresentationSpec::new(
+            LayoutSpec::Flat,
+            vec![
+                FileRuleSpec::new(
+                    SelectSpec::MultiDiscGames,
+                    NamingSpec::PartName,
+                    ArtifactSpec::new(ContentType::Disc).with_format(Format::Bin),
+                ),
+                FileRuleSpec::new(
+                    SelectSpec::MultiDiscGames,
+                    NamingSpec::PlaylistName,
+                    ArtifactSpec::new(ContentType::Playlist).with_format(Format::M3u),
+                ),
+            ],
+        )
+    }
+
+    fn multi_disc_game(id: &str) -> NormalizedContent {
+        NormalizedContent::Game(GameContent {
+            id: ContentId::new(id),
+            source: SourceRef::new(format!("file:/roms/{id}-disc1.cue")),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new(format!("file:/roms/{id}-disc2.cue")),
+                    disc_number: 2,
+                    consumed_sources: vec![],
+                }),
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new(format!("file:/roms/{id}-disc1.cue")),
+                    disc_number: 1,
+                    consumed_sources: vec![],
+                }),
+            ],
+            consumed_sources: vec![],
+        })
+    }
+
     #[test]
     fn single_disc_game_matches_flat_presenter() {
         let content = vec![NormalizedContent::Game(GameContent {
@@ -92,37 +159,8 @@ mod flat_parity_tests {
         for (expected_entry, actual_entry) in expected.entries.iter().zip(actual.entries.iter()) {
             match (expected_entry, actual_entry) {
                 (PlanEntry::File(expected_file), PlanEntry::File(actual_file)) => {
-                    println!("expected name: {}", expected_file.name);
-                    println!(
-                        "expected content_type: {:?}",
-                        expected_file.artifact.requirements.content_type
-                    );
-                    println!(
-                        "expected format: {:?}",
-                        expected_file.artifact.requirements.format
-                    );
-
-                    println!("actual name: {}", actual_file.name);
-                    println!(
-                        "actual content_type: {:?}",
-                        actual_file.artifact.requirements.content_type
-                    );
-                    println!(
-                        "actual format: {:?}",
-                        actual_file.artifact.requirements.format
-                    );
-
                     assert_eq!(expected_file.name, actual_file.name);
-
-                    assert_eq!(
-                        expected_file.artifact.requirements.content_type,
-                        actual_file.artifact.requirements.content_type
-                    );
-
-                    assert_eq!(
-                        expected_file.artifact.requirements.format,
-                        actual_file.artifact.requirements.format
-                    );
+                    assert_eq!(expected_file.artifact, actual_file.artifact);
                 }
                 _ => panic!("expected matching file entries"),
             }
@@ -161,6 +199,30 @@ mod flat_parity_tests {
 
         let spec = flat_spec_for_text();
         let compiled_plan = compile_presentation_spec(&spec, &content, &policy);
+
+        assert_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
+    #[test]
+    fn multi_disc_game_with_playlist_matches_flat_presenter() {
+        let content = vec![multi_disc_game("ff7")];
+        let policy = test_policy();
+
+        let presenter_plan = FlatPresenter::new().present(&content, &policy);
+        let compiled_plan =
+            compile_presentation_spec(&flat_spec_for_multi_disc(), &content, &policy);
+
+        assert_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
+    #[test]
+    fn duplicate_multi_disc_games_match_flat_presenter_conflict_handling() {
+        let content = vec![multi_disc_game("ff7-a"), multi_disc_game("ff7-b")];
+        let policy = suffix_conflict_policy();
+
+        let presenter_plan = FlatPresenter::new().present(&content, &policy);
+        let compiled_plan =
+            compile_presentation_spec(&flat_spec_for_multi_disc(), &content, &policy);
 
         assert_plan_equivalent(&presenter_plan, &compiled_plan);
     }

--- a/tests/presentation_compile_grouped.rs
+++ b/tests/presentation_compile_grouped.rs
@@ -36,6 +36,24 @@ mod grouped_parity_tests {
         )
     }
 
+    fn grouped_spec_for_multi_disc() -> PresentationSpec {
+        PresentationSpec::new(
+            LayoutSpec::GroupedByPlatformAndGame,
+            vec![
+                FileRuleSpec::new(
+                    SelectSpec::MultiDiscGames,
+                    NamingSpec::PartName,
+                    ArtifactSpec::new(ContentType::Disc).with_format(Format::Bin),
+                ),
+                FileRuleSpec::new(
+                    SelectSpec::MultiDiscGames,
+                    NamingSpec::PlaylistName,
+                    ArtifactSpec::new(ContentType::Playlist).with_format(Format::M3u),
+                ),
+            ],
+        )
+    }
+
     #[test]
     fn single_disc_game_matches_grouped_presenter() {
         let content = vec![NormalizedContent::Game(GameContent {
@@ -61,6 +79,36 @@ mod grouped_parity_tests {
         assert_grouped_plan_equivalent(&presenter_plan, &compiled_plan);
     }
 
+    #[test]
+    fn multi_disc_game_with_playlist_matches_grouped_presenter() {
+        let content = vec![NormalizedContent::Game(GameContent {
+            id: ContentId::new("ps1:final-fantasy-vii"),
+            source: SourceRef::new("file:/roms/Final Fantasy VII (Disc 1).cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new("file:/roms/Final Fantasy VII (Disc 2).cue"),
+                    disc_number: 2,
+                    consumed_sources: vec![],
+                }),
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new("file:/roms/Final Fantasy VII (Disc 1).cue"),
+                    disc_number: 1,
+                    consumed_sources: vec![],
+                }),
+            ],
+            consumed_sources: vec![],
+        })];
+
+        let policy = test_policy();
+        let presenter_plan = GroupedPresenter::new().present(&content, &policy);
+        let compiled_plan =
+            compile_presentation_spec(&grouped_spec_for_multi_disc(), &content, &policy);
+
+        assert_grouped_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
     fn assert_grouped_plan_equivalent(expected: &PresentationPlan, actual: &PresentationPlan) {
         assert_eq!(expected.entries.len(), actual.entries.len());
 
@@ -76,14 +124,7 @@ mod grouped_parity_tests {
             }
             (PlanEntry::File(expected_file), PlanEntry::File(actual_file)) => {
                 assert_eq!(expected_file.name, actual_file.name);
-                assert_eq!(
-                    expected_file.artifact.requirements.content_type,
-                    actual_file.artifact.requirements.content_type
-                );
-                assert_eq!(
-                    expected_file.artifact.requirements.format,
-                    actual_file.artifact.requirements.format
-                );
+                assert_eq!(expected_file.artifact, actual_file.artifact);
             }
             _ => panic!("expected matching entry kinds"),
         }

--- a/tests/presentation_compile_grouped.rs
+++ b/tests/presentation_compile_grouped.rs
@@ -15,14 +15,41 @@ mod grouped_parity_tests {
     };
     use retromount::policy::{
         default::{DefaultConflictPolicy, DefaultFormattingPolicy, DefaultNamingPolicy},
-        PolicySet,
+        ConflictPolicy, PolicySet,
     };
+
+    struct SuffixConflictPolicy;
+
+    impl ConflictPolicy for SuffixConflictPolicy {
+        fn resolve_name_conflict(&self, proposed: &str, existing: &[String]) -> String {
+            if !existing.iter().any(|name| name == proposed) {
+                return proposed.to_string();
+            }
+
+            let mut suffix = 1;
+            loop {
+                let candidate = format!("{proposed} ({suffix})");
+                if !existing.iter().any(|name| name == &candidate) {
+                    return candidate;
+                }
+                suffix += 1;
+            }
+        }
+    }
 
     fn test_policy() -> PolicySet {
         PolicySet::new(
             Box::new(DefaultNamingPolicy),
             Box::new(DefaultFormattingPolicy),
             Box::new(DefaultConflictPolicy),
+        )
+    }
+
+    fn suffix_conflict_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(DefaultNamingPolicy),
+            Box::new(DefaultFormattingPolicy),
+            Box::new(SuffixConflictPolicy),
         )
     }
 
@@ -176,6 +203,64 @@ mod grouped_parity_tests {
         ];
 
         let policy = test_policy();
+        let presenter_plan = GroupedPresenter::new().present(&content, &policy);
+        let compiled_plan =
+            compile_presentation_spec(&grouped_spec_for_mixed_content(), &content, &policy);
+
+        assert_grouped_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
+    #[test]
+    fn duplicate_game_directories_match_grouped_presenter_conflict_handling() {
+        let content = vec![
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("ps1:duplicate-one"),
+                source: SourceRef::new("file:/roms/duplicate-one.bin"),
+                title: "Duplicate Game".to_string(),
+                platform: Platform::Ps1,
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("file:/roms/duplicate-one.bin"),
+                    size: 100,
+                })],
+                consumed_sources: vec![],
+            }),
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("ps1:duplicate-two"),
+                source: SourceRef::new("file:/roms/duplicate-two.bin"),
+                title: "Duplicate Game".to_string(),
+                platform: Platform::Ps1,
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("file:/roms/duplicate-two.bin"),
+                    size: 200,
+                })],
+                consumed_sources: vec![],
+            }),
+        ];
+
+        let policy = suffix_conflict_policy();
+        let presenter_plan = GroupedPresenter::new().present(&content, &policy);
+        let compiled_plan =
+            compile_presentation_spec(&grouped_spec_for_mixed_content(), &content, &policy);
+
+        assert_grouped_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
+    #[test]
+    fn colliding_preserved_path_files_match_grouped_presenter_conflict_handling() {
+        let content = vec![
+            NormalizedContent::Bytes(BytesContent {
+                id: ContentId::new("firmware/primary"),
+                source: SourceRef::new("file:/roms/primary/bios"),
+                size: 512,
+            }),
+            NormalizedContent::Bytes(BytesContent {
+                id: ContentId::new("firmware/backup"),
+                source: SourceRef::new("file:/roms/backup/bios"),
+                size: 512,
+            }),
+        ];
+
+        let policy = suffix_conflict_policy();
         let presenter_plan = GroupedPresenter::new().present(&content, &policy);
         let compiled_plan =
             compile_presentation_spec(&grouped_spec_for_mixed_content(), &content, &policy);

--- a/tests/presentation_compile_grouped.rs
+++ b/tests/presentation_compile_grouped.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod grouped_parity_tests {
     use retromount::core::content::{
-        ContentId, DiscPart, GameContent, GamePart, NormalizedContent, Platform,
+        BytesContent, ContentId, DiscPart, GameContent, GamePart, NormalizedContent, Platform,
+        RomPart, TextContent,
     };
     use retromount::core::source::SourceRef;
     use retromount::output::capabilities::{ContentType, Format};
@@ -49,6 +50,34 @@ mod grouped_parity_tests {
                     SelectSpec::MultiDiscGames,
                     NamingSpec::PlaylistName,
                     ArtifactSpec::new(ContentType::Playlist).with_format(Format::M3u),
+                ),
+            ],
+        )
+    }
+
+    fn grouped_spec_for_mixed_content() -> PresentationSpec {
+        PresentationSpec::new(
+            LayoutSpec::GroupedByPlatformAndGame,
+            vec![
+                FileRuleSpec::new(
+                    SelectSpec::SingleRomGames,
+                    NamingSpec::PartName,
+                    ArtifactSpec::new(ContentType::Rom).with_format(Format::Bin),
+                ),
+                FileRuleSpec::new(
+                    SelectSpec::SingleDiscGames,
+                    NamingSpec::PartName,
+                    ArtifactSpec::new(ContentType::Disc).with_format(Format::Bin),
+                ),
+                FileRuleSpec::new(
+                    SelectSpec::Bytes,
+                    NamingSpec::SourceName,
+                    ArtifactSpec::new(ContentType::Bytes).with_format(Format::Bin),
+                ),
+                FileRuleSpec::new(
+                    SelectSpec::Text,
+                    NamingSpec::SourceName,
+                    ArtifactSpec::new(ContentType::Text).with_format(Format::Text),
                 ),
             ],
         )
@@ -105,6 +134,51 @@ mod grouped_parity_tests {
         let presenter_plan = GroupedPresenter::new().present(&content, &policy);
         let compiled_plan =
             compile_presentation_spec(&grouped_spec_for_multi_disc(), &content, &policy);
+
+        assert_grouped_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
+    #[test]
+    fn mixed_content_with_preserved_paths_matches_grouped_presenter() {
+        let content = vec![
+            NormalizedContent::Bytes(BytesContent {
+                id: ContentId::new(r"firmware\ps1\bios"),
+                source: SourceRef::new("file:/roms/firmware/ps1/scph1001"),
+                size: 512,
+            }),
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("megadrive:sonic"),
+                source: SourceRef::new("file:/roms/megadrive/sonic.bin"),
+                title: "Sonic the Hedgehog".to_string(),
+                platform: Platform::Megadrive,
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("file:/roms/megadrive/sonic.bin"),
+                    size: 1024,
+                })],
+                consumed_sources: vec![],
+            }),
+            NormalizedContent::Game(GameContent {
+                id: ContentId::new("megadrive:streets-of-rage"),
+                source: SourceRef::new("file:/roms/megadrive/streets-of-rage.bin"),
+                title: "Streets of Rage".to_string(),
+                platform: Platform::Megadrive,
+                parts: vec![GamePart::Rom(RomPart {
+                    source: SourceRef::new("file:/roms/megadrive/streets-of-rage.bin"),
+                    size: 2048,
+                })],
+                consumed_sources: vec![],
+            }),
+            NormalizedContent::Text(TextContent {
+                id: ContentId::new("docs/guides/readme"),
+                source: SourceRef::new("file:/roms/docs/guides/readme"),
+                size: 64,
+            }),
+        ];
+
+        let policy = test_policy();
+        let presenter_plan = GroupedPresenter::new().present(&content, &policy);
+        let compiled_plan =
+            compile_presentation_spec(&grouped_spec_for_mixed_content(), &content, &policy);
 
         assert_grouped_plan_equivalent(&presenter_plan, &compiled_plan);
     }

--- a/tests/presentation_compile_grouped.rs
+++ b/tests/presentation_compile_grouped.rs
@@ -1,0 +1,100 @@
+#[cfg(test)]
+mod grouped_parity_tests {
+    use retromount::core::content::{
+        ContentId, DiscPart, GameContent, GamePart, NormalizedContent, Platform,
+    };
+    use retromount::core::source::SourceRef;
+    use retromount::output::capabilities::{ContentType, Format};
+    use retromount::output::grouped_presenter::GroupedPresenter;
+    use retromount::output::plan::{PlanDirectory, PlanEntry, PresentationPlan};
+    use retromount::output::present::OutputPresenter;
+    use retromount::output::presentation_compile::compile_presentation_spec;
+    use retromount::output::presentation_spec::{
+        ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
+    };
+    use retromount::policy::{
+        default::{DefaultConflictPolicy, DefaultFormattingPolicy, DefaultNamingPolicy},
+        PolicySet,
+    };
+
+    fn test_policy() -> PolicySet {
+        PolicySet::new(
+            Box::new(DefaultNamingPolicy),
+            Box::new(DefaultFormattingPolicy),
+            Box::new(DefaultConflictPolicy),
+        )
+    }
+
+    fn grouped_spec_for_single_disc() -> PresentationSpec {
+        PresentationSpec::new(
+            LayoutSpec::GroupedByPlatformAndGame,
+            vec![FileRuleSpec::new(
+                SelectSpec::SingleDiscGames,
+                NamingSpec::PartName,
+                ArtifactSpec::new(ContentType::Disc).with_format(Format::Bin),
+            )],
+        )
+    }
+
+    #[test]
+    fn single_disc_game_matches_grouped_presenter() {
+        let content = vec![NormalizedContent::Game(GameContent {
+            id: ContentId::new("ps2:ico"),
+            source: SourceRef::new("file:/roms/ico.chd"),
+            title: "ICO".to_string(),
+            platform: Platform::Unknown,
+            parts: vec![GamePart::Disc(DiscPart {
+                source: SourceRef::new("file:/roms/ico.chd"),
+                disc_number: 1,
+                consumed_sources: vec![],
+            })],
+            consumed_sources: vec![],
+        })];
+
+        let policy = test_policy();
+
+        let presenter_plan = GroupedPresenter::new().present(&content, &policy);
+
+        let spec = grouped_spec_for_single_disc();
+        let compiled_plan = compile_presentation_spec(&spec, &content, &policy);
+
+        assert_grouped_plan_equivalent(&presenter_plan, &compiled_plan);
+    }
+
+    fn assert_grouped_plan_equivalent(expected: &PresentationPlan, actual: &PresentationPlan) {
+        assert_eq!(expected.entries.len(), actual.entries.len());
+
+        for (expected_entry, actual_entry) in expected.entries.iter().zip(actual.entries.iter()) {
+            assert_entry_equivalent(expected_entry, actual_entry);
+        }
+    }
+
+    fn assert_entry_equivalent(expected: &PlanEntry, actual: &PlanEntry) {
+        match (expected, actual) {
+            (PlanEntry::Directory(expected_dir), PlanEntry::Directory(actual_dir)) => {
+                assert_directory_equivalent(expected_dir, actual_dir);
+            }
+            (PlanEntry::File(expected_file), PlanEntry::File(actual_file)) => {
+                assert_eq!(expected_file.name, actual_file.name);
+                assert_eq!(
+                    expected_file.artifact.requirements.content_type,
+                    actual_file.artifact.requirements.content_type
+                );
+                assert_eq!(
+                    expected_file.artifact.requirements.format,
+                    actual_file.artifact.requirements.format
+                );
+            }
+            _ => panic!("expected matching entry kinds"),
+        }
+    }
+
+    fn assert_directory_equivalent(expected: &PlanDirectory, actual: &PlanDirectory) {
+        assert_eq!(expected.name, actual.name);
+        assert_eq!(expected.entries.len(), actual.entries.len());
+
+        for (expected_entry, actual_entry) in expected.entries.iter().zip(actual.entries.iter()) {
+            assert_entry_equivalent(expected_entry, actual_entry);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- compile grouped multi-disc games and generated M3U playlists from `PresentationSpec`
- preserve relative paths for grouped bytes and text content
- merge shared platform and path directories
- validate grouped conflict handling against the legacy presenter
- validate exact flat multi-disc and playlist parity

## Why

This completes the parity work needed before built-in runtime views can move from Rust-coded presenters to declarative presentation specifications.

## Impact

The compiler can now reproduce the existing flat and grouped behavior for simple, mixed, multi-disc, preserved-path, and conflicting-name cases. Legacy presenters remain available as regression oracles in this PR.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`