### PR TITLE
Add live PS2 CHD support for OPL presentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +101,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "block-buffer"
@@ -120,6 +135,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bzip2"
@@ -155,6 +176,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chd"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e16e43ebc68e33e0c66f7158ca00f0a6eb2c1241556a8ceb36deaeb4299986"
+dependencies = [
+ "arrayvec",
+ "bitreader",
+ "byteorder",
+ "claxon",
+ "crc",
+ "flate2",
+ "lzma-rs-perf-exp",
+ "num-derive",
+ "num-traits",
+ "ruzstd",
+ "text_io",
+]
+
+[[package]]
 name = "cipher"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +203,12 @@ dependencies = [
  "crypto-common 0.2.1",
  "inout",
 ]
+
+[[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "cmov"
@@ -211,6 +257,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -573,6 +634,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lzma-rs-perf-exp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38435c1305548bb408c98242841c3cf161246323e72a3e4433787f3c05bf18ee"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "lzma-rust2"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +695,26 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_enum"
@@ -846,6 +937,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "retromount"
 version = "0.1.0"
 dependencies = [
+ "chd",
  "env_logger",
  "fuser",
  "libc",
@@ -876,6 +968,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "ryu"
@@ -1027,6 +1128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "text_io"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8d3ca3b06292094e03841d8995e910712d2a10b5869c8f9725385b29761115"
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1202,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typed-path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4"
 env_logger = "0.11.10"
 thiserror = "2.0"                                        # For custom error types
 zip = "8"
+chd = "0.3.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 fuser = "0.18"
@@ -55,9 +56,6 @@ assets = [
 
 [features]
 default = []
-
-# Placeholder for future translator dependencies
-# chd_to_iso = ["dep:some_crate"]
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Fields:
 | `source`    | Source directory, archive, or disc image                   |
 | `mount`     | Mount point for the virtual filesystem                     |
 | `platform`  | Target platform (e.g. `ps1`, `ps2`, `snes`, `megadrive`)   |
-| `presenter` | Layout (`grouped`, `flat`, `opl`; default: `grouped`)       |
+| `presenter` | Layout (`grouped`, `flat`, `opl`; default: `grouped`)      |
 | `encoder`   | File representation strategy (default: `basic`)            |
 
 Platform names are **case-insensitive** and accept friendly aliases.

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ Retromount is under active development and progressing through a structured road
 
 ### In Progress
 
-* First practical consumer target — PS2/OPL
+* First practical consumer target — PS2/OPL; the live CHD-to-logical-ISO path
+  and automated mount-preparation coverage are implemented, with real-image
+  and OPL/SMB validation remaining
 
 ### Planned
 
-* PS2/OPL presentation backed by live random-access CHD decoding and an
-  ISO-compatible logical-disc view
 * Advanced encoders and external integrations (e.g. torrent compatibility)
 * Phase 7 — Performance, caching, and optimisation
 
@@ -110,6 +110,7 @@ RetroMount can expose a collection as a read-only filesystem using FUSE.
 
 ```bash
 retromount mount <input> <mountpoint>
+retromount mount "/roms/ps2/Test Game.chd" /mnt/retromount/ps2 --view opl
 ```
 
 ### Example
@@ -148,6 +149,12 @@ Create a file called `retromount.yaml`:
   presenter: grouped
   encoder: basic
 
+- name: ps2-opl
+  source: /roms/ps2/Test Game.chd
+  mount: /mnt/retromount/ps2
+  platform: ps2
+  presenter: opl
+
 - name: snes
   source: /roms/snes
   mount: /mnt/retromount/snes
@@ -167,8 +174,8 @@ Fields:
 | `name`      | Logical name for the mounted view                          |
 | `source`    | Source directory, archive, or disc image                   |
 | `mount`     | Mount point for the virtual filesystem                     |
-| `platform`  | Target platform (e.g. `ps1`, `snes`, `megadrive`)          |
-| `presenter` | Layout (`grouped`, `flat`; default: `grouped`)             |
+| `platform`  | Target platform (e.g. `ps1`, `ps2`, `snes`, `megadrive`)   |
+| `presenter` | Layout (`grouped`, `flat`, `opl`; default: `grouped`)       |
 | `encoder`   | File representation strategy (default: `basic`)            |
 
 Platform names are **case-insensitive** and accept friendly aliases.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Retromount is under active development and progressing through a structured road
 
 ### Planned
 
-* PS2/OPL presentation backed by CHD-to-ISO
+* PS2/OPL presentation backed by live random-access CHD decoding and an
+  ISO-compatible logical-disc view
 * Advanced encoders and external integrations (e.g. torrent compatibility)
 * Phase 7 — Performance, caching, and optimisation
 

--- a/docs/roadmap/ps2-opl-design-spike.md
+++ b/docs/roadmap/ps2-opl-design-spike.md
@@ -1,0 +1,415 @@
+# PS2/OPL Design Spike
+
+## Status
+
+Revised proposed contract and capability assessment.
+
+This spike follows Phase 6 and defines the smallest useful PS2/Open PS2 Loader
+(OPL) target. It is a design input for implementation, not a claim that the
+target currently works end to end.
+
+## Decision summary
+
+The first target is:
+
+* one CHD containing a single PS2 DVD image;
+* one OPL view with one output at `DVD/<game title>.iso`;
+* live, random-access reads of the logical disc data stored in the CHD;
+* bounded in-memory caching of individual decompressed hunks only;
+* preservation of the generic input → decode → normalize → encode → output
+  pipeline.
+
+The first target explicitly excludes CD games, multi-disc games, parent/delta
+CHDs, USBExtreme splitting, ZSO output, game artwork and configuration, and
+automatic extraction of a PS2 game ID.
+
+The PS2/OPL target is a presentation specification, not a conversion workflow.
+CHD is one possible input container, and ISO is one possible output
+representation. They are selected and implemented independently.
+
+Whole-image extraction is prohibited for this target. The implementation must
+not invoke an extraction command, create a temporary ISO, create a persistent
+ISO cache, or require an ISO-sized intermediate artifact. Its behavior should
+match the live, random-access model exemplified by `chd2iso-fuse`.
+
+## Architectural invariant
+
+The implementation must preserve this composition:
+
+```text
+Input source
+    ↓
+Identify input container
+    ↓
+Decode media and geometry to canonical logical disc + random-access content
+    ↓
+Normalize game/platform/disc metadata
+    ↓
+Compile OPL presentation requirements
+    ↓
+Resolve an ISO output encoder
+    ↓
+Materialize a reader-backed VFS file
+    ↓
+OPL reads arbitrary ISO ranges
+```
+
+No component should implement the whole path from CHD input to OPL layout:
+
+* the CHD decoder must not know about OPL paths or names;
+* the OPL presentation must not know about CHD;
+* the ISO encoder must not require CHD as its input;
+* the VFS must not know which input container supplies the bytes.
+
+This allows the same decoded CHD disc to be used by other presentations and
+encoders, and allows the OPL presentation to accept other decoders that produce
+the same canonical logical-disc contract.
+
+## OPL output contract
+
+### Filesystem shape
+
+The root presented to OPL is an OPL share root:
+
+```text
+/
+└── DVD/
+    └── Shadow of the Colossus.iso
+```
+
+For the first target:
+
+* `DVD` is a literal, case-sensitive directory at the view root;
+* exactly one regular file is emitted below it;
+* the file extension is exactly `.iso`;
+* no playlist is emitted;
+* the ISO is read-only;
+* the reported size is the exact logical ISO byte length;
+* reads at arbitrary offsets return the corresponding logical ISO bytes;
+* no complete ISO or ISO-sized intermediate is written before or during the
+  mount.
+
+The presentation contract is consumer-facing. It does not name CHD, a CHD
+library, or a specific encoder implementation.
+
+### Selection
+
+The presentation selects only a normalized game that:
+
+* is identified as PlayStation 2;
+* contains exactly one disc part;
+* represents DVD media;
+* has a canonical logical data view that can satisfy an ISO artifact request.
+
+Selection must fail closed. Content with unknown platform or unknown media type
+must not silently appear in the OPL `DVD/` directory.
+
+### Naming
+
+The first target uses:
+
+```text
+<sanitized game title>.iso
+```
+
+The output-format extension replaces any source or policy-derived extension.
+
+The first slice does not require OPL's optional game-ID-prefixed form. A later
+profile may produce:
+
+```text
+<game ID>.<sanitized game title>.iso
+```
+
+when reliable game-ID extraction and an explicit length policy exist.
+
+Name allocation must be deterministic and must reject or resolve collisions
+before materialization starts.
+
+### Artifact request
+
+The compiled `PresentationPlan` should contain the equivalent of:
+
+```text
+path: DVD/Shadow of the Colossus.iso
+kind: content-backed
+input: canonical logical disc handle
+requirements:
+  content_type: disc
+  output_format: iso
+  media: dvd
+  required_features:
+    - random_access
+    - lossless
+```
+
+The request describes the desired output. It contains no CHD-specific
+requirement.
+
+### Encoder capability
+
+The ISO encoder should advertise a representation capability such as:
+
+```text
+capability_id: disc.logical-to-iso.dvd
+content_type: disc
+output_formats:
+  - iso
+accepted_inputs:
+  representations:
+    - logical_dvd_data
+  media:
+    - dvd
+features:
+  - random_access
+  - lossless
+```
+
+The accepted input is a canonical representation, not a storage format. The
+same encoder should work with logical DVD data produced from CHD, ISO, or any
+future supported container.
+
+For a DVD whose canonical logical view is already a contiguous stream of
+2048-byte sectors, ISO materialization can be a lightweight reader adapter
+rather than a byte conversion.
+
+## Stage contracts
+
+### Identify
+
+Identification determines that a source is a CHD container. It may also extract
+cheap header information, but it does not choose an output format or consumer.
+
+### Decode
+
+The CHD decoder:
+
+* validates the CHD header and metadata;
+* determines the media type and logical geometry;
+* exposes the disc's canonical logical data;
+* provides random-access reads by decompressing only the hunks needed for a
+  requested range;
+* may use a bounded in-memory cache of decompressed hunks;
+* never extracts or writes a complete ISO;
+* does not choose an output name or directory.
+
+The decoder output needs a content handle that can open or retain a
+random-access reader. A bare `SourceRef` is insufficient because it describes
+where encoded input lives, not how to read decoded logical content.
+
+Conceptually:
+
+```text
+DecodedDisc {
+  media: DVD
+  logical_sector_size: 2048
+  logical_sector_count: N
+  content: ContentHandle
+}
+
+ContentHandle.open() -> Reader
+Reader.len() -> N * 2048
+Reader.read_at(offset, buffer) -> logical disc bytes
+```
+
+### Normalize
+
+Normalization adds stable semantic information:
+
+* title;
+* platform;
+* disc number;
+* media type;
+* canonical disc representation and geometry;
+* the opaque content handle.
+
+It must not discard the decoded content handle and regress to the original CHD
+path. It also must not contain OPL layout or ISO naming decisions.
+
+### Present
+
+The OPL specification:
+
+* selects a single PS2 DVD game;
+* places it below literal directory `DVD`;
+* derives the consumer-facing name;
+* requests `Disc + ISO + DVD + RandomAccess + Lossless`.
+
+It does not inspect `.chd` extensions and does not select a named encoder.
+
+### Encode
+
+The ISO encoder consumes the normalized canonical logical-disc representation.
+It:
+
+* verifies DVD media and ISO-compatible logical sector geometry;
+* calculates the exact output length;
+* returns a reader-backed view over the canonical disc content;
+* maps requested byte ranges to the underlying logical-disc reader;
+* remains independent of the original input container.
+
+For the first DVD target this can be an identity mapping over logical sector
+bytes. The encoder boundary is still valuable: later disc representations may
+need framing removal, track selection, padding, or another output-specific
+mapping without changing the presentation or decoder.
+
+### Output/VFS
+
+The VFS must support a materialized artifact backed by a live reader, in
+addition to inline and path-backed files.
+
+Conceptually:
+
+```text
+MaterializedArtifact::ReaderBacked {
+  handle: ReaderHandle,
+  size: u64,
+}
+```
+
+The handle should be opaque and resolved through a mount-session resource
+registry or equivalent lifetime owner. It should not serialize a Rust trait
+object into the plugin protocol.
+
+The mount session must:
+
+* keep the decoded content and reader factory alive;
+* open or reuse readers safely;
+* forward FUSE offset reads without whole-file materialization;
+* support concurrent or repeated reads;
+* release resources when the session ends.
+
+## Random-access read behavior
+
+A read of output range `[offset, offset + length)` should:
+
+1. validate and clamp the request against the logical ISO length;
+2. identify the logical sectors and CHD hunks covering that range;
+3. fetch and decompress only those hunks not already in the bounded cache;
+4. copy only the requested bytes into the output buffer;
+5. return without creating an extracted ISO file.
+
+The optional hunk cache is an implementation detail of the CHD reader, not an
+output artifact:
+
+* it should be bounded;
+* it may retain decompressed hunks in memory;
+* it must not change the observable ISO bytes;
+* it must not be required for correctness;
+* it can be shared where safe across readers for the same decoded content.
+
+It must never contain or grow into a complete ISO representation.
+
+## Existing capability assessment
+
+### What already fits
+
+The current architecture has several correct foundations:
+
+* `Reader` already defines `read_at(offset, buffer)` and `len()`;
+* readers are explicitly read-only;
+* `ReaderFactory` and `ReaderRegistry` already establish reader construction as
+  a distinct concern;
+* `PresentationSpec` can request `ContentType::Disc` and `Format::Iso`;
+* `PresentationPlan` separates artifact intent from materialization;
+* capability resolution selects encoders independently of presentations;
+* FUSE already forwards offset reads through the reader abstraction.
+
+These are the pieces to extend. They should not be replaced by an extraction
+workflow.
+
+### Blocking gaps
+
+| Area | Current behavior | Required change |
+| --- | --- | --- |
+| CHD input | No CHD reader or decoder exists. | Add a random-access CHD reader that exposes logical disc bytes and media metadata. |
+| Input identification | Only `.cue` is identified as a disc image; `.chd` becomes generic bytes. | Identify CHD as a disc container and route it to the CHD decoder. |
+| Decoded content | `DecodedDiscContent` retains source metadata but no live decoded-content handle or geometry. | Carry a reusable canonical logical-disc handle, media kind, sector size, and sector count. |
+| Normalized content | `DiscPart` retains only source, disc number, and consumed sources. | Preserve the canonical representation and content handle through normalization. |
+| Platform model | The active normalized `Platform` enum has no PS2 variant. | Add PS2 and derive it from an explicit hint or reliable identification. |
+| Presentation placement | Layouts are only flat or grouped by platform/game. | Express literal `DVD/` placement declaratively. |
+| Presentation selection | Rules cannot filter by platform, media, or representation. | Add declarative filters needed by the OPL rule. |
+| Naming | `PartName` produces `.cue`, and the compiler preserves existing extensions. | Make output-format extension replacement explicit. |
+| Capability model | Capabilities match output content type and format, but not canonical input representation or media. | Match encoders against normalized representation and media, not source container extension. |
+| Materialized output | Artifacts can only be inline or source-path-backed. | Add a reader-backed artifact and mount-session lifetime owner. |
+| VFS model | `VfsFile` derives serializable/value equality over path or bytes. | Separate inspectable file metadata from non-serializable runtime backing handles. |
+| Plugin protocol | The subprocess model is one request/one response and can return only bytes or a path. | Do not force live readers through protocol v1; design a persistent/random-read plugin contract later if external reader plugins are required. |
+| Validation | No synthetic PS2 DVD CHD fixture or live-read test exists. | Verify geometry, exact length, unaligned reads, hunk-boundary reads, repeated reads, and final OPL path. |
+
+## Plugin boundary conclusion
+
+Runtime encoder plugins remain the output extensibility mechanism, but protocol
+v1 cannot transport a live random-access reader. This spike must not work around
+that limitation by materializing a path-backed ISO. Doing so would optimize for
+the existing protocol at the expense of the architecture.
+
+For the first target:
+
+* CHD decoding should use the input/reader side of the architecture;
+* the ISO encoder should operate on the canonical logical-disc handle;
+* reader-backed materialization should be an in-process host capability;
+* OPL remains a declarative presentation.
+
+If external CHD decoders or live output encoders are required later, they need a
+persistent protocol with open/read/close semantics or another shared
+random-access backing mechanism. That is a separate input/runtime-plugin design
+problem and should not be hidden inside a PS2-specific encoder.
+
+## Recommended implementation order
+
+1. Define the canonical logical-disc representation and opaque content-handle
+   lifetime.
+2. Add reader-backed materialized artifacts and mount-session resource
+   ownership, proven first with a simple test reader.
+3. Add PS2, DVD media, geometry, and canonical representation metadata to
+   decode and normalization.
+4. Implement a random-access CHD reader with bounded decompressed-hunk caching.
+5. Add the generic logical-DVD-to-ISO encoder adapter.
+6. Add the declarative OPL `DVD/` presentation and correct extension handling.
+7. Prove one synthetic DVD CHD end to end through inspect, mount preparation,
+   unaligned reads, hunk-boundary reads, and reads near end-of-file.
+8. Validate the mounted share with a current OPL build over SMB.
+
+## Acceptance criteria for the first target
+
+The spike is implemented when:
+
+* a PS2 DVD CHD is decoded into a canonical logical-disc handle;
+* no complete ISO or ISO-sized intermediate is created;
+* the OPL presentation compiles exactly one
+  `Disc + ISO + DVD + RandomAccess + Lossless` request at
+  `DVD/<title>.iso`;
+* resolution selects an encoder based on canonical representation and media,
+  independently of CHD;
+* the materialized VFS file reports the exact non-zero logical ISO size;
+* arbitrary, unaligned, repeated, and out-of-order reads return correct bytes;
+* reads spanning CHD hunk boundaries return correct bytes;
+* memory use is bounded independently of total ISO size;
+* invalid CHD, unsupported media, decompression failure, and out-of-range reads
+  produce actionable behavior;
+* an OPL SMB client lists and launches the test image;
+* no fixed CHD→OPL pipeline, extraction command, or whole-image cache is
+  introduced.
+
+## Deferred questions
+
+These should not expand the first target:
+
+* CD track selection and conversion to a 2048-byte-sector ISO view;
+* DVD9 and layer-break validation;
+* parent/delta CHDs;
+* CHDs inside ZIP or other virtual sources;
+* external/persistent reader plugin transport;
+* cross-session decompressed-hunk caching;
+* game-ID extraction and optional OPL-prefixed names;
+* FAT32/USBExtreme splitting;
+* ZSO output;
+* multi-disc presentation and OPL per-game metadata.
+
+## External references
+
+* [Open PS2 Loader README](https://github.com/ps2homebrew/Open-PS2-Loader)
+  documents the `CD` and `DVD` directory layout and ISO support for USB and SMB.
+* [OPL USB mode documentation](https://github.com/ps2homebrew/Open-PS2-Loader/wiki/usb-mode)
+  documents DVD/CD placement, the optional game-ID naming form, and FAT
+  filesystem size limits.

--- a/docs/roadmap/ps2-opl-design-spike.md
+++ b/docs/roadmap/ps2-opl-design-spike.md
@@ -300,6 +300,25 @@ output artifact:
 
 It must never contain or grow into a complete ISO representation.
 
+## CHD implementation dependency
+
+The initial reader implementation should use the pure-Rust
+[`chd` crate](https://docs.rs/crate/chd/latest) from chd-rs.
+
+The selection is based on the requirements of this design:
+
+* direct indexed hunk access rather than whole-image extraction;
+* CHD v5 codec coverage;
+* metadata iteration for detecting DVD media;
+* no subprocess or C/C++ toolchain requirement;
+* caller-owned decompressed and temporary buffers, allowing RetroMount to
+  enforce bounded memory use.
+
+The dependency is provisional until a synthetic DVD fixture proves metadata
+detection, logical sizing, hunk-boundary reads, and exact byte equivalence. The
+reader should use the direct hunk API rather than the crate's extraction command
+or whole-file adapters.
+
 ## Existing capability assessment
 
 ### What already fits

--- a/docs/roadmap/ps2-opl-design-spike.md
+++ b/docs/roadmap/ps2-opl-design-spike.md
@@ -337,23 +337,18 @@ The current architecture has several correct foundations:
 These are the pieces to extend. They should not be replaced by an extraction
 workflow.
 
-### Blocking gaps
+### Implementation status
 
-| Area | Current behavior | Required change |
+| Area | Implemented behavior | Remaining validation |
 | --- | --- | --- |
-| CHD input | No CHD reader or decoder exists. | Add a random-access CHD reader that exposes logical disc bytes and media metadata. |
-| Input identification | Only `.cue` is identified as a disc image; `.chd` becomes generic bytes. | Identify CHD as a disc container and route it to the CHD decoder. |
-| Decoded content | `DecodedDiscContent` retains source metadata but no live decoded-content handle or geometry. | Carry a reusable canonical logical-disc handle, media kind, sector size, and sector count. |
-| Normalized content | `DiscPart` retains only source, disc number, and consumed sources. | Preserve the canonical representation and content handle through normalization. |
-| Platform model | The active normalized `Platform` enum has no PS2 variant. | Add PS2 and derive it from an explicit hint or reliable identification. |
-| Presentation placement | Layouts are only flat or grouped by platform/game. | Express literal `DVD/` placement declaratively. |
-| Presentation selection | Rules cannot filter by platform, media, or representation. | Add declarative filters needed by the OPL rule. |
-| Naming | `PartName` produces `.cue`, and the compiler preserves existing extensions. | Make output-format extension replacement explicit. |
-| Capability model | Capabilities match output content type and format, but not canonical input representation or media. | Match encoders against normalized representation and media, not source container extension. |
-| Materialized output | Artifacts can only be inline or source-path-backed. | Add a reader-backed artifact and mount-session lifetime owner. |
-| VFS model | `VfsFile` derives serializable/value equality over path or bytes. | Separate inspectable file metadata from non-serializable runtime backing handles. |
-| Plugin protocol | The subprocess model is one request/one response and can return only bytes or a path. | Do not force live readers through protocol v1; design a persistent/random-read plugin contract later if external reader plugins are required. |
-| Validation | No synthetic PS2 DVD CHD fixture or live-read test exists. | Verify geometry, exact length, unaligned reads, hunk-boundary reads, repeated reads, and final OPL path. |
+| CHD input | `.chd` is identified separately and routed through a dedicated DVD decoder and bounded random-access hunk reader. | Exercise the supported codecs with a representative `chdman`-created PS2 DVD CHD. |
+| Canonical content | Decode and normalization retain DVD media, 2048-byte sector geometry, and an opaque live reader handle. | Validate the geometry against a representative real image. |
+| Platform model | PS2 is supported; the OPL composition supplies an explicit PS2 normalization hint. | None for the first target. |
+| Presentation | The declarative OPL rule selects one PS2 DVD and emits `DVD/<title>.iso`. | Validate the resulting share with OPL. |
+| Capability model | The logical-DVD ISO encoder is selected from canonical media and representation requirements, independently of CHD. | None for the first target. |
+| Materialized output | Reader-backed artifacts flow through the VFS and mount session without creating an ISO-sized intermediate. | Observe behavior under a representative full-size image workload. |
+| Plugin protocol | Protocol v1 explicitly rejects live content-backed artifacts; the built-in reader remains an in-process capability. | A persistent random-read plugin contract remains deferred. |
+| Automated validation | A generated CHD v5 fixture proves identification through mount preparation, exact size, unaligned/repeated/out-of-order reads, hunk boundaries, EOF behavior, and unsupported inputs. | Add a real compressed-image compatibility test when a redistributable fixture is available. |
 
 ## Plugin boundary conclusion
 
@@ -376,6 +371,9 @@ problem and should not be hidden inside a PS2-specific encoder.
 
 ## Recommended implementation order
 
+Items 1–7 are implemented and covered by automated tests. Item 8 remains an
+external acceptance step.
+
 1. Define the canonical logical-disc representation and opaque content-handle
    lifetime.
 2. Add reader-backed materialized artifacts and mount-session resource
@@ -388,6 +386,20 @@ problem and should not be hidden inside a PS2-specific encoder.
 7. Prove one synthetic DVD CHD end to end through inspect, mount preparation,
    unaligned reads, hunk-boundary reads, and reads near end-of-file.
 8. Validate the mounted share with a current OPL build over SMB.
+
+## Remaining validation
+
+The generated fixture is a small, uncompressed CHD v5 image. It deliberately
+keeps the repository and test suite independent of `chdman`, while exercising
+the real CHD parser, metadata iterator, hunk map, decode/normalize/encode
+contracts, VFS backing, and mount-session preparation.
+
+Before calling the consumer spike complete:
+
+1. Test a representative, `chdman`-created and compressed PS2 DVD CHD to
+   confirm codec and real-world metadata compatibility.
+2. Mount the resulting `DVD/<title>.iso` view, export it over SMB, and confirm a
+   current OPL build can list and launch it.
 
 ## Acceptance criteria for the first target
 

--- a/retromount.yaml.example
+++ b/retromount.yaml.example
@@ -7,6 +7,12 @@
 #   presenter → filesystem layout (default: grouped)
 #   encoder   → file representation (default: basic)
 
+- name: ps2-opl
+  source: /roms/ps2/Test Game.chd
+  mount: /mnt/retromount/ps2
+  platform: ps2
+  presenter: opl
+
 - name: ps1
   source: /roms/ps1/Ridge Racer.cue
   mount: /mnt/retromount/ps1

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -40,7 +40,7 @@ pub enum NormalizedContentKind {
     Text,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum Platform {
     Snes,
     Ps1,

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -44,6 +44,7 @@ pub enum NormalizedContentKind {
 pub enum Platform {
     Snes,
     Ps1,
+    Ps2,
     Nes,
     Megadrive,
     Unknown,
@@ -54,6 +55,7 @@ impl fmt::Display for Platform {
         let value = match self {
             Self::Snes => "snes",
             Self::Ps1 => "ps1",
+            Self::Ps2 => "ps2",
             Self::Nes => "nes",
             Self::Megadrive => "megadrive",
             Self::Unknown => "unknown",
@@ -273,6 +275,7 @@ mod tests {
     fn formats_platform_as_expected() {
         assert_eq!(Platform::Snes.to_string(), "snes");
         assert_eq!(Platform::Ps1.to_string(), "ps1");
+        assert_eq!(Platform::Ps2.to_string(), "ps2");
         assert_eq!(Platform::Nes.to_string(), "nes");
         assert_eq!(Platform::Megadrive.to_string(), "megadrive");
         assert_eq!(Platform::Unknown.to_string(), "unknown");

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -2,7 +2,28 @@ use serde::Serialize;
 use std::fmt;
 use std::sync::Arc;
 
+use crate::core::reader_handle::ReaderHandle;
 use crate::core::source::SourceRef;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum DiscMedia {
+    Cd,
+    Dvd,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LogicalDisc {
+    pub media: DiscMedia,
+    pub sector_size: u32,
+    pub sector_count: u64,
+    pub content: ReaderHandle,
+}
+
+impl LogicalDisc {
+    pub fn byte_len(&self) -> Option<u64> {
+        u64::from(self.sector_size).checked_mul(self.sector_count)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum DecodedContentKind {
@@ -172,6 +193,7 @@ pub struct DecodedDiscContent {
     pub title: String,
     pub disc_number: u32,
     pub consumed_sources: Vec<SourceRef>,
+    pub logical_disc: Option<LogicalDisc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -201,6 +223,7 @@ pub struct DiscPart {
     pub source: SourceRef,
     pub disc_number: u32,
     pub consumed_sources: Vec<SourceRef>,
+    pub logical_disc: Option<LogicalDisc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -263,6 +286,7 @@ mod tests {
             title: "Game".to_string(),
             disc_number: 1,
             consumed_sources: vec![SourceRef::new("cue:/roms/game-disc1.bin")],
+            logical_disc: None,
         });
 
         assert_eq!(content.id().to_string(), "disc-1");
@@ -281,6 +305,7 @@ mod tests {
                 source: SourceRef::new("cue:/roms/game-disc1.cue"),
                 disc_number: 1,
                 consumed_sources: vec![SourceRef::new("cue:/roms/game-disc1.bin")],
+                logical_disc: None,
             })],
             consumed_sources: vec![SourceRef::new("cue:/roms/game-disc1.bin")],
         });

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod normalizer;
 pub mod platform;
 pub mod reader;
 pub mod reader_factory;
+pub mod reader_handle;
 pub mod reader_registry;
 pub mod source;
 pub mod track;

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -143,6 +143,8 @@ fn platform_from_segments(path: &str) -> Option<Platform> {
             Platform::Snes
         } else if matches_platform_segment(segment, &["ps1", "psx", "playstation"]) {
             Platform::Ps1
+        } else if matches_platform_segment(segment, &["ps2", "playstation2"]) {
+            Platform::Ps2
         } else if matches_platform_segment(segment, &["nes"]) {
             Platform::Nes
         } else if matches_platform_segment(segment, &["megadrive", "genesis"]) {
@@ -431,6 +433,8 @@ mod tests {
     fn derives_platform_from_path() {
         assert_eq!(derive_platform("roms/snes/game.sfc"), Platform::Snes);
         assert_eq!(derive_platform("roms/ps1/game.cue"), Platform::Ps1);
+        assert_eq!(derive_platform("roms/ps2/game.chd"), Platform::Ps2);
+        assert_eq!(derive_platform("roms/playstation2/game.chd"), Platform::Ps2);
         assert_eq!(derive_platform("roms/psx/game.cue"), Platform::Ps1);
         assert_eq!(derive_platform("roms/playstation/game.cue"), Platform::Ps1);
         assert_eq!(derive_platform("roms/nes/game.nes"), Platform::Nes);

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -198,6 +198,7 @@ fn normalize_disc_group(
                 source: disc.source.clone(),
                 disc_number: disc.disc_number,
                 consumed_sources: disc.consumed_sources.clone(),
+                logical_disc: disc.logical_disc.clone(),
             })
         })
         .collect();
@@ -259,9 +260,11 @@ mod tests {
     use super::*;
     use crate::core::content::{
         ContentId, DecodedContent, DecodedContentKind, DecodedDiscContent, DecodedRomContent,
-        GamePart, NormalizedContent, NormalizedContentKind, TextContent,
+        DiscMedia, GamePart, LogicalDisc, NormalizedContent, NormalizedContentKind, TextContent,
     };
+    use crate::core::reader_handle::ReaderHandle;
     use crate::core::source::SourceRef;
+    use crate::readers::inline_reader::InlineReader;
 
     #[test]
     fn normalizes_rom_to_game() {
@@ -303,6 +306,7 @@ mod tests {
                     title: "Final Fantasy VII".to_string(),
                     disc_number: 2,
                     consumed_sources: vec![SourceRef::new("cue:/roms/ps1/ff7-disc2.bin")],
+                    logical_disc: None,
                 }),
                 DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("ps1/ff7-disc1"),
@@ -310,6 +314,7 @@ mod tests {
                     title: "Final Fantasy VII".to_string(),
                     disc_number: 1,
                     consumed_sources: vec![SourceRef::new("cue:/roms/ps1/ff7-disc1.bin")],
+                    logical_disc: None,
                 }),
             ],
             &NormalizationOptions::default(),
@@ -354,6 +359,7 @@ mod tests {
                     consumed_sources: vec![SourceRef::new(
                         "file:/roms/discs/ps1_multi/game_disc1.bin",
                     )],
+                    logical_disc: None,
                 }),
             ],
             &NormalizationOptions::default(),
@@ -385,6 +391,7 @@ mod tests {
                     title: "game".to_string(),
                     disc_number: 1,
                     consumed_sources: vec![SourceRef::new("file:/roms/ps1_multi/game_disc1.bin")],
+                    logical_disc: None,
                 }),
                 DecodedContent::Disc(DecodedDiscContent {
                     id: ContentId::new("ps1_single/game.cue"),
@@ -392,6 +399,7 @@ mod tests {
                     title: "game".to_string(),
                     disc_number: 1,
                     consumed_sources: vec![SourceRef::new("file:/roms/ps1_single/game.bin")],
+                    logical_disc: None,
                 }),
             ],
             &NormalizationOptions::default(),
@@ -468,5 +476,37 @@ mod tests {
         });
 
         assert_eq!(content.kind(), NormalizedContentKind::Text);
+    }
+
+    #[test]
+    fn preserves_logical_disc_through_normalization() {
+        let decoded = DecodedContent::Disc(DecodedDiscContent {
+            id: ContentId::new("ps2/game.chd"),
+            source: SourceRef::new("file:/roms/ps2/game.chd"),
+            title: "Game".to_string(),
+            disc_number: 1,
+            consumed_sources: vec![],
+            logical_disc: Some(LogicalDisc {
+                media: DiscMedia::Dvd,
+                sector_size: 2048,
+                sector_count: 2,
+                content: ReaderHandle::new("test:ps2-dvd", || {
+                    Ok(Box::new(InlineReader::new(vec![0; 4096])))
+                }),
+            }),
+        });
+
+        let normalized = normalize_decoded_content(vec![decoded], &NormalizationOptions::default());
+        let NormalizedContent::Game(game) = &normalized[0] else {
+            panic!("expected normalized game");
+        };
+        let GamePart::Disc(disc) = &game.parts[0] else {
+            panic!("expected normalized disc");
+        };
+        let logical_disc = disc.logical_disc.as_ref().expect("logical disc");
+
+        assert_eq!(logical_disc.media, DiscMedia::Dvd);
+        assert_eq!(logical_disc.byte_len(), Some(4096));
+        assert_eq!(logical_disc.content.id(), "test:ps2-dvd");
     }
 }

--- a/src/core/normalizer.rs
+++ b/src/core/normalizer.rs
@@ -55,7 +55,6 @@ pub(crate) fn normalize_decoded_content(
                         title: leaf_stem_from_source(&rom.source),
                         platform: options
                             .platform_hint
-                            .clone()
                             .unwrap_or_else(|| derive_platform_from_source(&rom.source)),
                         parts: vec![GamePart::Rom(RomPart {
                             source: rom.source,
@@ -216,7 +215,6 @@ fn normalize_disc_group(
         title: primary.title.clone(),
         platform: options
             .platform_hint
-            .clone()
             .unwrap_or_else(|| derive_platform_from_source(&primary.source)),
         parts,
         consumed_sources,

--- a/src/core/reader_handle.rs
+++ b/src/core/reader_handle.rs
@@ -1,0 +1,102 @@
+use std::fmt;
+use std::io;
+use std::sync::Arc;
+
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
+
+use crate::core::reader::Reader;
+
+type ReaderOpener = dyn Fn() -> io::Result<Box<dyn Reader>> + Send + Sync;
+
+/// A clonable, opaque handle that can open a live random-access reader.
+///
+/// Runtime behavior stays in process while debug/inspection output exposes
+/// only the stable identifier.
+#[derive(Clone)]
+pub struct ReaderHandle {
+    id: Arc<str>,
+    open: Arc<ReaderOpener>,
+}
+
+impl ReaderHandle {
+    pub fn new(
+        id: impl Into<Arc<str>>,
+        open: impl Fn() -> io::Result<Box<dyn Reader>> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            open: Arc::new(open),
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn open(&self) -> io::Result<Box<dyn Reader>> {
+        (self.open)()
+    }
+}
+
+impl fmt::Debug for ReaderHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ReaderHandle")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for ReaderHandle {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ReaderHandle {}
+
+impl Serialize for ReaderHandle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("ReaderHandle", 1)?;
+        state.serialize_field("id", self.id())?;
+        state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::readers::inline_reader::InlineReader;
+
+    #[test]
+    fn opens_independent_random_access_readers() {
+        let handle = ReaderHandle::new("test:disc", || {
+            Ok(Box::new(InlineReader::new(b"disc bytes".to_vec())))
+        });
+
+        let mut first = handle.open().unwrap();
+        let mut second = handle.open().unwrap();
+        let mut first_bytes = [0; 4];
+        let mut second_bytes = [0; 5];
+
+        first.read_at(5, &mut first_bytes).unwrap();
+        second.read_at(0, &mut second_bytes).unwrap();
+
+        assert_eq!(&first_bytes, b"byte");
+        assert_eq!(&second_bytes, b"disc ");
+    }
+
+    #[test]
+    fn serializes_only_the_stable_identifier() {
+        let handle = ReaderHandle::new("test:disc", || Ok(Box::new(InlineReader::new(Vec::new()))));
+
+        assert_eq!(
+            serde_json::to_value(handle).unwrap(),
+            serde_json::json!({ "id": "test:disc" })
+        );
+    }
+}

--- a/src/core/vfs.rs
+++ b/src/core/vfs.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+use crate::core::reader_handle::ReaderHandle;
 use crate::core::source::SourceRef;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -126,6 +127,7 @@ impl VfsDirectory {
 pub enum FileBacking {
     Source(SourceRef),
     Inline(Vec<u8>),
+    Reader(ReaderHandle),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -153,6 +155,14 @@ impl VfsFile {
             name: name.into(),
             size: contents.len() as u64,
             backing: FileBacking::Inline(contents),
+        }
+    }
+
+    pub fn reader_backed(name: impl Into<String>, size: u64, handle: ReaderHandle) -> Self {
+        Self {
+            name: name.into(),
+            size,
+            backing: FileBacking::Reader(handle),
         }
     }
 }

--- a/src/core/vfs_reader.rs
+++ b/src/core/vfs_reader.rs
@@ -12,6 +12,7 @@ pub fn open_vfs_file(file: &VfsFile) -> Result<Box<dyn Reader>, io::Error> {
     match &file.backing {
         FileBacking::Inline(contents) => Ok(Box::new(InlineReader::new(contents.clone()))),
         FileBacking::Source(source) => open_source_ref(source),
+        FileBacking::Reader(handle) => handle.open(),
     }
 }
 
@@ -46,6 +47,7 @@ fn open_source_ref(source: &SourceRef) -> Result<Box<dyn Reader>, io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::reader_handle::ReaderHandle;
     use crate::core::vfs::VfsFile;
     use std::fs;
     use std::io::Write;
@@ -60,6 +62,21 @@ mod tests {
 
         assert_eq!(bytes, file.size as usize);
         assert_eq!(&buf, b"disc1.cue\ndisc2.cue\n");
+    }
+
+    #[test]
+    fn opens_live_reader_backed_vfs_file_at_arbitrary_offsets() {
+        let handle = ReaderHandle::new("test:logical-disc", || {
+            Ok(Box::new(InlineReader::new(b"logical disc bytes".to_vec())))
+        });
+        let file = VfsFile::reader_backed("game.iso", 18, handle);
+
+        let mut reader = open_vfs_file(&file).unwrap();
+        let mut buf = vec![0; 4];
+        let bytes = reader.read_at(8, &mut buf).unwrap();
+
+        assert_eq!(bytes, 4);
+        assert_eq!(&buf, b"disc");
     }
 
     #[test]

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -113,11 +113,13 @@ mod tests {
                     source: SourceRef::new("file:/roms/ff7-disc2.cue"),
                     disc_number: 2,
                     consumed_sources: vec![],
+                    logical_disc: None,
                 }),
                 GamePart::Disc(DiscPart {
                     source: SourceRef::new("file:/roms/ff7-disc1.cue"),
                     disc_number: 1,
                     consumed_sources: vec![],
+                    logical_disc: None,
                 }),
             ],
             consumed_sources: vec![],

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -1,27 +1,44 @@
-use crate::output::capabilities::{ContentType, Format};
+use crate::core::content::{DiscMedia, Platform};
+use crate::output::capabilities::{CapabilityFeature, ContentType, Format};
 use crate::output::presentation_spec::{
     ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
 };
 
-const BUILT_IN_PRESENTATIONS: [&str; 2] = ["flat", "grouped"];
+const BUILT_IN_PRESENTATIONS: [&str; 3] = ["flat", "grouped", "opl"];
 
 pub fn built_in_presentation_names() -> &'static [&'static str] {
     &BUILT_IN_PRESENTATIONS
 }
 
 pub fn build_presentation_spec(name: &str) -> Result<PresentationSpec, String> {
-    let layout = match name {
-        "flat" => LayoutSpec::Flat,
-        "grouped" => LayoutSpec::GroupedByPlatformAndGame,
-        _ => {
-            return Err(format!(
-                "unsupported view '{name}'; expected one of: {}",
-                built_in_presentation_names().join(", ")
-            ))
-        }
-    };
-
-    Ok(PresentationSpec::new(layout, built_in_file_rules()))
+    match name {
+        "flat" => Ok(PresentationSpec::new(
+            LayoutSpec::Flat,
+            built_in_file_rules(),
+        )),
+        "grouped" => Ok(PresentationSpec::new(
+            LayoutSpec::GroupedByPlatformAndGame,
+            built_in_file_rules(),
+        )),
+        "opl" => Ok(PresentationSpec::new(
+            LayoutSpec::LiteralRoot("DVD".to_string()),
+            vec![FileRuleSpec::new(
+                SelectSpec::SingleDiscGamesByPlatformAndMedia {
+                    platform: Platform::Ps2,
+                    media: DiscMedia::Dvd,
+                },
+                NamingSpec::GameTitle,
+                ArtifactSpec::new(ContentType::Disc)
+                    .with_format(Format::Iso)
+                    .require_feature(CapabilityFeature::RandomAccess)
+                    .require_feature(CapabilityFeature::Lossless),
+            )],
+        )),
+        _ => Err(format!(
+            "unsupported view '{name}'; expected one of: {}",
+            built_in_presentation_names().join(", ")
+        )),
+    }
 }
 
 fn built_in_file_rules() -> Vec<FileRuleSpec> {
@@ -68,16 +85,20 @@ fn built_in_file_rules() -> Vec<FileRuleSpec> {
 mod tests {
     use super::*;
     use crate::core::content::{
-        ContentId, DiscPart, GameContent, GamePart, NormalizedContent, Platform,
+        ContentId, DiscPart, GameContent, GamePart, LogicalDisc, NormalizedContent, Platform,
     };
+    use crate::core::reader_handle::ReaderHandle;
     use crate::core::source::SourceRef;
+    use crate::core::vfs_reader::open_vfs_file;
+    use crate::output::materialize::materialize_plan;
     use crate::output::plan::{GeneratedArtifact, PlanEntry, PlannedArtifactKind};
     use crate::output::presentation_compile::compile_presentation_spec;
     use crate::policy::PolicySet;
+    use crate::readers::inline_reader::InlineReader;
 
     #[test]
     fn exposes_stable_built_in_presentation_names() {
-        assert_eq!(built_in_presentation_names(), &["flat", "grouped"]);
+        assert_eq!(built_in_presentation_names(), &["flat", "grouped", "opl"]);
     }
 
     #[test]
@@ -90,6 +111,10 @@ mod tests {
             build_presentation_spec("grouped").unwrap().layout,
             LayoutSpec::GroupedByPlatformAndGame
         );
+        assert_eq!(
+            build_presentation_spec("opl").unwrap().layout,
+            LayoutSpec::LiteralRoot("DVD".to_string())
+        );
     }
 
     #[test]
@@ -97,7 +122,7 @@ mod tests {
         let error = build_presentation_spec("unknown").unwrap_err();
         assert_eq!(
             error,
-            "unsupported view 'unknown'; expected one of: flat, grouped"
+            "unsupported view 'unknown'; expected one of: flat, grouped, opl"
         );
     }
 
@@ -136,5 +161,42 @@ mod tests {
             playlist.artifact.kind,
             PlannedArtifactKind::Generated(GeneratedArtifact::Playlist(_))
         ));
+    }
+
+    #[test]
+    fn opl_presentation_materializes_live_ps2_dvd_iso() {
+        let disc_bytes = vec![0x5a; 4096];
+        let reader_bytes = disc_bytes.clone();
+        let content = vec![NormalizedContent::Game(GameContent {
+            id: ContentId::new("ps2:game"),
+            source: SourceRef::new("file:/roms/ps2/Game.chd"),
+            title: "Game".to_string(),
+            platform: Platform::Ps2,
+            parts: vec![GamePart::Disc(DiscPart {
+                source: SourceRef::new("file:/roms/ps2/Game.chd"),
+                disc_number: 1,
+                consumed_sources: vec![],
+                logical_disc: Some(LogicalDisc {
+                    media: DiscMedia::Dvd,
+                    sector_size: 2048,
+                    sector_count: 2,
+                    content: ReaderHandle::new("test:opl-disc", move || {
+                        Ok(Box::new(InlineReader::new(reader_bytes.clone())))
+                    }),
+                }),
+            })],
+            consumed_sources: vec![],
+        })];
+
+        let presentation = build_presentation_spec("opl").unwrap();
+        let plan = compile_presentation_spec(&presentation, &content, &PolicySet::default());
+        let root = materialize_plan(&plan).unwrap();
+        let file = root.find_file("DVD/Game.iso").unwrap();
+        let mut reader = open_vfs_file(file).unwrap();
+        let mut bytes = [0; 8];
+
+        assert_eq!(file.size, 4096);
+        reader.read_at(2044, &mut bytes).unwrap();
+        assert_eq!(&bytes, &[0x5a; 8]);
     }
 }

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -1,7 +1,9 @@
 use crate::engine::bootstrap::build_presentation_spec;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
+use crate::input::chd_disc_decoder::ChdDiscDecoder;
 use crate::input::decode::InputDecoder;
+use crate::input::decoder_registry::DecoderRegistry;
 use crate::input::identify::InputIdentifier;
 use crate::output::presentation_spec::PresentationSpec;
 use crate::policy::PolicySet;
@@ -27,9 +29,13 @@ pub fn pipeline_components(presentation_name: &str) -> Result<PipelineComponents
     let presentation =
         build_presentation_spec(presentation_name).map_err(RetromountError::LoadError)?;
 
+    let mut decoder = DecoderRegistry::new();
+    decoder.register(ChdDiscDecoder::new());
+    decoder.register(BasicInputDecoder::new());
+
     Ok(PipelineComponents {
         identifier: Box::new(BasicInputIdentifier::new()),
-        decoder: Box::new(BasicInputDecoder::new()),
+        decoder: Box::new(decoder),
         presentation,
         policy: PolicySet::default(),
     })

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -1,3 +1,5 @@
+use crate::core::content::Platform;
+use crate::core::normalizer::NormalizationOptions;
 use crate::engine::bootstrap::build_presentation_spec;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
@@ -18,6 +20,7 @@ pub struct PipelineComponents {
     pub identifier: Box<dyn InputIdentifier>,
     pub decoder: Box<dyn InputDecoder>,
     pub presentation: PresentationSpec,
+    pub normalization: NormalizationOptions,
     pub policy: PolicySet,
 }
 
@@ -33,10 +36,19 @@ pub fn pipeline_components(presentation_name: &str) -> Result<PipelineComponents
     decoder.register(ChdDiscDecoder::new());
     decoder.register(BasicInputDecoder::new());
 
+    let normalization = if presentation_name == "opl" {
+        NormalizationOptions {
+            platform_hint: Some(Platform::Ps2),
+        }
+    } else {
+        NormalizationOptions::default()
+    };
+
     Ok(PipelineComponents {
         identifier: Box::new(BasicInputIdentifier::new()),
         decoder: Box::new(decoder),
         presentation,
+        normalization,
         policy: PolicySet::default(),
     })
 }

--- a/src/engine/inspect.rs
+++ b/src/engine/inspect.rs
@@ -6,10 +6,7 @@ use crate::engine::components::pipeline_components_for_presentation;
 use crate::error::RetromountError;
 use crate::output::plugin_registry::PluginRegistry;
 
-use super::pipeline::{
-    run_pipeline_with_presentation_options, run_pipeline_with_presentation_trace, PipelineOptions,
-    PipelineTrace,
-};
+use super::pipeline::{run_pipeline_with_presentation_options, PipelineOptions, PipelineTrace};
 use super::preview::{build_input_source, write_vfs_tree};
 
 pub fn run_phase3_inspect(
@@ -30,26 +27,17 @@ pub fn run_phase3_inspect_with_plugins(
     let kind = source.kind();
     let components = pipeline_components_for_presentation(presentation_name)?;
 
-    let trace = match plugin_registry {
-        Some(plugin_registry) => run_pipeline_with_presentation_options(
-            source.as_ref(),
-            components.identifier.as_ref(),
-            components.decoder.as_ref(),
-            &components.presentation,
-            &components.policy,
-            &PipelineOptions {
-                normalization: Default::default(),
-                plugin_registry: Some(plugin_registry),
-            },
-        )?,
-        None => run_pipeline_with_presentation_trace(
-            source.as_ref(),
-            components.identifier.as_ref(),
-            components.decoder.as_ref(),
-            &components.presentation,
-            &components.policy,
-        )?,
-    };
+    let trace = run_pipeline_with_presentation_options(
+        source.as_ref(),
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &components.presentation,
+        &components.policy,
+        &PipelineOptions {
+            normalization: components.normalization.clone(),
+            plugin_registry,
+        },
+    )?;
 
     if json {
         let output = serde_json::to_string_pretty(&trace)

--- a/src/engine/mount.rs
+++ b/src/engine/mount.rs
@@ -3,9 +3,7 @@ use std::path::Path;
 use log::info;
 
 use crate::engine::components::pipeline_components_for_presentation;
-use crate::engine::pipeline::{
-    run_pipeline_with_presentation, run_pipeline_with_presentation_options, PipelineOptions,
-};
+use crate::engine::pipeline::{run_pipeline_with_presentation_options, PipelineOptions};
 use crate::engine::preview::build_input_source;
 use crate::error::RetromountError;
 use crate::input::decode::InputDecoder;
@@ -65,13 +63,14 @@ pub fn prepare_mount_session_with_plugins(
     let source = build_input_source(input)?;
     let components = pipeline_components_for_presentation(presentation_name)?;
 
-    prepare_mount_session_from_presentation(
+    prepare_mount_session_from_presentation_with_normalization(
         source.as_ref(),
         components.identifier.as_ref(),
         components.decoder.as_ref(),
         &components.presentation,
         &components.policy,
         plugin_registry,
+        &components.normalization,
     )
 }
 
@@ -83,25 +82,39 @@ pub fn prepare_mount_session_from_presentation(
     policy: &PolicySet,
     plugin_registry: Option<&PluginRegistry>,
 ) -> Result<MountSession, RetromountError> {
-    let root = match plugin_registry {
-        Some(plugin_registry) => {
-            run_pipeline_with_presentation_options(
-                source,
-                identifier,
-                decoder,
-                presentation,
-                policy,
-                &PipelineOptions {
-                    normalization: Default::default(),
-                    plugin_registry: Some(plugin_registry),
-                },
-            )
-            .map_err(|err| RetromountError::LoadError(err.to_string()))?
-            .output_vfs
-        }
-        None => run_pipeline_with_presentation(source, identifier, decoder, presentation, policy)
-            .map_err(|err| RetromountError::LoadError(err.to_string()))?,
-    };
+    prepare_mount_session_from_presentation_with_normalization(
+        source,
+        identifier,
+        decoder,
+        presentation,
+        policy,
+        plugin_registry,
+        &Default::default(),
+    )
+}
+
+fn prepare_mount_session_from_presentation_with_normalization(
+    source: &dyn InputSource,
+    identifier: &dyn InputIdentifier,
+    decoder: &dyn InputDecoder,
+    presentation: &crate::output::presentation_spec::PresentationSpec,
+    policy: &PolicySet,
+    plugin_registry: Option<&PluginRegistry>,
+    normalization: &crate::core::normalizer::NormalizationOptions,
+) -> Result<MountSession, RetromountError> {
+    let root = run_pipeline_with_presentation_options(
+        source,
+        identifier,
+        decoder,
+        presentation,
+        policy,
+        &PipelineOptions {
+            normalization: normalization.clone(),
+            plugin_registry,
+        },
+    )
+    .map_err(|err| RetromountError::LoadError(err.to_string()))?
+    .output_vfs;
 
     Ok(MountSession::from_root(&root))
 }

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -80,7 +80,7 @@ impl InputDecoder for BasicInputDecoder {
                 source: object.source.clone(),
                 size,
             }),
-            InputIdentity::Directory | InputIdentity::Archive => {
+            InputIdentity::Directory | InputIdentity::Archive | InputIdentity::ChdDisc => {
                 return Ok(Vec::new());
             }
         };
@@ -280,6 +280,13 @@ mod tests {
         let content = decoder.decode(&object, &InputIdentity::File).unwrap();
         assert_eq!(content.len(), 1);
         assert!(matches!(content[0], DecodedContent::Rom(_)));
+    }
+
+    #[test]
+    fn leaves_chd_content_for_a_dedicated_decoder() {
+        let decoder = BasicInputDecoder::new();
+
+        assert!(!decoder.supports(&InputIdentity::ChdDisc));
     }
 
     #[test]

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -57,6 +57,7 @@ impl InputDecoder for BasicInputDecoder {
                     title,
                     disc_number,
                     consumed_sources: consumed_sources_for_disc_image(object)?,
+                    logical_disc: None,
                 })
             }
             InputIdentity::File => {

--- a/src/input/basic_identifier.rs
+++ b/src/input/basic_identifier.rs
@@ -23,6 +23,7 @@ impl InputIdentifier for BasicInputIdentifier {
 
         let identity = match path.extension().and_then(|ext| ext.to_str()) {
             Some(ext) if ext.eq_ignore_ascii_case("cue") => InputIdentity::DiscImage,
+            Some(ext) if ext.eq_ignore_ascii_case("chd") => InputIdentity::ChdDisc,
             Some(ext)
                 if ext.eq_ignore_ascii_case("txt")
                     || ext.eq_ignore_ascii_case("md")
@@ -65,5 +66,19 @@ mod tests {
 
         let identity = identifier.identify(&object).unwrap();
         assert_eq!(identity, InputIdentity::DiscImage);
+    }
+
+    #[test]
+    fn identifies_chd_as_distinct_disc_container() {
+        let identifier = BasicInputIdentifier::new();
+        let object = SourceObject {
+            source: SourceRef::new("/tmp/game.CHD"),
+            name: "game.CHD".to_string(),
+        };
+
+        assert_eq!(
+            identifier.identify(&object).unwrap(),
+            InputIdentity::ChdDisc
+        );
     }
 }

--- a/src/input/chd_disc_decoder.rs
+++ b/src/input/chd_disc_decoder.rs
@@ -1,0 +1,203 @@
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use chd::metadata::MetadataTag;
+use chd::Chd;
+
+use crate::core::content::{ContentId, DecodedContent, DecodedDiscContent, DiscMedia, LogicalDisc};
+use crate::core::reader_handle::ReaderHandle;
+use crate::core::source::SourceObject;
+use crate::input::decode::InputDecoder;
+use crate::input::identify::InputIdentity;
+use crate::readers::chd_reader::ChdReader;
+
+const DVD_METADATA_TAG: u32 = u32::from_be_bytes(*b"DVD ");
+const DVD_SECTOR_SIZE: u32 = 2048;
+
+#[derive(Debug, Default)]
+pub struct ChdDiscDecoder;
+
+#[derive(Debug, Clone, Copy)]
+struct ChdDiscInfo {
+    has_parent: bool,
+    has_dvd_metadata: bool,
+    unit_bytes: u32,
+    logical_bytes: u64,
+}
+
+impl ChdDiscDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn inspect(path: &Path) -> io::Result<ChdDiscInfo> {
+        let file = File::open(path)?;
+        let mut chd = Chd::open(file, None)
+            .map_err(|error| io::Error::other(format!("failed to open CHD: {error}")))?;
+        let header = chd.header();
+        let has_parent = header.has_parent();
+        let unit_bytes = header.unit_bytes();
+        let logical_bytes = header.logical_bytes();
+        let has_dvd_metadata = chd
+            .metadata_refs()
+            .any(|metadata| metadata.metatag() == DVD_METADATA_TAG);
+
+        Ok(ChdDiscInfo {
+            has_parent,
+            has_dvd_metadata,
+            unit_bytes,
+            logical_bytes,
+        })
+    }
+
+    fn logical_disc(path: PathBuf, info: ChdDiscInfo) -> io::Result<LogicalDisc> {
+        if info.has_parent {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "parent/delta CHDs are not supported",
+            ));
+        }
+        if !info.has_dvd_metadata {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "CHD does not describe DVD media",
+            ));
+        }
+        if info.unit_bytes != DVD_SECTOR_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "DVD CHD unit size must be {DVD_SECTOR_SIZE} bytes, found {}",
+                    info.unit_bytes
+                ),
+            ));
+        }
+        if info.logical_bytes == 0 || !info.logical_bytes.is_multiple_of(DVD_SECTOR_SIZE.into()) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "DVD CHD logical size must contain whole 2048-byte sectors",
+            ));
+        }
+
+        let reader_path = path.clone();
+        let handle_id = format!("chd:{}", path.to_string_lossy());
+        Ok(LogicalDisc {
+            media: DiscMedia::Dvd,
+            sector_size: DVD_SECTOR_SIZE,
+            sector_count: info.logical_bytes / u64::from(DVD_SECTOR_SIZE),
+            content: ReaderHandle::new(handle_id, move || {
+                Ok(Box::new(ChdReader::open(&reader_path)?))
+            }),
+        })
+    }
+}
+
+impl InputDecoder for ChdDiscDecoder {
+    fn supports(&self, identity: &InputIdentity) -> bool {
+        matches!(identity, InputIdentity::ChdDisc)
+    }
+
+    fn decode(
+        &self,
+        object: &SourceObject,
+        identity: &InputIdentity,
+    ) -> Result<Vec<DecodedContent>, io::Error> {
+        if !self.supports(identity) {
+            return Ok(Vec::new());
+        }
+
+        let path = PathBuf::from(object.source.0.as_ref());
+        let logical_disc = Self::logical_disc(path.clone(), Self::inspect(&path)?)?;
+        let title = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or(&object.name)
+            .to_string();
+
+        Ok(vec![DecodedContent::Disc(DecodedDiscContent {
+            id: ContentId::new(object.name.clone()),
+            source: object.source.clone(),
+            title,
+            disc_number: 1,
+            consumed_sources: Vec::new(),
+            logical_disc: Some(logical_disc),
+        })])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_info() -> ChdDiscInfo {
+        ChdDiscInfo {
+            has_parent: false,
+            has_dvd_metadata: true,
+            unit_bytes: DVD_SECTOR_SIZE,
+            logical_bytes: u64::from(DVD_SECTOR_SIZE) * 3,
+        }
+    }
+
+    #[test]
+    fn builds_a_live_logical_dvd_from_valid_geometry() {
+        let disc =
+            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), valid_info()).unwrap();
+
+        assert_eq!(disc.media, DiscMedia::Dvd);
+        assert_eq!(disc.sector_size, DVD_SECTOR_SIZE);
+        assert_eq!(disc.sector_count, 3);
+        assert_eq!(disc.byte_len(), Some(6144));
+        assert_eq!(disc.content.id(), "chd:/tmp/game.chd");
+    }
+
+    #[test]
+    fn rejects_parent_and_non_dvd_chds() {
+        let parent = ChdDiscInfo {
+            has_parent: true,
+            ..valid_info()
+        };
+        let non_dvd = ChdDiscInfo {
+            has_dvd_metadata: false,
+            ..valid_info()
+        };
+
+        assert_eq!(
+            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), parent)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), non_dvd)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Unsupported
+        );
+    }
+
+    #[test]
+    fn rejects_non_iso_dvd_geometry() {
+        let wrong_unit = ChdDiscInfo {
+            unit_bytes: 4096,
+            ..valid_info()
+        };
+        let partial_sector = ChdDiscInfo {
+            logical_bytes: 2049,
+            ..valid_info()
+        };
+
+        assert_eq!(
+            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), wrong_unit)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), partial_sector)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/src/input/chd_disc_decoder.rs
+++ b/src/input/chd_disc_decoder.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use chd::metadata::MetadataTag;
-use chd::Chd;
+use chd::{Chd, Error as ChdError};
 
 use crate::core::content::{ContentId, DecodedContent, DecodedDiscContent, DiscMedia, LogicalDisc};
 use crate::core::reader_handle::ReaderHandle;
