### PR TITLE
feat(output): wire presentation specs into runtime

### DIFF
--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -1,32 +1,161 @@
-use crate::output::flat_presenter::FlatPresenter;
-use crate::output::grouped_presenter::GroupedPresenter;
+use crate::core::content::NormalizedContent;
+use crate::output::capabilities::{ContentType, Format};
+use crate::output::plan::PresentationPlan;
 use crate::output::present::OutputPresenter;
-use crate::output::presenter_registry::PresenterRegistry;
+use crate::output::presentation_compile::compile_presentation_spec;
+use crate::output::presentation_spec::{
+    ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
+};
+use crate::policy::PolicySet;
 
-pub fn default_presenter_registry() -> PresenterRegistry {
-    let mut registry = PresenterRegistry::new();
+const BUILT_IN_PRESENTATIONS: [&str; 2] = ["flat", "grouped"];
 
-    registry.register("grouped", || {
-        Box::new(GroupedPresenter) as Box<dyn OutputPresenter>
-    });
-
-    registry.register("flat", || {
-        Box::new(FlatPresenter) as Box<dyn OutputPresenter>
-    });
-
-    registry
+pub fn built_in_presentation_names() -> &'static [&'static str] {
+    &BUILT_IN_PRESENTATIONS
 }
 
-pub fn build_presenter(presenter_name: &str) -> Result<Box<dyn OutputPresenter>, String> {
-    match presenter_name {
-        "grouped" => Ok(Box::new(GroupedPresenter::new()) as Box<dyn OutputPresenter>),
-        "flat" => Ok(Box::new(FlatPresenter::new()) as Box<dyn OutputPresenter>),
+pub fn build_presentation_spec(name: &str) -> Result<PresentationSpec, String> {
+    let layout = match name {
+        "flat" => LayoutSpec::Flat,
+        "grouped" => LayoutSpec::GroupedByPlatformAndGame,
         _ => {
-            let presenter_registry = default_presenter_registry();
-            Err(format!(
-                "unsupported view '{presenter_name}'; expected one of: {}",
-                presenter_registry.names().join(", ")
+            return Err(format!(
+                "unsupported view '{name}'; expected one of: {}",
+                built_in_presentation_names().join(", ")
             ))
         }
+    };
+
+    Ok(PresentationSpec::new(layout, built_in_file_rules()))
+}
+
+pub fn build_presentation(name: &str) -> Result<Box<dyn OutputPresenter>, String> {
+    Ok(Box::new(CompiledPresentation::new(
+        build_presentation_spec(name)?,
+    )))
+}
+
+fn built_in_file_rules() -> Vec<FileRuleSpec> {
+    vec![
+        FileRuleSpec::new(
+            SelectSpec::GamesWithoutParts,
+            NamingSpec::GameName,
+            ArtifactSpec::new(ContentType::Game),
+        ),
+        FileRuleSpec::new(
+            SelectSpec::SingleRomGames,
+            NamingSpec::PartName,
+            ArtifactSpec::new(ContentType::Rom).with_format(Format::Bin),
+        ),
+        FileRuleSpec::new(
+            SelectSpec::SingleDiscGames,
+            NamingSpec::PartName,
+            ArtifactSpec::new(ContentType::Disc).with_format(Format::Bin),
+        ),
+        FileRuleSpec::new(
+            SelectSpec::MultiDiscGames,
+            NamingSpec::PartName,
+            ArtifactSpec::new(ContentType::Disc).with_format(Format::Bin),
+        ),
+        FileRuleSpec::new(
+            SelectSpec::MultiDiscGames,
+            NamingSpec::PlaylistName,
+            ArtifactSpec::new(ContentType::Playlist).with_format(Format::M3u),
+        ),
+        FileRuleSpec::new(
+            SelectSpec::Bytes,
+            NamingSpec::SourceName,
+            ArtifactSpec::new(ContentType::Bytes).with_format(Format::Bin),
+        ),
+        FileRuleSpec::new(
+            SelectSpec::Text,
+            NamingSpec::SourceName,
+            ArtifactSpec::new(ContentType::Text).with_format(Format::Text),
+        ),
+    ]
+}
+
+struct CompiledPresentation {
+    spec: PresentationSpec,
+}
+
+impl CompiledPresentation {
+    fn new(spec: PresentationSpec) -> Self {
+        Self { spec }
+    }
+}
+
+impl OutputPresenter for CompiledPresentation {
+    fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> PresentationPlan {
+        compile_presentation_spec(&self.spec, content, policy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::content::{ContentId, DiscPart, GameContent, GamePart, Platform};
+    use crate::core::source::SourceRef;
+    use crate::output::plan::{GeneratedArtifact, PlanEntry, PlannedArtifactKind};
+
+    #[test]
+    fn exposes_stable_built_in_presentation_names() {
+        assert_eq!(built_in_presentation_names(), &["flat", "grouped"]);
+    }
+
+    #[test]
+    fn builds_expected_layout_for_each_built_in_presentation() {
+        assert_eq!(
+            build_presentation_spec("flat").unwrap().layout,
+            LayoutSpec::Flat
+        );
+        assert_eq!(
+            build_presentation_spec("grouped").unwrap().layout,
+            LayoutSpec::GroupedByPlatformAndGame
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_built_in_presentation() {
+        let error = build_presentation_spec("unknown").unwrap_err();
+        assert_eq!(
+            error,
+            "unsupported view 'unknown'; expected one of: flat, grouped"
+        );
+    }
+
+    #[test]
+    fn compiled_flat_presentation_emits_multi_disc_playlist() {
+        let content = vec![NormalizedContent::Game(GameContent {
+            id: ContentId::new("ff7"),
+            source: SourceRef::new("file:/roms/ff7-disc1.cue"),
+            title: "Final Fantasy VII".to_string(),
+            platform: Platform::Ps1,
+            parts: vec![
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new("file:/roms/ff7-disc2.cue"),
+                    disc_number: 2,
+                    consumed_sources: vec![],
+                }),
+                GamePart::Disc(DiscPart {
+                    source: SourceRef::new("file:/roms/ff7-disc1.cue"),
+                    disc_number: 1,
+                    consumed_sources: vec![],
+                }),
+            ],
+            consumed_sources: vec![],
+        })];
+
+        let presentation = build_presentation("flat").unwrap();
+        let plan = presentation.present(&content, &PolicySet::default());
+
+        assert_eq!(plan.entries.len(), 3);
+        let PlanEntry::File(playlist) = &plan.entries[2] else {
+            panic!("expected playlist file");
+        };
+        assert!(matches!(
+            playlist.artifact.kind,
+            PlannedArtifactKind::Generated(GeneratedArtifact::Playlist(_))
+        ));
     }
 }

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -1,12 +1,7 @@
-use crate::core::content::NormalizedContent;
 use crate::output::capabilities::{ContentType, Format};
-use crate::output::plan::PresentationPlan;
-use crate::output::present::OutputPresenter;
-use crate::output::presentation_compile::compile_presentation_spec;
 use crate::output::presentation_spec::{
     ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
 };
-use crate::policy::PolicySet;
 
 const BUILT_IN_PRESENTATIONS: [&str; 2] = ["flat", "grouped"];
 
@@ -27,12 +22,6 @@ pub fn build_presentation_spec(name: &str) -> Result<PresentationSpec, String> {
     };
 
     Ok(PresentationSpec::new(layout, built_in_file_rules()))
-}
-
-pub fn build_presentation(name: &str) -> Result<Box<dyn OutputPresenter>, String> {
-    Ok(Box::new(CompiledPresentation::new(
-        build_presentation_spec(name)?,
-    )))
 }
 
 fn built_in_file_rules() -> Vec<FileRuleSpec> {
@@ -75,28 +64,16 @@ fn built_in_file_rules() -> Vec<FileRuleSpec> {
     ]
 }
 
-struct CompiledPresentation {
-    spec: PresentationSpec,
-}
-
-impl CompiledPresentation {
-    fn new(spec: PresentationSpec) -> Self {
-        Self { spec }
-    }
-}
-
-impl OutputPresenter for CompiledPresentation {
-    fn present(&self, content: &[NormalizedContent], policy: &PolicySet) -> PresentationPlan {
-        compile_presentation_spec(&self.spec, content, policy)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::content::{ContentId, DiscPart, GameContent, GamePart, Platform};
+    use crate::core::content::{
+        ContentId, DiscPart, GameContent, GamePart, NormalizedContent, Platform,
+    };
     use crate::core::source::SourceRef;
     use crate::output::plan::{GeneratedArtifact, PlanEntry, PlannedArtifactKind};
+    use crate::output::presentation_compile::compile_presentation_spec;
+    use crate::policy::PolicySet;
 
     #[test]
     fn exposes_stable_built_in_presentation_names() {
@@ -146,8 +123,8 @@ mod tests {
             consumed_sources: vec![],
         })];
 
-        let presentation = build_presentation("flat").unwrap();
-        let plan = presentation.present(&content, &PolicySet::default());
+        let presentation = build_presentation_spec("flat").unwrap();
+        let plan = compile_presentation_spec(&presentation, &content, &PolicySet::default());
 
         assert_eq!(plan.entries.len(), 3);
         let PlanEntry::File(playlist) = &plan.entries[2] else {

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -1,4 +1,4 @@
-use crate::engine::bootstrap::{build_presenter, default_presenter_registry};
+use crate::engine::bootstrap::build_presentation;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
 use crate::input::decode::InputDecoder;
@@ -24,15 +24,7 @@ pub fn default_pipeline_components() -> Result<PipelineComponents, RetromountErr
 }
 
 pub fn pipeline_components(presenter_name: &str) -> Result<PipelineComponents, RetromountError> {
-    let presenter_registry = default_presenter_registry();
-    if presenter_registry.get(presenter_name).is_none() {
-        return Err(RetromountError::LoadError(format!(
-            "unsupported view '{presenter_name}'; expected one of: {}",
-            presenter_registry.names().join(", ")
-        )));
-    }
-
-    let presenter = build_presenter(presenter_name).map_err(RetromountError::LoadError)?;
+    let presenter = build_presentation(presenter_name).map_err(RetromountError::LoadError)?;
 
     Ok(PipelineComponents {
         identifier: Box::new(BasicInputIdentifier::new()),

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -1,21 +1,21 @@
-use crate::engine::bootstrap::build_presentation;
+use crate::engine::bootstrap::build_presentation_spec;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentifier;
-use crate::output::present::OutputPresenter;
+use crate::output::presentation_spec::PresentationSpec;
 use crate::policy::PolicySet;
 use crate::RetromountError;
 
 /// The concrete pipeline components used to run Retromount.
 ///
 /// This provides a single composition boundary for built-in implementations,
-/// allowing application entrypoints to depend on traits rather than directly
-/// constructing concrete decoders, identifiers, and presenters.
+/// allowing application entrypoints to use a selected declarative presentation
+/// without directly constructing legacy presenter implementations.
 pub struct PipelineComponents {
     pub identifier: Box<dyn InputIdentifier>,
     pub decoder: Box<dyn InputDecoder>,
-    pub presenter: Box<dyn OutputPresenter>,
+    pub presentation: PresentationSpec,
     pub policy: PolicySet,
 }
 
@@ -24,12 +24,13 @@ pub fn default_pipeline_components() -> Result<PipelineComponents, RetromountErr
 }
 
 pub fn pipeline_components(presenter_name: &str) -> Result<PipelineComponents, RetromountError> {
-    let presenter = build_presentation(presenter_name).map_err(RetromountError::LoadError)?;
+    let presentation =
+        build_presentation_spec(presenter_name).map_err(RetromountError::LoadError)?;
 
     Ok(PipelineComponents {
         identifier: Box::new(BasicInputIdentifier::new()),
         decoder: Box::new(BasicInputDecoder::new()),
-        presenter,
+        presentation,
         policy: PolicySet::default(),
     })
 }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -7,7 +7,8 @@ use crate::error::RetromountError;
 use crate::output::plugin_registry::PluginRegistry;
 
 use super::pipeline::{
-    run_pipeline_with_options, run_pipeline_with_trace, PipelineOptions, PipelineTrace,
+    run_pipeline_with_presentation_options, run_pipeline_with_presentation_trace, PipelineOptions,
+    PipelineTrace,
 };
 use super::preview::{build_input_source, write_vfs_tree};
 
@@ -30,22 +31,22 @@ pub fn run_phase3_inspect_with_plugins(
     let components = pipeline_components_for_presenter(presenter_name)?;
 
     let trace = match plugin_registry {
-        Some(plugin_registry) => run_pipeline_with_options(
+        Some(plugin_registry) => run_pipeline_with_presentation_options(
             source.as_ref(),
             components.identifier.as_ref(),
             components.decoder.as_ref(),
-            components.presenter.as_ref(),
+            &components.presentation,
             &components.policy,
             &PipelineOptions {
                 normalization: Default::default(),
                 plugin_registry: Some(plugin_registry),
             },
         )?,
-        None => run_pipeline_with_trace(
+        None => run_pipeline_with_presentation_trace(
             source.as_ref(),
             components.identifier.as_ref(),
             components.decoder.as_ref(),
-            components.presenter.as_ref(),
+            &components.presentation,
             &components.policy,
         )?,
     };

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 use log::info;
 
 use crate::engine::components::pipeline_components_for_presenter;
-use crate::engine::pipeline::{run_pipeline, run_pipeline_with_options, PipelineOptions};
+use crate::engine::pipeline::{
+    run_pipeline, run_pipeline_with_options, run_pipeline_with_presentation,
+    run_pipeline_with_presentation_options, PipelineOptions,
+};
 use crate::engine::preview::build_input_source;
 use crate::error::RetromountError;
 use crate::input::decode::InputDecoder;
@@ -64,14 +67,45 @@ pub fn prepare_mount_session_with_plugins(
     let source = build_input_source(input)?;
     let components = pipeline_components_for_presenter(presenter_name)?;
 
-    prepare_mount_session_from_pipeline(
+    prepare_mount_session_from_presentation(
         source.as_ref(),
         components.identifier.as_ref(),
         components.decoder.as_ref(),
-        components.presenter.as_ref(),
+        &components.presentation,
         &components.policy,
         plugin_registry,
     )
+}
+
+fn prepare_mount_session_from_presentation(
+    source: &dyn InputSource,
+    identifier: &dyn InputIdentifier,
+    decoder: &dyn InputDecoder,
+    presentation: &crate::output::presentation_spec::PresentationSpec,
+    policy: &PolicySet,
+    plugin_registry: Option<&PluginRegistry>,
+) -> Result<MountSession, RetromountError> {
+    let root = match plugin_registry {
+        Some(plugin_registry) => {
+            run_pipeline_with_presentation_options(
+                source,
+                identifier,
+                decoder,
+                presentation,
+                policy,
+                &PipelineOptions {
+                    normalization: Default::default(),
+                    plugin_registry: Some(plugin_registry),
+                },
+            )
+            .map_err(|err| RetromountError::LoadError(err.to_string()))?
+            .output_vfs
+        }
+        None => run_pipeline_with_presentation(source, identifier, decoder, presentation, policy)
+            .map_err(|err| RetromountError::LoadError(err.to_string()))?,
+    };
+
+    Ok(MountSession::from_root(&root))
 }
 
 pub fn prepare_mount_session_from_pipeline(

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -12,6 +12,8 @@ use crate::output::materialize::{materialize_plan, materialize_plan_with_plugins
 use crate::output::plan::PresentationPlan;
 use crate::output::plugin_registry::PluginRegistry;
 use crate::output::present::OutputPresenter;
+use crate::output::presentation_compile::compile_presentation_spec;
+use crate::output::presentation_spec::PresentationSpec;
 use crate::policy::PolicySet;
 use serde::Serialize;
 
@@ -79,6 +81,80 @@ pub fn run_pipeline_with_options(
     policy: &PolicySet,
     options: &PipelineOptions<'_>,
 ) -> Result<PipelineTrace, io::Error> {
+    run_pipeline_with_plan_builder(
+        source,
+        identifier,
+        decoder,
+        policy,
+        options,
+        |content, policy| presenter.present(content, policy),
+    )
+}
+
+pub fn run_pipeline_with_presentation(
+    source: &dyn InputSource,
+    identifier: &dyn InputIdentifier,
+    decoder: &dyn InputDecoder,
+    presentation: &PresentationSpec,
+    policy: &PolicySet,
+) -> Result<VfsDirectory, io::Error> {
+    Ok(run_pipeline_with_presentation_options(
+        source,
+        identifier,
+        decoder,
+        presentation,
+        policy,
+        &PipelineOptions::default(),
+    )?
+    .output_vfs)
+}
+
+pub fn run_pipeline_with_presentation_trace(
+    source: &dyn InputSource,
+    identifier: &dyn InputIdentifier,
+    decoder: &dyn InputDecoder,
+    presentation: &PresentationSpec,
+    policy: &PolicySet,
+) -> Result<PipelineTrace, io::Error> {
+    run_pipeline_with_presentation_options(
+        source,
+        identifier,
+        decoder,
+        presentation,
+        policy,
+        &PipelineOptions::default(),
+    )
+}
+
+pub fn run_pipeline_with_presentation_options(
+    source: &dyn InputSource,
+    identifier: &dyn InputIdentifier,
+    decoder: &dyn InputDecoder,
+    presentation: &PresentationSpec,
+    policy: &PolicySet,
+    options: &PipelineOptions<'_>,
+) -> Result<PipelineTrace, io::Error> {
+    run_pipeline_with_plan_builder(
+        source,
+        identifier,
+        decoder,
+        policy,
+        options,
+        |content, policy| compile_presentation_spec(presentation, content, policy),
+    )
+}
+
+fn run_pipeline_with_plan_builder<F>(
+    source: &dyn InputSource,
+    identifier: &dyn InputIdentifier,
+    decoder: &dyn InputDecoder,
+    policy: &PolicySet,
+    options: &PipelineOptions<'_>,
+    build_plan: F,
+) -> Result<PipelineTrace, io::Error>
+where
+    F: FnOnce(&[NormalizedContent], &PolicySet) -> PresentationPlan,
+{
     let objects = source.enumerate()?;
     let mut traced_objects = Vec::new();
     let mut all_decoded_content = Vec::new();
@@ -105,7 +181,7 @@ pub fn run_pipeline_with_options(
 
     let normalized = normalize_decoded_content(all_decoded_content, &options.normalization);
     let normalized_presentable_content = suppress_consumed_content(&normalized);
-    let presentation_plan = presenter.present(&normalized_presentable_content, policy);
+    let presentation_plan = build_plan(&normalized_presentable_content, policy);
     let output_vfs = materialize_presentation_plan(&presentation_plan, options)?;
 
     Ok(PipelineTrace {

--- a/src/engine/preview.rs
+++ b/src/engine/preview.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 
 use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::engine::components::default_pipeline_components;
-use crate::engine::pipeline::{run_pipeline, run_pipeline_with_options, PipelineOptions};
+use crate::engine::pipeline::{
+    run_pipeline_with_presentation, run_pipeline_with_presentation_options, PipelineOptions,
+};
 use crate::error::RetromountError;
 use crate::input::directory_source::DirectoryInputSource;
 use crate::input::file_source::FileInputSource;
@@ -24,11 +26,11 @@ pub fn run_phase3_preview_with_plugins(
 
     let root = match plugin_registry {
         Some(plugin_registry) => {
-            run_pipeline_with_options(
+            run_pipeline_with_presentation_options(
                 source.as_ref(),
                 components.identifier.as_ref(),
                 components.decoder.as_ref(),
-                components.presenter.as_ref(),
+                &components.presentation,
                 &components.policy,
                 &PipelineOptions {
                     normalization: Default::default(),
@@ -37,11 +39,11 @@ pub fn run_phase3_preview_with_plugins(
             )?
             .output_vfs
         }
-        None => run_pipeline(
+        None => run_pipeline_with_presentation(
             source.as_ref(),
             components.identifier.as_ref(),
             components.decoder.as_ref(),
-            components.presenter.as_ref(),
+            &components.presentation,
             &components.policy,
         )?,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use retromount::engine::bootstrap::{build_presentation_spec, built_in_presentati
 use retromount::engine::components::pipeline_components;
 use retromount::engine::inspect::{run_phase3_inspect, run_phase3_inspect_with_plugins};
 use retromount::engine::mount::{run_mount_command, run_mount_command_with_plugins};
-use retromount::engine::pipeline::{run_pipeline_with_options, PipelineOptions};
+use retromount::engine::pipeline::{run_pipeline_with_presentation_options, PipelineOptions};
 use retromount::engine::plugins::load_plugin_registry;
 use retromount::engine::preview::{
     build_input_source, run_phase3_preview, run_phase3_preview_with_plugins, write_vfs_tree,
@@ -189,11 +189,11 @@ fn run_configured_views() -> Result<(), RetromountError> {
         let components = pipeline_components(presenter_name)?;
         let source = build_input_source(&view.source)?;
 
-        let trace = run_pipeline_with_options(
+        let trace = run_pipeline_with_presentation_options(
             source.as_ref(),
             components.identifier.as_ref(),
             components.decoder.as_ref(),
-            components.presenter.as_ref(),
+            &components.presentation,
             &components.policy,
             &pipeline_options_for_view(view),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use retromount::core::content::{
 };
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
-use retromount::engine::bootstrap::default_presenter_registry;
+use retromount::engine::bootstrap::{build_presentation_spec, built_in_presentation_names};
 use retromount::engine::components::pipeline_components;
 use retromount::engine::inspect::{run_phase3_inspect, run_phase3_inspect_with_plugins};
 use retromount::engine::mount::{run_mount_command, run_mount_command_with_plugins};
@@ -158,14 +158,13 @@ fn main() -> Result<(), RetromountError> {
 
 fn parse_presenter_name(value: &std::ffi::OsStr) -> Result<String, RetromountError> {
     let value = value.to_string_lossy().to_string();
-    let registry = default_presenter_registry();
 
-    if registry.get(&value).is_some() {
+    if build_presentation_spec(&value).is_ok() {
         Ok(value)
     } else {
         Err(RetromountError::LoadError(format!(
             "unsupported view '{value}'; expected one of: {}",
-            registry.names().join(", ")
+            built_in_presentation_names().join(", ")
         )))
     }
 }

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -114,6 +114,7 @@ fn try_compile_rule(
 
     let match_result = match rule.select {
         SelectSpec::Games => match_game(item),
+        SelectSpec::GamesWithoutParts => match_game_without_parts(item),
         SelectSpec::SingleDiscGames => match_single_disc_game(item),
         SelectSpec::MultiDiscGames => unreachable!("handled above"),
         SelectSpec::SingleRomGames => match_single_rom_game(item),
@@ -325,6 +326,17 @@ fn match_game(item: &NormalizedContent) -> Option<SourceMatch> {
     }
 }
 
+fn match_game_without_parts(item: &NormalizedContent) -> Option<SourceMatch> {
+    let NormalizedContent::Game(game) = item else {
+        return None;
+    };
+
+    game.parts.is_empty().then(|| SourceMatch {
+        source: game.source.clone(),
+        size: 0,
+    })
+}
+
 fn match_single_disc_game(item: &NormalizedContent) -> Option<SourceMatch> {
     let NormalizedContent::Game(game) = item else {
         return None;
@@ -389,10 +401,18 @@ fn build_name(
 ) -> Option<String> {
     match naming {
         NamingSpec::GameTitle => game_title(item),
+        NamingSpec::GameName => game_name(item, policy),
         NamingSpec::PartName => part_name(item, policy),
         NamingSpec::PlaylistName => playlist_name(item, policy),
         NamingSpec::SourceName => source_name(item, artifact),
         NamingSpec::Literal(value) => Some(value.clone()),
+    }
+}
+
+fn game_name(item: &NormalizedContent, policy: &PolicySet) -> Option<String> {
+    match item {
+        NormalizedContent::Game(game) => Some(policy.naming().game_name(game)),
+        _ => None,
     }
 }
 
@@ -490,6 +510,9 @@ fn extension_for_format(format: Option<Format>) -> Option<&'static str> {
 fn build_artifact_id(select: &SelectSpec, item: &NormalizedContent) -> ArtifactId {
     match (select, item) {
         (SelectSpec::Games, NormalizedContent::Game(game)) => {
+            ArtifactId::new(format!("game:{}", game.id))
+        }
+        (SelectSpec::GamesWithoutParts, NormalizedContent::Game(game)) => {
             ArtifactId::new(format!("game:{}", game.id))
         }
         (SelectSpec::SingleDiscGames, NormalizedContent::Game(game)) => {

--- a/src/output/presentation_spec.rs
+++ b/src/output/presentation_spec.rs
@@ -49,6 +49,9 @@ pub enum SelectSpec {
     /// Match any normalized game.
     Games,
 
+    /// Match games that contain no parts.
+    GamesWithoutParts,
+
     /// Match games with exactly one disc part.
     SingleDiscGames,
 
@@ -69,6 +72,9 @@ pub enum SelectSpec {
 pub enum NamingSpec {
     /// Use the game title.
     GameTitle,
+
+    /// Use the policy-derived game name.
+    GameName,
 
     /// Use the policy-derived part name for a single-part game.
     PartName,

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -8,7 +8,7 @@ use retromount::core::content::{GamePart, NormalizedContent};
 use retromount::core::vfs::VfsNode;
 use retromount::engine::components::default_pipeline_components;
 use retromount::engine::mount::prepare_mount_session_from_pipeline;
-use retromount::engine::pipeline::{run_pipeline_with_options, PipelineOptions};
+use retromount::engine::pipeline::{run_pipeline_with_presentation_options, PipelineOptions};
 use retromount::engine::plugins::load_plugin_registry;
 use retromount::input::file_source::FileInputSource;
 use retromount::mount::session::MountNodeKind;
@@ -18,6 +18,9 @@ use retromount::output::plan::{
     SourceArtifact,
 };
 use retromount::output::present::OutputPresenter;
+use retromount::output::presentation_spec::{
+    ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
+};
 use retromount::policy::PolicySet;
 use tempfile::TempDir;
 
@@ -137,13 +140,20 @@ fn pipeline_materializes_disc_via_fixture_plugin() {
 
     let source = FileInputSource::new(&cue_path);
     let components = default_pipeline_components().unwrap();
-    let presenter = PluginOnlyDiscPresenter;
+    let presentation = PresentationSpec::new(
+        LayoutSpec::Flat,
+        vec![FileRuleSpec::new(
+            SelectSpec::SingleDiscGames,
+            NamingSpec::Literal("Plugin Test.chd".to_string()),
+            ArtifactSpec::new(ContentType::Disc).with_format(Format::Chd),
+        )],
+    );
 
-    let trace = run_pipeline_with_options(
+    let trace = run_pipeline_with_presentation_options(
         &source,
         components.identifier.as_ref(),
         components.decoder.as_ref(),
-        &presenter,
+        &presentation,
         &components.policy,
         &PipelineOptions {
             normalization: Default::default(),


### PR DESCRIPTION
## What changed

- define complete built-in `flat` and `grouped` presentation specifications
- resolve CLI and configured view names through the presentation catalog
- make `PresentationSpec` a first-class pipeline component
- add spec-native pipeline entry points for inspect, preview, mount, and configured views
- retain presenter-based entry points temporarily for legacy parity and custom failure-path tests
- cover plugin encoder materialization through the spec-native pipeline

## Why

With declarative parity established in #121, runtime execution should compile selected presentation specifications directly instead of constructing built-in Rust presenters.

## Impact

Built-in runtime paths no longer depend on `FlatPresenter`, `GroupedPresenter`, or `PresenterRegistry`. Their remaining use is limited to compatibility seams and regression oracles pending the cleanup phase.

## Relationship

- Follows merged PR #121
- Targets the Phase 6 integration branch directly

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`