@@ -33,8 +33,7 @@ impl ChdDiscDecoder {
 
     fn inspect(path: &Path) -> io::Result<ChdDiscInfo> {
         let file = File::open(path)?;
-        let mut chd = Chd::open(file, None)
-            .map_err(|error| io::Error::other(format!("failed to open CHD: {error}")))?;
+        let mut chd = Chd::open(file, None).map_err(map_chd_open_error)?;
         let header = chd.header();
         let has_parent = header.has_parent();
         let unit_bytes = header.unit_bytes();
@@ -91,6 +90,23 @@ impl ChdDiscDecoder {
             }),
         })
     }
+}
+
+fn map_chd_open_error(error: ChdError) -> io::Error {
+    let kind = match error {
+        ChdError::InvalidFile
+        | ChdError::InvalidData
+        | ChdError::InvalidMetadata
+        | ChdError::InvalidMetadataSize
+        | ChdError::ReadError => io::ErrorKind::InvalidData,
+        ChdError::RequiresParent
+        | ChdError::NotSupported
+        | ChdError::UnsupportedFormat
+        | ChdError::UnsupportedVersion => io::ErrorKind::Unsupported,
+        _ => io::ErrorKind::Other,
+    };
+
+    io::Error::new(kind, format!("failed to open CHD: {error}"))
 }
 
 impl InputDecoder for ChdDiscDecoder {
@@ -198,6 +214,22 @@ mod tests {
                 .unwrap_err()
                 .kind(),
             io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn maps_invalid_and_unsupported_chd_errors_to_actionable_io_kinds() {
+        assert_eq!(
+            map_chd_open_error(ChdError::InvalidData).kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            map_chd_open_error(ChdError::UnsupportedVersion).kind(),
+            io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            map_chd_open_error(ChdError::RequiresParent).kind(),
+            io::ErrorKind::Unsupported
         );
     }
 }

--- a/src/input/decoder_registry.rs
+++ b/src/input/decoder_registry.rs
@@ -1,0 +1,84 @@
+use std::io;
+
+use crate::core::content::DecodedContent;
+use crate::core::source::SourceObject;
+use crate::input::decode::InputDecoder;
+use crate::input::identify::InputIdentity;
+
+#[derive(Default)]
+pub struct DecoderRegistry {
+    decoders: Vec<Box<dyn InputDecoder>>,
+}
+
+impl DecoderRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, decoder: impl InputDecoder + 'static) {
+        self.decoders.push(Box::new(decoder));
+    }
+}
+
+impl InputDecoder for DecoderRegistry {
+    fn supports(&self, identity: &InputIdentity) -> bool {
+        self.decoders
+            .iter()
+            .any(|decoder| decoder.supports(identity))
+    }
+
+    fn decode(
+        &self,
+        object: &SourceObject,
+        identity: &InputIdentity,
+    ) -> Result<Vec<DecodedContent>, io::Error> {
+        let decoder = self
+            .decoders
+            .iter()
+            .find(|decoder| decoder.supports(identity))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!("no decoder supports {identity:?}"),
+                )
+            })?;
+
+        decoder.decode(object, identity)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::basic_decoder::BasicInputDecoder;
+
+    #[test]
+    fn delegates_to_a_decoder_that_supports_the_identity() {
+        let mut registry = DecoderRegistry::new();
+        registry.register(BasicInputDecoder::new());
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let object = SourceObject {
+            source: crate::core::source::SourceRef::new(file.path().to_string_lossy().into_owned()),
+            name: "readme.txt".to_string(),
+        };
+
+        let decoded = registry.decode(&object, &InputIdentity::Text).unwrap();
+
+        assert_eq!(decoded.len(), 1);
+    }
+
+    #[test]
+    fn rejects_an_identity_without_a_registered_decoder() {
+        let registry = DecoderRegistry::new();
+        let object = SourceObject {
+            source: crate::core::source::SourceRef::new("/tmp/game.chd"),
+            name: "game.chd".to_string(),
+        };
+
+        let error = registry
+            .decode(&object, &InputIdentity::ChdDisc)
+            .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+    }
+}

--- a/src/input/identify.rs
+++ b/src/input/identify.rs
@@ -7,6 +7,7 @@ pub enum InputIdentity {
     Directory,
     Archive,
     DiscImage,
+    ChdDisc,
     Text,
     Unknown,
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,6 +1,8 @@
 pub mod basic_decoder;
 pub mod basic_identifier;
+pub mod chd_disc_decoder;
 pub mod decode;
+pub mod decoder_registry;
 pub mod directory_source;
 pub mod file_source;
 pub mod identify;

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,7 @@ fn pipeline_options_for_view(view: &ViewConfig) -> PipelineOptions<'static> {
 fn map_view_platform(platform: &ConfigPlatform) -> ContentPlatform {
     match platform {
         ConfigPlatform::PlayStation => ContentPlatform::Ps1,
+        ConfigPlatform::PlayStation2 => ContentPlatform::Ps2,
         ConfigPlatform::SuperNintendo => ContentPlatform::Snes,
         ConfigPlatform::MegaDrive => ContentPlatform::Megadrive,
         _ => ContentPlatform::Unknown,

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ fn main() -> Result<(), RetromountError> {
         }
 
         _ => Err(RetromountError::LoadError(
-            "usage:\n  retromount\n  retromount phase3-preview <path> [--plugin-dir <dir>]\n  retromount inspect <path> [--json] [--view <grouped|flat>] [--plugin-dir <dir>]\n  retromount mount <input> <mountpoint> [--view <grouped|flat>] [--plugin-dir <dir>]"
+            "usage:\n  retromount\n  retromount phase3-preview <path> [--plugin-dir <dir>]\n  retromount inspect <path> [--json] [--view <grouped|flat|opl>] [--plugin-dir <dir>]\n  retromount mount <input> <mountpoint> [--view <grouped|flat|opl>] [--plugin-dir <dir>]"
                 .to_string(),
         )),
     }

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::io;
 
+use crate::core::reader_handle::ReaderHandle;
 use crate::core::source::SourceRef;
 use crate::core::vfs::VfsFile;
 use crate::output::capabilities::EncoderCapability;
@@ -10,6 +11,7 @@ use crate::output::plan::{ArtifactId, ArtifactRequest};
 pub enum MaterializedArtifact {
     SourceBacked { source: SourceRef, size: u64 },
     Inline(Vec<u8>),
+    ReaderBacked { handle: ReaderHandle, size: u64 },
 }
 
 impl MaterializedArtifact {
@@ -19,6 +21,9 @@ impl MaterializedArtifact {
                 VfsFile::source_backed(name, *size, source.clone())
             }
             Self::Inline(contents) => VfsFile::inline(name, contents.clone()),
+            Self::ReaderBacked { handle, size } => {
+                VfsFile::reader_backed(name, *size, handle.clone())
+            }
         }
     }
 }

--- a/src/output/encoder_registry.rs
+++ b/src/output/encoder_registry.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::output::basic_encoder::BasicEncoder;
 use crate::output::encode::OutputEncoder;
+use crate::output::logical_disc_iso_encoder::LogicalDiscIsoEncoder;
 
 pub struct EncoderRegistry {
     encoders: HashMap<String, Box<dyn Fn() -> Box<dyn OutputEncoder>>>,
@@ -51,5 +52,9 @@ impl Default for EncoderRegistry {
 pub fn default_encoder_registry() -> EncoderRegistry {
     let mut registry = EncoderRegistry::new();
     registry.register("basic", || Box::new(BasicEncoder::new()));
+    registry.register(
+        "logical-disc-iso",
+        || Box::new(LogicalDiscIsoEncoder::new()),
+    );
     registry
 }

--- a/src/output/logical_disc_iso_encoder.rs
+++ b/src/output/logical_disc_iso_encoder.rs
@@ -1,0 +1,74 @@
+use std::io;
+
+use crate::core::content::DiscMedia;
+use crate::output::capabilities::{CapabilityFeature, ContentType, EncoderCapability, Format};
+use crate::output::encode::{MaterializationContext, MaterializedArtifact, OutputEncoder};
+use crate::output::plan::{ArtifactRequest, PlannedArtifactKind};
+
+pub struct LogicalDiscIsoEncoder;
+
+impl LogicalDiscIsoEncoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LogicalDiscIsoEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OutputEncoder for LogicalDiscIsoEncoder {
+    fn plugin_id(&self) -> &str {
+        "logical-disc-iso"
+    }
+
+    fn capabilities(&self) -> Vec<EncoderCapability> {
+        vec![
+            EncoderCapability::new(self.plugin_id(), "disc.logical-dvd.iso", ContentType::Disc)
+                .supports_format(Format::Iso)
+                .with_feature(CapabilityFeature::RandomAccess)
+                .with_feature(CapabilityFeature::Lossless),
+        ]
+    }
+
+    fn materialize(
+        &self,
+        _file_name: &str,
+        artifact: &ArtifactRequest,
+        selected_capability_id: &str,
+        _context: &MaterializationContext,
+    ) -> Result<MaterializedArtifact, io::Error> {
+        if selected_capability_id != "disc.logical-dvd.iso" {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unsupported capability '{selected_capability_id}'"),
+            ));
+        }
+
+        let PlannedArtifactKind::ContentBacked(content) = &artifact.kind else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "logical DVD ISO encoding requires a content-backed artifact",
+            ));
+        };
+        let disc = &content.logical_disc;
+
+        if disc.media != DiscMedia::Dvd || disc.sector_size != 2048 {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "ISO output requires DVD media with 2048-byte logical sectors",
+            ));
+        }
+
+        let size = disc.byte_len().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "logical disc size overflow")
+        })?;
+
+        Ok(MaterializedArtifact::ReaderBacked {
+            handle: disc.content.clone(),
+            size,
+        })
+    }
+}

--- a/src/output/materialize.rs
+++ b/src/output/materialize.rs
@@ -162,12 +162,17 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::core::content::{DiscMedia, LogicalDisc};
+    use crate::core::reader_handle::ReaderHandle;
     use crate::core::source::SourceRef;
+    use crate::core::vfs_reader::open_vfs_file;
     use crate::output::basic_encoder::BasicEncoder;
-    use crate::output::capabilities::{CapabilityRequirements, ContentType, Format};
+    use crate::output::capabilities::{
+        CapabilityFeature, CapabilityRequirements, ContentType, Format,
+    };
     use crate::output::plan::{
-        ArtifactReference, ArtifactRequest, GeneratedArtifact, PlanFile, PlannedArtifactKind,
-        PlaylistArtifact, SourceArtifact, SourceArtifactInput,
+        ArtifactReference, ArtifactRequest, ContentArtifact, GeneratedArtifact, PlanFile,
+        PlannedArtifactKind, PlaylistArtifact, SourceArtifact, SourceArtifactInput,
     };
     use crate::output::plugin_client::EncoderPluginClient;
     use crate::output::plugin_protocol::{
@@ -175,6 +180,7 @@ mod tests {
         ProtocolEncoderCapability, ProtocolFormat, ProtocolMaterializedSourceFile,
         ENCODER_PLUGIN_PROTOCOL_V1,
     };
+    use crate::readers::inline_reader::InlineReader;
 
     #[derive(Clone)]
     struct TestPluginClient {
@@ -339,6 +345,45 @@ mod tests {
 
         assert_eq!(root.children().len(), 1);
         assert_eq!(root.children()[0].name(), "game.bin");
+    }
+
+    #[test]
+    fn materializes_logical_dvd_as_live_random_access_iso() {
+        let mut bytes = vec![0; 4096];
+        bytes[32..36].copy_from_slice(b"head");
+        bytes[3000..3004].copy_from_slice(b"tail");
+        let reader_bytes = bytes.clone();
+        let plan = PresentationPlan::new(vec![PlanEntry::File(PlanFile::new(
+            "Game.iso",
+            ArtifactRequest::new(
+                ArtifactId::new("game"),
+                PlannedArtifactKind::ContentBacked(ContentArtifact::logical_disc(LogicalDisc {
+                    media: DiscMedia::Dvd,
+                    sector_size: 2048,
+                    sector_count: 2,
+                    content: ReaderHandle::new("test:logical-dvd", move || {
+                        Ok(Box::new(InlineReader::new(reader_bytes.clone())))
+                    }),
+                })),
+                CapabilityRequirements::new(ContentType::Disc)
+                    .with_format(Format::Iso)
+                    .require_feature(CapabilityFeature::RandomAccess)
+                    .require_feature(CapabilityFeature::Lossless),
+            ),
+        ))]);
+
+        let root = materialize_plan(&plan).unwrap();
+        let file = root.find_file("Game.iso").unwrap();
+        assert_eq!(file.size, 4096);
+
+        let mut reader = open_vfs_file(file).unwrap();
+        let mut tail = [0; 4];
+        let mut head = [0; 4];
+        reader.read_at(3000, &mut tail).unwrap();
+        reader.read_at(32, &mut head).unwrap();
+
+        assert_eq!(&tail, b"tail");
+        assert_eq!(&head, b"head");
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -2,6 +2,7 @@ pub mod basic_encoder;
 pub mod capabilities;
 pub mod encode;
 pub mod encoder_registry;
+pub mod logical_disc_iso_encoder;
 pub mod materialize;
 pub mod name_allocator;
 pub mod plan;

--- a/src/output/plan.rs
+++ b/src/output/plan.rs
@@ -1,3 +1,4 @@
+use crate::core::content::LogicalDisc;
 use crate::core::source::SourceRef;
 use crate::output::capabilities::CapabilityRequirements;
 
@@ -87,7 +88,19 @@ impl ArtifactRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlannedArtifactKind {
     SourceBacked(SourceArtifact),
+    ContentBacked(ContentArtifact),
     Generated(GeneratedArtifact),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentArtifact {
+    pub logical_disc: LogicalDisc,
+}
+
+impl ContentArtifact {
+    pub fn logical_disc(logical_disc: LogicalDisc) -> Self {
+        Self { logical_disc }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/output/plugin_client.rs
+++ b/src/output/plugin_client.rs
@@ -27,7 +27,7 @@ pub fn materialize_via_plugin(
     let manifest = client.manifest()?;
     validate_manifest(&manifest)?;
 
-    let request = to_materialization_request(file_name, artifact, selected_capability_id, context);
+    let request = to_materialization_request(file_name, artifact, selected_capability_id, context)?;
 
     validate_materialization_request(&request, &manifest)?;
 

--- a/src/output/plugin_encoder.rs
+++ b/src/output/plugin_encoder.rs
@@ -63,7 +63,8 @@ impl OutputEncoder for PluginBackedEncoder {
         capability_id: &str,
         context: &MaterializationContext,
     ) -> Result<MaterializedArtifact, std::io::Error> {
-        let request = to_materialization_request(file_name, artifact, capability_id, context);
+        let request = to_materialization_request(file_name, artifact, capability_id, context)
+            .map_err(to_io_error)?;
 
         let response = self.client.materialize(&request).map_err(to_io_error)?;
 

--- a/src/output/plugin_protocol_conversion.rs
+++ b/src/output/plugin_protocol_conversion.rs
@@ -428,8 +428,10 @@ pub fn to_artifact_request(
     Ok((logical_name, artifact, selected_capability_id, context))
 }
 
-pub fn to_protocol_response(artifact: MaterializedArtifact) -> MaterializationResponse {
-    match artifact {
+pub fn to_protocol_response(
+    artifact: MaterializedArtifact,
+) -> Result<MaterializationResponse, ProtocolError> {
+    let response = match artifact {
         MaterializedArtifact::SourceBacked { source, size } => {
             MaterializationResponse::SourceBacked(ProtocolMaterializedSourceFile {
                 source: source.0.as_ref().to_string(),
@@ -439,7 +441,14 @@ pub fn to_protocol_response(artifact: MaterializedArtifact) -> MaterializationRe
         MaterializedArtifact::Inline(bytes) => {
             MaterializationResponse::Inline(ProtocolInlineFile { bytes })
         }
-    }
+        MaterializedArtifact::ReaderBacked { .. } => {
+            return Err(ProtocolError::UnsupportedArtifactKind {
+                message: "protocol v1 cannot transport reader-backed artifacts".to_string(),
+            });
+        }
+    };
+
+    Ok(response)
 }
 
 pub fn to_encoder_capability(

--- a/src/output/plugin_protocol_conversion.rs
+++ b/src/output/plugin_protocol_conversion.rs
@@ -45,15 +45,15 @@ pub fn to_materialization_request(
     artifact: &ArtifactRequest,
     selected_capability_id: &str,
     context: &MaterializationContext,
-) -> MaterializationRequest {
-    MaterializationRequest {
+) -> Result<MaterializationRequest, ProtocolError> {
+    Ok(MaterializationRequest {
         artifact_id: artifact.id.0.clone(),
         logical_name: file_name.to_string(),
         selected_capability_id: selected_capability_id.to_string(),
-        artifact_kind: ProtocolArtifactKind::from(artifact.kind.clone()),
+        artifact_kind: artifact.kind.clone().try_into()?,
         requirements: ProtocolCapabilityRequirements::from(artifact.requirements.clone()),
         context: ProtocolMaterializationContext::from(context.clone()),
-    }
+    })
 }
 
 pub fn from_materialization_response(
@@ -239,16 +239,23 @@ impl From<GeneratedArtifact> for ProtocolGeneratedArtifact {
     }
 }
 
-impl From<PlannedArtifactKind> for ProtocolArtifactKind {
-    fn from(value: PlannedArtifactKind) -> Self {
-        match value {
+impl TryFrom<PlannedArtifactKind> for ProtocolArtifactKind {
+    type Error = ProtocolError;
+
+    fn try_from(value: PlannedArtifactKind) -> Result<Self, Self::Error> {
+        Ok(match value {
             PlannedArtifactKind::SourceBacked(source_artifact) => {
                 Self::SourceBacked(source_artifact.into())
             }
             PlannedArtifactKind::Generated(generated_artifact) => {
                 Self::Generated(generated_artifact.into())
             }
-        }
+            PlannedArtifactKind::ContentBacked(_) => {
+                return Err(ProtocolError::UnsupportedArtifactKind {
+                    message: "protocol v1 cannot transport content-backed artifacts".to_string(),
+                });
+            }
+        })
     }
 }
 
@@ -476,6 +483,10 @@ pub fn to_encoder_capability(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::content::{DiscMedia, LogicalDisc};
+    use crate::core::reader_handle::ReaderHandle;
+    use crate::output::plan::ContentArtifact;
+    use crate::readers::inline_reader::InlineReader;
 
     #[test]
     fn converts_encoder_capability_to_protocol_capability() {
@@ -493,6 +504,34 @@ mod tests {
             .features
             .contains(&ProtocolCapabilityFeature::Lossless));
         assert_eq!(protocol.priority, 100);
+    }
+
+    #[test]
+    fn rejects_content_backed_artifacts_for_protocol_v1() {
+        let artifact = ArtifactRequest::new(
+            ArtifactId::new("disc-1"),
+            PlannedArtifactKind::ContentBacked(ContentArtifact::logical_disc(LogicalDisc {
+                media: DiscMedia::Dvd,
+                sector_size: 2048,
+                sector_count: 1,
+                content: ReaderHandle::new("test:disc", || {
+                    Ok(Box::new(InlineReader::new(vec![0; 2048])))
+                }),
+            })),
+            CapabilityRequirements::new(ContentType::Disc).with_format(Format::Iso),
+        );
+
+        assert!(matches!(
+            to_materialization_request(
+                "Game.iso",
+                &artifact,
+                "disc.logical-to-iso",
+                &MaterializationContext {
+                    artifact_names: HashMap::new(),
+                },
+            ),
+            Err(ProtocolError::UnsupportedArtifactKind { .. })
+        ));
     }
 
     #[test]
@@ -514,7 +553,8 @@ mod tests {
 
         let context = MaterializationContext { artifact_names };
 
-        let request = to_materialization_request("Game.m3u", &artifact, "playlist.m3u", &context);
+        let request =
+            to_materialization_request("Game.m3u", &artifact, "playlist.m3u", &context).unwrap();
 
         assert_eq!(request.artifact_id, "playlist-1");
         assert_eq!(request.logical_name, "Game.m3u");
@@ -574,7 +614,7 @@ mod tests {
         let context = MaterializationContext { artifact_names };
 
         let protocol_request =
-            to_materialization_request("Game.iso", &artifact, "disc.iso", &context);
+            to_materialization_request("Game.iso", &artifact, "disc.iso", &context).unwrap();
 
         let (logical_name, decoded_artifact, selected_capability_id, decoded_context) =
             to_artifact_request(protocol_request).unwrap();

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -25,10 +25,17 @@ pub fn compile_presentation_spec(
     content: &[NormalizedContent],
     policy: &PolicySet,
 ) -> PresentationPlan {
-    match spec.layout {
+    match &spec.layout {
         LayoutSpec::Flat => compile_flat(spec, content, policy),
         LayoutSpec::GroupedByPlatformAndGame => {
             compile_grouped_by_platform_and_game(spec, content, policy)
+        }
+        LayoutSpec::LiteralRoot(name) => {
+            let flat = compile_flat(spec, content, policy);
+            PresentationPlan::new(vec![PlanEntry::Directory(PlanDirectory::new(
+                name.clone(),
+                flat.entries,
+            ))])
         }
     }
 }
@@ -117,6 +124,9 @@ fn try_compile_rule(
         SelectSpec::Games => match_game(item),
         SelectSpec::GamesWithoutParts => match_game_without_parts(item),
         SelectSpec::SingleDiscGames => match_single_disc_game(item),
+        SelectSpec::SingleDiscGamesByPlatformAndMedia { platform, media } => {
+            match_single_disc_game_by_platform_and_media(item, platform, media)
+        }
         SelectSpec::MultiDiscGames => unreachable!("handled above"),
         SelectSpec::SingleRomGames => match_single_rom_game(item),
         SelectSpec::Bytes => match_bytes(item),
@@ -370,6 +380,23 @@ fn match_single_disc_game(item: &NormalizedContent) -> Option<SourceMatch> {
     }
 }
 
+fn match_single_disc_game_by_platform_and_media(
+    item: &NormalizedContent,
+    platform: crate::core::content::Platform,
+    media: crate::core::content::DiscMedia,
+) -> Option<SourceMatch> {
+    let NormalizedContent::Game(game) = item else {
+        return None;
+    };
+
+    if game.platform != platform {
+        return None;
+    }
+
+    let matched = match_single_disc_game(item)?;
+    (matched.logical_disc.as_ref()?.media == media).then_some(matched)
+}
+
 fn match_single_rom_game(item: &NormalizedContent) -> Option<SourceMatch> {
     let NormalizedContent::Game(game) = item else {
         return None;
@@ -534,6 +561,9 @@ fn build_artifact_id(select: &SelectSpec, item: &NormalizedContent) -> ArtifactI
             ArtifactId::new(format!("game:{}", game.id))
         }
         (SelectSpec::SingleDiscGames, NormalizedContent::Game(game)) => {
+            ArtifactId::new(format!("game:{}", game.id))
+        }
+        (SelectSpec::SingleDiscGamesByPlatformAndMedia { .. }, NormalizedContent::Game(game)) => {
             ArtifactId::new(format!("game:{}", game.id))
         }
         (SelectSpec::MultiDiscGames, NormalizedContent::Game(game)) => {

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -2,8 +2,9 @@ use crate::core::content::{ContentMeta, GameContent, GamePart, NormalizedContent
 use crate::core::source::SourceRef;
 use crate::output::capabilities::{CapabilityRequirements, ContentType, Format};
 use crate::output::plan::{
-    ArtifactId, ArtifactReference, ArtifactRequest, GeneratedArtifact, PlanDirectory, PlanEntry,
-    PlanFile, PlannedArtifactKind, PlaylistArtifact, PresentationPlan, SourceArtifact,
+    ArtifactId, ArtifactReference, ArtifactRequest, ContentArtifact, GeneratedArtifact,
+    PlanDirectory, PlanEntry, PlanFile, PlannedArtifactKind, PlaylistArtifact, PresentationPlan,
+    SourceArtifact,
 };
 use crate::output::presentation_expansion::{is_multi_disc_game, sorted_disc_parts};
 use crate::output::presentation_spec::{
@@ -135,10 +136,15 @@ fn try_compile_rule(
 
     let artifact = ArtifactRequest::new(
         build_artifact_id(&rule.select, item),
-        PlannedArtifactKind::SourceBacked(SourceArtifact::single(
-            match_result.source,
-            match_result.size,
-        )),
+        match match_result.logical_disc {
+            Some(logical_disc) => {
+                PlannedArtifactKind::ContentBacked(ContentArtifact::logical_disc(logical_disc))
+            }
+            None => PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                match_result.source,
+                match_result.size,
+            )),
+        },
         build_requirements(&rule.artifact),
     );
 
@@ -179,10 +185,15 @@ fn try_compile_multi_disc_rule(
                     allocated_name,
                     ArtifactRequest::new(
                         artifact_id,
-                        PlannedArtifactKind::SourceBacked(SourceArtifact::single(
-                            disc.source.clone(),
-                            0,
-                        )),
+                        match &disc.logical_disc {
+                            Some(logical_disc) => PlannedArtifactKind::ContentBacked(
+                                ContentArtifact::logical_disc(logical_disc.clone()),
+                            ),
+                            None => PlannedArtifactKind::SourceBacked(SourceArtifact::single(
+                                disc.source.clone(),
+                                0,
+                            )),
+                        },
                         build_requirements(&rule.artifact),
                     ),
                 ))
@@ -314,6 +325,7 @@ fn child_names(directory: &PlanDirectory) -> Vec<String> {
 struct SourceMatch {
     source: SourceRef,
     size: u64,
+    logical_disc: Option<crate::core::content::LogicalDisc>,
 }
 
 fn match_game(item: &NormalizedContent) -> Option<SourceMatch> {
@@ -321,6 +333,7 @@ fn match_game(item: &NormalizedContent) -> Option<SourceMatch> {
         NormalizedContent::Game(game) => Some(SourceMatch {
             source: game.source.clone(),
             size: 0,
+            logical_disc: None,
         }),
         _ => None,
     }
@@ -334,6 +347,7 @@ fn match_game_without_parts(item: &NormalizedContent) -> Option<SourceMatch> {
     game.parts.is_empty().then(|| SourceMatch {
         source: game.source.clone(),
         size: 0,
+        logical_disc: None,
     })
 }
 
@@ -350,6 +364,7 @@ fn match_single_disc_game(item: &NormalizedContent) -> Option<SourceMatch> {
         GamePart::Disc(disc) => Some(SourceMatch {
             source: disc.source.clone(),
             size: 0,
+            logical_disc: disc.logical_disc.clone(),
         }),
         GamePart::Rom(_) => None,
     }
@@ -368,6 +383,7 @@ fn match_single_rom_game(item: &NormalizedContent) -> Option<SourceMatch> {
         GamePart::Rom(rom) => Some(SourceMatch {
             source: rom.source.clone(),
             size: rom.size,
+            logical_disc: None,
         }),
         GamePart::Disc(_) => None,
     }
@@ -378,6 +394,7 @@ fn match_bytes(item: &NormalizedContent) -> Option<SourceMatch> {
         NormalizedContent::Bytes(bytes) => Some(SourceMatch {
             source: bytes.source.clone(),
             size: bytes.size,
+            logical_disc: None,
         }),
         _ => None,
     }
@@ -388,6 +405,7 @@ fn match_text(item: &NormalizedContent) -> Option<SourceMatch> {
         NormalizedContent::Text(text) => Some(SourceMatch {
             source: text.source.clone(),
             size: text.size,
+            logical_disc: None,
         }),
         _ => None,
     }

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -596,6 +596,7 @@ mod tests {
                 source: SourceRef::new("file:/roms/Shadow of the Colossus.chd"),
                 disc_number: 1,
                 consumed_sources: vec![],
+                logical_disc: None,
             })],
             consumed_sources: vec![],
         })];

--- a/src/output/presentation_expansion.rs
+++ b/src/output/presentation_expansion.rs
@@ -36,6 +36,7 @@ mod tests {
             source: SourceRef::new(format!("file:/roms/disc{number}.cue")),
             disc_number: number,
             consumed_sources: vec![SourceRef::new(format!("file:/roms/disc{number}.bin"))],
+            logical_disc: None,
         })
     }
 

--- a/src/output/presentation_spec.rs
+++ b/src/output/presentation_spec.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use crate::core::content::{DiscMedia, Platform};
 use crate::output::capabilities::{CapabilityFeature, ContentType, Format};
 
 /// Declarative presentation specifications.
@@ -21,10 +22,11 @@ impl PresentationSpec {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LayoutSpec {
     Flat,
     GroupedByPlatformAndGame,
+    LiteralRoot(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,6 +56,12 @@ pub enum SelectSpec {
 
     /// Match games with exactly one disc part.
     SingleDiscGames,
+
+    /// Match a single-disc game for a specific platform and media kind.
+    SingleDiscGamesByPlatformAndMedia {
+        platform: Platform,
+        media: DiscMedia,
+    },
 
     /// Match games consisting entirely of multiple disc parts.
     MultiDiscGames,

--- a/src/output/resolution.rs
+++ b/src/output/resolution.rs
@@ -193,6 +193,7 @@ impl CapabilityResolver {
                 }
             }
             PlannedArtifactKind::Generated(_) => {}
+            PlannedArtifactKind::ContentBacked(_) => {}
         }
 
         reasons

--- a/src/policy/default.rs
+++ b/src/policy/default.rs
@@ -69,6 +69,7 @@ mod tests {
             source: SourceRef::new("cue:/roms/ff7-disc2.cue"),
             disc_number: 2,
             consumed_sources: vec![SourceRef::new("cue:/roms/ff7-disc2.bin")],
+            logical_disc: None,
         });
 
         let policy = DefaultNamingPolicy;

--- a/src/readers/chd_reader.rs
+++ b/src/readers/chd_reader.rs
@@ -1,0 +1,211 @@
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+use chd::Chd;
+
+use crate::core::reader::Reader;
+
+const DEFAULT_CACHE_HUNKS: usize = 4;
+
+trait HunkSource: Send + Sync {
+    fn hunk_size(&self) -> u32;
+    fn logical_bytes(&self) -> u64;
+    fn read_hunk(&mut self, index: u32, output: &mut [u8]) -> io::Result<()>;
+}
+
+struct ChdHunkSource {
+    chd: Chd<File>,
+    compressed: Vec<u8>,
+}
+
+impl HunkSource for ChdHunkSource {
+    fn hunk_size(&self) -> u32 {
+        self.chd.header().hunk_size()
+    }
+
+    fn logical_bytes(&self) -> u64 {
+        self.chd.header().logical_bytes()
+    }
+
+    fn read_hunk(&mut self, index: u32, output: &mut [u8]) -> io::Result<()> {
+        self.chd
+            .hunk(index)
+            .and_then(|mut hunk| hunk.read_hunk_in(&mut self.compressed, output))
+            .map(|_| ())
+            .map_err(|error| io::Error::other(format!("failed to read CHD hunk {index}: {error}")))
+    }
+}
+
+/// Provides bounded, live random access to the logical byte stream of a CHD.
+pub struct ChdReader {
+    source: Box<dyn HunkSource>,
+    hunk_size: u64,
+    logical_bytes: u64,
+    cache_capacity: usize,
+    cache: VecDeque<(u32, Vec<u8>)>,
+}
+
+impl ChdReader {
+    pub fn open(path: &Path) -> io::Result<Self> {
+        let file = File::open(path)?;
+        let chd = Chd::open(file, None)
+            .map_err(|error| io::Error::other(format!("failed to open CHD: {error}")))?;
+
+        Self::from_source(
+            Box::new(ChdHunkSource {
+                chd,
+                compressed: Vec::new(),
+            }),
+            DEFAULT_CACHE_HUNKS,
+        )
+    }
+
+    fn from_source(source: Box<dyn HunkSource>, cache_capacity: usize) -> io::Result<Self> {
+        let hunk_size = u64::from(source.hunk_size());
+        if hunk_size == 0 || cache_capacity == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CHD hunk size and cache capacity must be non-zero",
+            ));
+        }
+
+        let logical_bytes = source.logical_bytes();
+        Ok(Self {
+            source,
+            hunk_size,
+            logical_bytes,
+            cache_capacity,
+            cache: VecDeque::with_capacity(cache_capacity),
+        })
+    }
+
+    fn ensure_hunk(&mut self, index: u32) -> io::Result<()> {
+        if let Some(position) = self
+            .cache
+            .iter()
+            .position(|(cached_index, _)| *cached_index == index)
+        {
+            let cached = self.cache.remove(position).expect("cache entry exists");
+            self.cache.push_back(cached);
+            return Ok(());
+        }
+
+        let mut bytes = vec![0; self.hunk_size as usize];
+        self.source.read_hunk(index, &mut bytes)?;
+
+        if self.cache.len() == self.cache_capacity {
+            self.cache.pop_front();
+        }
+        self.cache.push_back((index, bytes));
+        Ok(())
+    }
+}
+
+impl Reader for ChdReader {
+    fn read_at(&mut self, offset: u64, buffer: &mut [u8]) -> io::Result<usize> {
+        if offset >= self.logical_bytes || buffer.is_empty() {
+            return Ok(0);
+        }
+
+        let requested = (self.logical_bytes - offset).min(buffer.len() as u64) as usize;
+        let mut copied = 0;
+
+        while copied < requested {
+            let logical_offset = offset + copied as u64;
+            let hunk_index = u32::try_from(logical_offset / self.hunk_size).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "CHD hunk index overflow")
+            })?;
+            let offset_in_hunk = (logical_offset % self.hunk_size) as usize;
+            self.ensure_hunk(hunk_index)?;
+
+            let (_, hunk) = self.cache.back().expect("requested hunk is cached");
+            let available = hunk.len() - offset_in_hunk;
+            let count = available.min(requested - copied);
+            buffer[copied..copied + count]
+                .copy_from_slice(&hunk[offset_in_hunk..offset_in_hunk + count]);
+            copied += count;
+        }
+
+        Ok(copied)
+    }
+
+    fn len(&self) -> u64 {
+        self.logical_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use super::*;
+
+    struct FakeHunkSource {
+        bytes: Vec<u8>,
+        hunk_size: u32,
+        logical_bytes: u64,
+        reads: Arc<AtomicUsize>,
+    }
+
+    impl HunkSource for FakeHunkSource {
+        fn hunk_size(&self) -> u32 {
+            self.hunk_size
+        }
+
+        fn logical_bytes(&self) -> u64 {
+            self.logical_bytes
+        }
+
+        fn read_hunk(&mut self, index: u32, output: &mut [u8]) -> io::Result<()> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            let start = index as usize * self.hunk_size as usize;
+            let available = self.bytes.len().saturating_sub(start).min(output.len());
+            output[..available].copy_from_slice(&self.bytes[start..start + available]);
+            Ok(())
+        }
+    }
+
+    fn reader(cache_capacity: usize, reads: Arc<AtomicUsize>) -> ChdReader {
+        ChdReader::from_source(
+            Box::new(FakeHunkSource {
+                bytes: (0..24).collect(),
+                hunk_size: 8,
+                logical_bytes: 20,
+                reads,
+            }),
+            cache_capacity,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn reads_across_hunk_boundaries_and_clamps_at_logical_end() {
+        let mut reader = reader(2, Arc::new(AtomicUsize::new(0)));
+        let mut across = [0; 10];
+        let mut tail = [0; 8];
+
+        assert_eq!(reader.read_at(6, &mut across).unwrap(), 10);
+        assert_eq!(across, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        assert_eq!(reader.read_at(18, &mut tail).unwrap(), 2);
+        assert_eq!(&tail[..2], &[18, 19]);
+    }
+
+    #[test]
+    fn reuses_cached_hunks_and_evicts_to_the_configured_bound() {
+        let reads = Arc::new(AtomicUsize::new(0));
+        let mut reader = reader(1, reads.clone());
+        let mut byte = [0; 1];
+
+        reader.read_at(0, &mut byte).unwrap();
+        reader.read_at(1, &mut byte).unwrap();
+        assert_eq!(reads.load(Ordering::SeqCst), 1);
+
+        reader.read_at(8, &mut byte).unwrap();
+        reader.read_at(0, &mut byte).unwrap();
+        assert_eq!(reads.load(Ordering::SeqCst), 3);
+        assert_eq!(reader.cache.len(), 1);
+    }
+}

--- a/src/readers/chd_reader.rs
+++ b/src/readers/chd_reader.rs
@@ -208,4 +208,34 @@ mod tests {
         assert_eq!(reads.load(Ordering::SeqCst), 3);
         assert_eq!(reader.cache.len(), 1);
     }
+
+    #[test]
+    fn propagates_hunk_decode_failures_without_partial_success() {
+        struct FailingHunkSource;
+
+        impl HunkSource for FailingHunkSource {
+            fn hunk_size(&self) -> u32 {
+                8
+            }
+
+            fn logical_bytes(&self) -> u64 {
+                8
+            }
+
+            fn read_hunk(&mut self, index: u32, _output: &mut [u8]) -> io::Result<()> {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("failed to decompress CHD hunk {index}"),
+                ))
+            }
+        }
+
+        let mut reader = ChdReader::from_source(Box::new(FailingHunkSource), 1).unwrap();
+        let mut output = [0; 4];
+        let error = reader.read_at(0, &mut output).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("decompress"));
+        assert!(reader.cache.is_empty());
+    }
 }

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -1,3 +1,4 @@
+pub mod chd_reader;
 pub mod dir_reader;
 pub mod inline_reader;
 pub mod zip_reader;

--- a/tests/chd_opl_integration.rs
+++ b/tests/chd_opl_integration.rs
@@ -4,8 +4,10 @@ use retromount::core::content::{DecodedContent, GamePart, NormalizedContent, Pla
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::vfs_resolver::open_file;
 use retromount::engine::components::pipeline_components;
+use retromount::engine::mount::prepare_mount_session;
 use retromount::engine::pipeline::{run_pipeline_with_presentation_options, PipelineOptions};
 use retromount::input::file_source::FileInputSource;
+use retromount::mount::session::MountNodeKind;
 
 const HEADER_SIZE: usize = 124;
 const HUNK_SIZE: usize = 4096;
@@ -107,6 +109,28 @@ fn presents_a_dvd_chd_as_a_live_opl_iso() {
             .unwrap(),
         0
     );
+}
+
+#[test]
+fn prepares_a_mount_session_with_the_opl_platform_context() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let chd_path = temp_dir.path().join("Test Game.chd");
+    fs::write(&chd_path, dvd_chd_fixture()).unwrap();
+
+    let session = prepare_mount_session(&chd_path, "opl").unwrap();
+    let dvd = session
+        .lookup_child(session.root_inode(), "DVD")
+        .expect("mount root should contain the OPL DVD directory");
+    let iso = session
+        .lookup_child(dvd.inode, "Test Game.iso")
+        .expect("DVD directory should contain the live ISO");
+    let MountNodeKind::File { file } = &iso.kind else {
+        panic!("OPL entry should be a file");
+    };
+
+    assert_eq!(file.size, LOGICAL_SIZE as u64);
+    let mut reader = retromount::core::vfs_reader::open_vfs_file(file).unwrap();
+    assert_read(&mut *reader, HUNK_SIZE - 3, 11);
 }
 
 #[test]

--- a/tests/chd_opl_integration.rs
+++ b/tests/chd_opl_integration.rs
@@ -1,0 +1,107 @@
+use std::fs;
+
+use retromount::core::content::Platform;
+use retromount::core::normalizer::NormalizationOptions;
+use retromount::core::vfs_resolver::open_file;
+use retromount::engine::components::pipeline_components;
+use retromount::engine::pipeline::{run_pipeline_with_presentation_options, PipelineOptions};
+use retromount::input::file_source::FileInputSource;
+
+const HEADER_SIZE: usize = 124;
+const HUNK_SIZE: usize = 4096;
+const SECTOR_SIZE: usize = 2048;
+const HUNK_COUNT: usize = 2;
+const LOGICAL_SIZE: usize = HUNK_SIZE * HUNK_COUNT;
+const MAP_OFFSET: usize = HEADER_SIZE;
+const METADATA_OFFSET: usize = MAP_OFFSET + HUNK_COUNT * 4;
+const DATA_OFFSET: usize = HUNK_SIZE;
+
+#[test]
+fn presents_a_dvd_chd_as_a_live_opl_iso() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let chd_path = temp_dir.path().join("Test Game.chd");
+    fs::write(&chd_path, dvd_chd_fixture()).unwrap();
+
+    let components = pipeline_components("opl").unwrap();
+    let source = FileInputSource::new(&chd_path);
+    let options = PipelineOptions {
+        normalization: NormalizationOptions {
+            platform_hint: Some(Platform::Ps2),
+        },
+        plugin_registry: None,
+    };
+
+    let trace = run_pipeline_with_presentation_options(
+        &source,
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &components.presentation,
+        &components.policy,
+        &options,
+    )
+    .unwrap();
+
+    assert!(trace.objects[0].supported);
+    let file = trace
+        .output_vfs
+        .find_file("DVD/Test Game.iso")
+        .expect("OPL ISO should be present");
+    assert_eq!(file.size, LOGICAL_SIZE as u64);
+
+    let mut reader = open_file(&trace.output_vfs, "DVD/Test Game.iso").unwrap();
+    let mut across_hunks = [0; 20];
+    let bytes_read = reader
+        .read_at((HUNK_SIZE - 7) as u64, &mut across_hunks)
+        .unwrap();
+
+    assert_eq!(bytes_read, across_hunks.len());
+    assert_eq!(
+        across_hunks,
+        std::array::from_fn(|index| fixture_byte(HUNK_SIZE - 7 + index))
+    );
+}
+
+/// Builds the smallest useful uncompressed CHD v5 image for integration tests.
+///
+/// The layout exercises the real CHD parser, metadata iterator, hunk map, and
+/// random-access reader without requiring `chdman` during test execution.
+fn dvd_chd_fixture() -> Vec<u8> {
+    let mut bytes = Vec::new();
+
+    bytes.extend_from_slice(b"MComprHD");
+    push_u32(&mut bytes, HEADER_SIZE as u32);
+    push_u32(&mut bytes, 5);
+    for _ in 0..4 {
+        push_u32(&mut bytes, 0);
+    }
+    push_u64(&mut bytes, LOGICAL_SIZE as u64);
+    push_u64(&mut bytes, MAP_OFFSET as u64);
+    push_u64(&mut bytes, METADATA_OFFSET as u64);
+    push_u32(&mut bytes, HUNK_SIZE as u32);
+    push_u32(&mut bytes, SECTOR_SIZE as u32);
+    bytes.resize(HEADER_SIZE, 0);
+
+    for hunk in 0..HUNK_COUNT {
+        push_u32(&mut bytes, (DATA_OFFSET / HUNK_SIZE + hunk) as u32);
+    }
+
+    bytes.extend_from_slice(b"DVD ");
+    push_u32(&mut bytes, 0);
+    push_u64(&mut bytes, 0);
+    bytes.resize(DATA_OFFSET, 0);
+    bytes.extend((0..LOGICAL_SIZE).map(fixture_byte));
+
+    bytes
+}
+
+fn fixture_byte(offset: usize) -> u8 {
+    ((offset * 17 + 3) % 251) as u8
+}
+
+fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend_from_slice(&value.to_be_bytes());
+}
+
+fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+    bytes.extend_from_slice(&value.to_be_bytes());
+}

--- a/tests/chd_opl_integration.rs
+++ b/tests/chd_opl_integration.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use retromount::core::content::Platform;
+use retromount::core::content::{DecodedContent, GamePart, NormalizedContent, Platform};
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::vfs_resolver::open_file;
 use retromount::engine::components::pipeline_components;
@@ -42,6 +42,28 @@ fn presents_a_dvd_chd_as_a_live_opl_iso() {
     .unwrap();
 
     assert!(trace.objects[0].supported);
+    let DecodedContent::Disc(decoded_disc) = &trace.objects[0].decoded[0] else {
+        panic!("CHD should decode as a disc");
+    };
+    let logical_disc = decoded_disc
+        .logical_disc
+        .as_ref()
+        .expect("decoded disc should retain live content");
+    assert_eq!(logical_disc.sector_size, SECTOR_SIZE as u32);
+    assert_eq!(
+        logical_disc.sector_count,
+        (LOGICAL_SIZE / SECTOR_SIZE) as u64
+    );
+
+    let NormalizedContent::Game(game) = &trace.normalized[0] else {
+        panic!("decoded disc should normalize as a game");
+    };
+    assert_eq!(game.platform, Platform::Ps2);
+    assert!(matches!(
+        &game.parts[0],
+        GamePart::Disc(part) if part.logical_disc.as_ref() == Some(logical_disc)
+    ));
+
     let file = trace
         .output_vfs
         .find_file("DVD/Test Game.iso")
@@ -59,6 +81,61 @@ fn presents_a_dvd_chd_as_a_live_opl_iso() {
         across_hunks,
         std::array::from_fn(|index| fixture_byte(HUNK_SIZE - 7 + index))
     );
+
+    assert_read(&mut *reader, 3, 13);
+    assert_read(&mut *reader, 3, 13);
+    assert_read(&mut *reader, HUNK_SIZE + 101, 31);
+    assert_read(&mut *reader, 27, 19);
+
+    let mut tail = [0; 16];
+    assert_eq!(
+        reader
+            .read_at((LOGICAL_SIZE - 5) as u64, &mut tail)
+            .unwrap(),
+        5
+    );
+    assert_eq!(
+        &tail[..5],
+        &(LOGICAL_SIZE - 5..LOGICAL_SIZE)
+            .map(fixture_byte)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(reader.read_at(LOGICAL_SIZE as u64, &mut tail).unwrap(), 0);
+    assert_eq!(
+        reader
+            .read_at((LOGICAL_SIZE + 100) as u64, &mut tail)
+            .unwrap(),
+        0
+    );
+}
+
+#[test]
+fn rejects_non_dvd_and_parent_chds_through_the_real_parser() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let non_dvd_path = temp_dir.path().join("Not DVD.chd");
+    fs::write(&non_dvd_path, chd_fixture(*b"GDDD", false)).unwrap();
+    let non_dvd_error = run_opl(&non_dvd_path).unwrap_err();
+    assert_eq!(non_dvd_error.kind(), std::io::ErrorKind::Unsupported);
+    assert!(non_dvd_error.to_string().contains("DVD media"));
+
+    let parent_path = temp_dir.path().join("Parent.chd");
+    fs::write(&parent_path, chd_fixture(*b"DVD ", true)).unwrap();
+    let parent_error = run_opl(&parent_path).unwrap_err();
+    assert_eq!(parent_error.kind(), std::io::ErrorKind::Unsupported);
+    assert!(parent_error.to_string().contains("parent/delta"));
+}
+
+#[test]
+fn reports_a_malformed_chd_as_invalid_data() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = temp_dir.path().join("Broken.chd");
+    fs::write(&path, b"not a CHD").unwrap();
+
+    let error = run_opl(&path).unwrap_err();
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(error.to_string().contains("failed to open CHD"));
 }
 
 /// Builds the smallest useful uncompressed CHD v5 image for integration tests.
@@ -66,6 +143,10 @@ fn presents_a_dvd_chd_as_a_live_opl_iso() {
 /// The layout exercises the real CHD parser, metadata iterator, hunk map, and
 /// random-access reader without requiring `chdman` during test execution.
 fn dvd_chd_fixture() -> Vec<u8> {
+    chd_fixture(*b"DVD ", false)
+}
+
+fn chd_fixture(metadata_tag: [u8; 4], has_parent: bool) -> Vec<u8> {
     let mut bytes = Vec::new();
 
     bytes.extend_from_slice(b"MComprHD");
@@ -80,18 +161,52 @@ fn dvd_chd_fixture() -> Vec<u8> {
     push_u32(&mut bytes, HUNK_SIZE as u32);
     push_u32(&mut bytes, SECTOR_SIZE as u32);
     bytes.resize(HEADER_SIZE, 0);
+    if has_parent {
+        bytes[104] = 1;
+    }
 
     for hunk in 0..HUNK_COUNT {
         push_u32(&mut bytes, (DATA_OFFSET / HUNK_SIZE + hunk) as u32);
     }
 
-    bytes.extend_from_slice(b"DVD ");
+    bytes.extend_from_slice(&metadata_tag);
     push_u32(&mut bytes, 0);
     push_u64(&mut bytes, 0);
     bytes.resize(DATA_OFFSET, 0);
     bytes.extend((0..LOGICAL_SIZE).map(fixture_byte));
 
     bytes
+}
+
+fn run_opl(path: &std::path::Path) -> std::io::Result<retromount::engine::pipeline::PipelineTrace> {
+    let components = pipeline_components("opl").unwrap();
+    let source = FileInputSource::new(path);
+    let options = PipelineOptions {
+        normalization: NormalizationOptions {
+            platform_hint: Some(Platform::Ps2),
+        },
+        plugin_registry: None,
+    };
+
+    run_pipeline_with_presentation_options(
+        &source,
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &components.presentation,
+        &components.policy,
+        &options,
+    )
+}
+
+fn assert_read(reader: &mut dyn retromount::core::reader::Reader, offset: usize, length: usize) {
+    let mut bytes = vec![0; length];
+    assert_eq!(reader.read_at(offset as u64, &mut bytes).unwrap(), length);
+    assert_eq!(
+        bytes,
+        (offset..offset + length)
+            .map(fixture_byte)
+            .collect::<Vec<_>>()
+    );
 }
 
 fn fixture_byte(offset: usize) -> u8 {

--- a/tests/presentation_compile_flat.rs
+++ b/tests/presentation_compile_flat.rs
@@ -113,11 +113,13 @@ mod flat_parity_tests {
                     source: SourceRef::new(format!("file:/roms/{id}-disc2.cue")),
                     disc_number: 2,
                     consumed_sources: vec![],
+                    logical_disc: None,
                 }),
                 GamePart::Disc(DiscPart {
                     source: SourceRef::new(format!("file:/roms/{id}-disc1.cue")),
                     disc_number: 1,
                     consumed_sources: vec![],
+                    logical_disc: None,
                 }),
             ],
             consumed_sources: vec![],
@@ -135,6 +137,7 @@ mod flat_parity_tests {
                 source: SourceRef::new("file:/roms/ico.chd"),
                 disc_number: 1,
                 consumed_sources: vec![],
+                logical_disc: None,
             })],
             consumed_sources: vec![],
         })];

--- a/tests/presentation_compile_grouped.rs
+++ b/tests/presentation_compile_grouped.rs
@@ -119,6 +119,7 @@ mod grouped_parity_tests {
                 source: SourceRef::new("file:/roms/ico.chd"),
                 disc_number: 1,
                 consumed_sources: vec![],
+                logical_disc: None,
             })],
             consumed_sources: vec![],
         })];
@@ -146,11 +147,13 @@ mod grouped_parity_tests {
                     source: SourceRef::new("file:/roms/Final Fantasy VII (Disc 2).cue"),
                     disc_number: 2,
                     consumed_sources: vec![],
+                    logical_disc: None,
                 }),
                 GamePart::Disc(DiscPart {
                     source: SourceRef::new("file:/roms/Final Fantasy VII (Disc 1).cue"),
                     disc_number: 1,
                     consumed_sources: vec![],
+                    logical_disc: None,
                 }),
             ],
             consumed_sources: vec![],


### PR DESCRIPTION
## Summary

- define the PS2/OPL output contract and document the live random-access design
- add opaque reader-backed content handles across decode, normalization, planning, materialization, VFS, and mount preparation
- identify CHD inputs and decode supported single-disc DVD CHDs into canonical logical-disc content
- add bounded random-access CHD hunk reading without extracting or caching a complete ISO
- add a generic logical-DVD-to-ISO adapter selected through output capabilities
- add the declarative OPL `DVD/<title>.iso` presentation
- add decoder composition and PS2 normalization context for OPL inspection and mounting
- document configuration and remaining external validation

## Why

OPL needs an ISO-compatible random-access view of PS2 DVD content, but materializing a CHD into a temporary or persistent ISO would violate RetroMount's staged input → decode → normalize → encode → output architecture and incur whole-image storage costs. This change keeps CHD as an input concern, ISO as an output representation, and OPL as a presentation concern.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `markdownlint-cli2 '**/*.md'`
- generated CHD v5 integration fixture covering identification through mount-session preparation
- exact geometry and output length
- unaligned, repeated, out-of-order, cross-hunk, near-EOF, and past-EOF reads
- malformed, non-DVD, parent/delta, and hunk-decode failure behavior

## Remaining external validation

- test a representative compressed, `chdman`-created PS2 DVD CHD
- export the mounted `DVD/` view over SMB and confirm a current OPL build can list and launch it