### PR TITLE
Add optical media roadmap and filesystem ISO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Retromount is under active development and progressing through a structured road
 
 ### In Progress
 
-* Optical-media capability expansion — filesystem ISO input is the next
-  vertical slice, followed by revised ZIP input, PS2 CD, and a named PS1
-  presentation
+* Optical-media capability expansion — filesystem ISO input through the PS2
+  DVD OPL path is implemented; the live input-content boundary and revised ZIP
+  integration are next
 
 ### Planned
 

--- a/README.md
+++ b/README.md
@@ -90,17 +90,21 @@ Retromount is under active development and progressing through a structured road
 * Phase 4D — Extensibility and configuration layer
 * Phase 5 — Runtime encoder plugin architecture
 * Phase 6 — Declarative presentation specifications
+* First practical consumer target — live PS2 DVD CHD to OPL-compatible ISO
+  presentation
 
 ### In Progress
 
-* First practical consumer target — PS2/OPL; the live CHD-to-logical-ISO path
-  and automated mount-preparation coverage are implemented, with real-image
-  and OPL/SMB validation remaining
+* Optical-media capability expansion — filesystem ISO input is the next
+  vertical slice, followed by revised ZIP input, PS2 CD, and a named PS1
+  presentation
 
 ### Planned
 
+* Additional optical-disc inputs and consumer presentations
+* Performance, caching, and optimisation after representative input and media
+  workloads are available
 * Advanced encoders and external integrations (e.g. torrent compatibility)
-* Phase 7 — Performance, caching, and optimisation
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -60,6 +60,9 @@ This structure ensures that:
 * `review-findings.md` — findings discovered during architecture review
 * `decisions.md` — architectural decisions made during the review
 * `cleanup-tracker.md` — concrete cleanup and refactor tasks arising from findings
+* `adr-010-optical-media-contract.md` — separates source containers, input
+  formats, media semantics, platforms, output representations, and
+  presentations for the next optical-media capability slices
 
 ---
 
@@ -216,7 +219,8 @@ The architecture review work in this directory aims to:
 
 ## Next Focus Areas
 
-* improve module-level documentation
-* introduce diagrams for better visualization of the pipeline
-* refine filesystem adapter behaviour and performance (e.g. read caching)
-* add examples for alternate presentation specifications, encoders, and adapter layers
+* add filesystem ISO input through the canonical PS2 DVD and OPL path
+* replace the old ZIP integration with a live input-content boundary
+* define PS2 CD requirements for the OPL presentation
+* implement a named PS1 consumer slice and track-aware CD model
+* measure representative workloads before introducing broader caching

--- a/docs/architecture/adr-010-optical-media-contract.md
+++ b/docs/architecture/adr-010-optical-media-contract.md
@@ -1,0 +1,182 @@
+# ADR-010: Evolve Optical Media Through Capability-Led Vertical Slices
+
+## Status
+
+Accepted
+
+## Context
+
+Retromount's first live optical-media path presents a PlayStation 2 DVD CHD as
+an ISO-compatible file in an OPL view. That path established several useful
+boundaries:
+
+* CHD is an input format;
+* DVD is a media kind;
+* PlayStation 2 is a platform;
+* ISO is an output representation;
+* OPL is a consumer presentation;
+* decoded content can remain reader-backed through the VFS.
+
+The next capabilities include filesystem ISO input, PlayStation 2 CDs,
+PlayStation 1 discs, and a replacement for the older ZIP integration. Longer
+term, Retromount is expected to support optical media used by systems such as
+Sega CD, PC Engine CD, Atari Jaguar CD, 3DO, CD-i, Dreamcast, and GameCube.
+
+Those systems cannot all be represented accurately as a contiguous stream of
+2048-byte sectors. Relevant differences may include:
+
+* CD and DVD media;
+* cooked and raw sectors;
+* data and audio tracks;
+* multiple sessions or tracks;
+* pregaps and index points;
+* subchannel data;
+* platform-specific metadata;
+* higher-density and otherwise non-standard layouts.
+
+Designing a universal optical-disc model before implementing those consumers
+would require assumptions that have not yet been tested. Extending the current
+DVD model ad hoc for each platform would instead couple input formats, media
+semantics, and consumer output requirements.
+
+The existing ZIP implementation also predates live decoded content. It embeds
+container addressing in `SourceRef` strings and requires some decoders to know
+whether content came from the filesystem or an archive. Path-based decoders
+cannot consume nested content through the same contract as filesystem content.
+
+## Decision
+
+Retromount will evolve optical-media support through small, capability-led
+vertical slices.
+
+The architecture will keep the following concepts distinct:
+
+| Concept | Responsibility | Examples |
+| --- | --- | --- |
+| Source/container | Locate and expose input bytes | filesystem, ZIP |
+| Input format/decoder | Interpret encoded input | ISO, CHD, CUE/BIN |
+| Media semantics | Describe the decoded carrier | CD, DVD, tracks, sectors |
+| Platform semantics | Identify the target system | PS1, PS2 |
+| Output representation | Describe requested artifacts | ISO, BIN, CUE, M3U |
+| Presentation | Arrange artifacts for a consumer | OPL, future PS1 view |
+
+No layer may infer that these concepts are interchangeable. In particular:
+
+* an `.iso` extension does not by itself establish a platform;
+* a CD is not necessarily a single 2048-byte data stream;
+* CHD is not inherently PS1, PS2, CD, or DVD;
+* ZIP is a container, not a decoder for the entries it contains;
+* a presentation requests consumer-visible artifacts without selecting an
+  input container.
+
+### Canonical media model
+
+The current `LogicalDisc` contract remains valid for media with one canonical,
+contiguous logical data view. It will not be expanded immediately into a
+universal optical-disc model.
+
+Track-aware CD concepts will be introduced only when the PS2 CD and PS1 slices
+define concrete requirements. Any extension must preserve information required
+for correct output and must not force all media into a lossy 2048-byte-sector
+view.
+
+Future formats must be able to add richer media descriptions without changing
+presentation or decoder responsibilities.
+
+### Live input content
+
+Decoders should consume an opaque input-content capability rather than opening
+filesystem paths directly. A later source-boundary slice will define the exact
+API, conceptually:
+
+```text
+SourceRef
+    ↓
+Source/container resolver
+    ↓
+Live input content / reader capability
+    ↓
+Identifier and decoder
+```
+
+The resolver owns filesystem and container addressing. Format decoders own
+format interpretation. A decoder must not parse ZIP addressing or require a
+temporary extracted path.
+
+Not every container entry can promise efficient random access. The source
+contract must expose the capabilities needed for a decoder to accept or reject
+an input deliberately. Support for compressed disc images inside ZIP files
+must not silently introduce whole-image extraction or unbounded memory use.
+
+### Implementation sequence
+
+Capabilities will be delivered in the following order:
+
+1. filesystem ISO to canonical PS2 DVD to the existing OPL presentation;
+2. a live input-content boundary and replacement ZIP integration;
+3. PS2 CD support in the OPL presentation;
+4. a named PS1 consumer presentation and its first input path;
+5. measurement-led caching and performance work.
+
+Each item is a separate milestone with its own acceptance criteria. Later input
+formats and presentations follow the same vertical-slice approach.
+
+## Consequences
+
+### Positive
+
+* The next implementation is small enough to validate decoder interchangeability.
+* Sony-specific assumptions do not become universal optical-media rules.
+* ZIP can be corrected at the source/container boundary instead of being
+  special-cased by every decoder.
+* The CD model will be driven by actual PS2 and PS1 requirements.
+* Performance work will be informed by multiple realistic access patterns.
+* Future platforms can extend media semantics without inheriting ISO- or
+  PlayStation-specific coupling.
+
+### Negative
+
+* The full optical-media model remains intentionally incomplete.
+* Some formats will require a design increment before implementation.
+* A source capability model adds an abstraction between discovery and decoding.
+* Compressed archive entries may need to be rejected for some random-access
+  formats until a bounded strategy exists.
+
+## Alternatives considered
+
+### Design a universal optical-disc model now
+
+Rejected. The known future systems demonstrate the need for extensibility, but
+do not yet provide sufficiently concrete output contracts to validate one
+complete model.
+
+### Extend `LogicalDisc` separately for each new platform
+
+Rejected. This would encode platform and input-format assumptions in the
+canonical media layer and make cross-format reuse difficult.
+
+### Begin with caching and performance
+
+Deferred. The current CHD reader already has bounded hunk caching, and there is
+not yet enough diversity of readers and media workloads to identify the right
+system-wide cache boundaries.
+
+### Design input plugins before adding more built-in decoders
+
+Deferred. ISO and the revised ZIP path should first provide additional evidence
+about the source/container and decoder contracts. Plugin transport can then be
+designed around demonstrated capabilities.
+
+## Non-goals
+
+This decision does not define or implement:
+
+* a complete track/session/subchannel model;
+* PS1 output layout;
+* PS2 CD conversion rules;
+* compressed random access inside ZIP files;
+* Dreamcast GDI/GD-ROM or GameCube MiniDVD semantics;
+* external input plugins;
+* new caching policies.
+
+These are follow-on decisions or implementation milestones.

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -1,0 +1,209 @@
+# Optical Media Capability Roadmap
+
+## Goal
+
+Expand Retromount beyond its first PS2 DVD CHD path without combining source
+containers, disc formats, media semantics, platforms, and consumer
+presentations into one implementation.
+
+This roadmap implements
+[ADR-010](../architecture/adr-010-optical-media-contract.md) as a sequence of
+independently deliverable milestones.
+
+## Current baseline
+
+Retromount currently supports:
+
+* live, bounded random-access reads from supported PS2 DVD CHDs;
+* a canonical contiguous DVD representation;
+* logical DVD-to-ISO materialization;
+* an OPL `DVD/<title>.iso` presentation;
+* reader-backed VFS files;
+* older ZIP enumeration and source-backed reads for basic content.
+
+The existing ZIP path is not the target architecture for live decoded content.
+In particular, path-based decoders cannot consume ZIP entries through the same
+contract as filesystem inputs.
+
+## Guiding constraints
+
+Every milestone must preserve these rules:
+
+* no whole-disc intermediate is created merely to cross a pipeline boundary;
+* decoders do not know consumer layouts;
+* presentations do not select input formats or named encoders;
+* source/container handling is independent of format decoding;
+* media information is preserved when a contiguous 2048-byte view would be
+  lossy;
+* platform identification is explicit and is not inferred solely from a disc
+  container or extension;
+* support fails clearly when required random-access capabilities are absent.
+
+## Milestone 1: Filesystem ISO input for PS2 DVD
+
+### Milestone 1 purpose
+
+Prove that multiple input decoders can produce the same canonical logical DVD
+and feed the same output presentation.
+
+### Milestone 1 scope
+
+* identify a filesystem ISO as a distinct disc input;
+* expose it as reader-backed 2048-byte logical DVD content;
+* normalize it as PS2 when the OPL composition supplies the explicit platform
+  context;
+* reuse the logical-DVD ISO encoder;
+* emit `DVD/<title>.iso` through the existing OPL specification.
+
+### Milestone 1 non-goals
+
+* probing arbitrary ISO contents to determine a platform;
+* CD media;
+* raw-sector or multi-track images;
+* ISO entries inside ZIP files;
+* a general input plugin API.
+
+### Milestone 1 acceptance criteria
+
+* CHD and ISO inputs produce equivalent canonical DVD requirements.
+* Arbitrary and unaligned output reads match the source ISO bytes.
+* The output length exactly matches the input logical length.
+* No ISO-sized copy or cache is created.
+* Invalid geometry and empty input fail with actionable errors.
+* The CHD path remains unchanged.
+
+## Milestone 2: Live input-content boundary and ZIP replacement
+
+### Milestone 2 purpose
+
+Allow identifiers and decoders to consume content independently of whether it
+comes from the filesystem or a container.
+
+### Milestone 2 design checkpoint
+
+Before implementation, define:
+
+* the resolved input-content handle and its lifetime;
+* size, sequential-read, and random-read capabilities;
+* how identifiers inspect content without consuming decoder state;
+* error behavior for a source that cannot satisfy decoder requirements;
+* ownership of nested source addressing.
+
+### Milestone 2 scope
+
+* centralize filesystem and ZIP `SourceRef` resolution;
+* remove ZIP parsing from individual decoders and VFS consumers where the
+  resolver should own it;
+* preserve ordinary compressed-ROM and sidecar use cases;
+* support stored ZIP entries as true random-access input;
+* exercise ISO decoding through a stored ZIP entry;
+* define explicit behavior for compressed random-access disc entries.
+
+### Milestone 2 initial policy for compressed disc entries
+
+Until a bounded strategy is designed and measured, a decoder that requires
+efficient random access may reject a compressed ZIP entry with an actionable
+diagnostic. It must not silently extract a complete disc, repeatedly decompress
+unbounded data, or retain a complete decompressed image in memory.
+
+### Milestone 2 acceptance criteria
+
+* The same decoder consumes filesystem and supported ZIP-backed content.
+* Decoders no longer parse `zip:<archive>#<entry>` strings.
+* Stored ISO input inside ZIP follows the same canonical DVD path.
+* Existing ROM, text, CUE-relative-reference, and VFS ZIP behavior is either
+  preserved or deliberately superseded with migration coverage.
+* Unsupported compressed random-access inputs fail before mount preparation.
+
+## Milestone 3: PS2 CD through OPL
+
+### Milestone 3 purpose
+
+Extend the existing consumer presentation to PS2 games distributed on CD
+media.
+
+### Milestone 3 required spike
+
+Confirm the exact canonical input and ISO-compatible output needed by current
+OPL versions, including sector layout and any required conversion from common
+PS2 CD source formats.
+
+### Milestone 3 scope
+
+* introduce only the CD semantics required by the confirmed OPL contract;
+* distinguish PS2 CD from PS1 CD and PS2 DVD;
+* add an OPL `CD/<title>.iso` rule alongside the existing `DVD` rule;
+* implement one supported PS2 CD input path end to end.
+
+### Milestone 3 acceptance criteria
+
+* DVD inputs continue to appear only below `DVD/`.
+* Supported PS2 CD inputs appear only below `CD/`.
+* PS1 CDs and unknown CDs fail closed for the OPL presentation.
+* Output sector mapping and length match the confirmed OPL contract.
+* No lossy normalization is used to force unsupported CD layouts into ISO.
+
+## Milestone 4: First PS1 vertical slice
+
+### Milestone 4 purpose
+
+Introduce a track-aware optical-media use case and the first dedicated PS1
+consumer presentation.
+
+### Milestone 4 required decisions
+
+Choose a named consumer before fixing the output contract. The design must
+then determine:
+
+* accepted filesystem layout and artifact formats;
+* treatment of data and audio tracks;
+* sector formats, pregaps, indexes, and information that must be preserved;
+* single-disc and multi-disc behavior;
+* whether CUE, BIN, CHD, and M3U artifacts are source-backed, generated, or
+  transformed.
+
+### Milestone 4 initial implementation
+
+Implement one input format and one consumer output end to end. Add further PS1
+input formats only after the canonical CD representation is proven by that
+slice.
+
+### Milestone 4 acceptance criteria
+
+* PS1 and PS2 CDs remain semantically distinct.
+* The canonical model preserves everything required by the selected consumer.
+* A mixed-mode or multi-track fixture prevents regression to a DVD-like
+  contiguous-data assumption.
+* Multi-disc support is included only when required by the chosen first
+  consumer contract.
+
+## Milestone 5: Performance, caching, and optimization
+
+Begin measurement-led optimization after the preceding milestones provide
+several representative workloads:
+
+* CHD hunk decompression;
+* filesystem ISO identity reads;
+* ZIP-backed reads;
+* PS2 DVD and CD access;
+* track-aware PS1 access.
+
+Establish benchmarks and observability before changing cache policy. Candidate
+work includes:
+
+* reader and handle reuse;
+* decompressed-hunk cache tuning;
+* ZIP access strategy;
+* concurrent-read behavior;
+* cache placement and lifetime;
+* bounded memory targets.
+
+## Later capability expansion
+
+Later vertical slices may cover Sega CD, PC Engine CD, Atari Jaguar CD, 3DO,
+CD-i, Dreamcast GDI/GD-ROM, GameCube MiniDVD, and other disc formats and
+consumer views.
+
+Their known differences are constraints on extensibility, not requirements for
+the first ISO, PS2 CD, or PS1 implementation. Each new slice should extend the
+canonical model only as required by a concrete decoder and presentation.

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -41,6 +41,8 @@ Every milestone must preserve these rules:
 
 ## Milestone 1: Filesystem ISO input for PS2 DVD
 
+**Status:** Implemented
+
 ### Milestone 1 purpose
 
 Prove that multiple input decoders can produce the same canonical logical DVD
@@ -73,6 +75,8 @@ and feed the same output presentation.
 * The CHD path remains unchanged.
 
 ## Milestone 2: Live input-content boundary and ZIP replacement
+
+**Status:** Next
 
 ### Milestone 2 purpose
 

--- a/docs/roadmap/phase6-integration-summary.md
+++ b/docs/roadmap/phase6-integration-summary.md
@@ -33,5 +33,8 @@ Adding a new consumer layout now means defining a presentation specification
 and, when needed, supplying an encoder capability. It no longer requires a new
 filesystem presenter implementation.
 
-The next milestone is the first practical consumer target: presenting
-server-side CHD content to PS2/OPL as ISO-compatible output.
+The first practical consumer target was subsequently delivered: supported PS2
+DVD CHD content can be presented through a live, ISO-compatible OPL view.
+
+The next capability roadmap is documented in
+[`optical-media-capabilities.md`](optical-media-capabilities.md).

--- a/docs/roadmap/ps2-opl-design-spike.md
+++ b/docs/roadmap/ps2-opl-design-spike.md
@@ -2,11 +2,13 @@
 
 ## Status
 
-Revised proposed contract and capability assessment.
+Implemented for the defined Retromount scope.
 
 This spike follows Phase 6 and defines the smallest useful PS2/Open PS2 Loader
-(OPL) target. It is a design input for implementation, not a claim that the
-target currently works end to end.
+(OPL) target. The live CHD-to-logical-ISO path and representative compressed
+image validation are complete. Export over SMB and validation with physical OPL
+clients are consumer-environment integration concerns and are not acceptance
+criteria for this milestone.
 
 ## Decision summary
 
@@ -339,16 +341,16 @@ workflow.
 
 ### Implementation status
 
-| Area | Implemented behavior | Remaining validation |
+| Area | Implemented behavior | Status or follow-up |
 | --- | --- | --- |
-| CHD input | `.chd` is identified separately and routed through a dedicated DVD decoder and bounded random-access hunk reader. | Exercise the supported codecs with a representative `chdman`-created PS2 DVD CHD. |
-| Canonical content | Decode and normalization retain DVD media, 2048-byte sector geometry, and an opaque live reader handle. | Validate the geometry against a representative real image. |
+| CHD input | `.chd` is identified separately and routed through a dedicated DVD decoder and bounded random-access hunk reader. | Representative compressed-image validation is complete. |
+| Canonical content | Decode and normalization retain DVD media, 2048-byte sector geometry, and an opaque live reader handle. | Representative geometry validation is complete. |
 | Platform model | PS2 is supported; the OPL composition supplies an explicit PS2 normalization hint. | None for the first target. |
-| Presentation | The declarative OPL rule selects one PS2 DVD and emits `DVD/<title>.iso`. | Validate the resulting share with OPL. |
+| Presentation | The declarative OPL rule selects one PS2 DVD and emits `DVD/<title>.iso`. | Physical OPL/SMB integration is outside this milestone. |
 | Capability model | The logical-DVD ISO encoder is selected from canonical media and representation requirements, independently of CHD. | None for the first target. |
-| Materialized output | Reader-backed artifacts flow through the VFS and mount session without creating an ISO-sized intermediate. | Observe behavior under a representative full-size image workload. |
+| Materialized output | Reader-backed artifacts flow through the VFS and mount session without creating an ISO-sized intermediate. | Representative image validation is complete; broader measurement belongs to the performance milestone. |
 | Plugin protocol | Protocol v1 explicitly rejects live content-backed artifacts; the built-in reader remains an in-process capability. | A persistent random-read plugin contract remains deferred. |
-| Automated validation | A generated CHD v5 fixture proves identification through mount preparation, exact size, unaligned/repeated/out-of-order reads, hunk boundaries, EOF behavior, and unsupported inputs. | Add a real compressed-image compatibility test when a redistributable fixture is available. |
+| Automated validation | A generated CHD v5 fixture proves identification through mount preparation, exact size, unaligned/repeated/out-of-order reads, hunk boundaries, EOF behavior, and unsupported inputs. | The repository remains independent of a redistributable full-size image fixture. |
 
 ## Plugin boundary conclusion
 
@@ -371,8 +373,8 @@ problem and should not be hidden inside a PS2-specific encoder.
 
 ## Recommended implementation order
 
-Items 1–7 are implemented and covered by automated tests. Item 8 remains an
-external acceptance step.
+Items 1–7 are implemented and covered by automated tests. Item 8 is an optional
+consumer-environment integration exercise outside the Retromount milestone.
 
 1. Define the canonical logical-disc representation and opaque content-handle
    lifetime.
@@ -385,21 +387,19 @@ external acceptance step.
 6. Add the declarative OPL `DVD/` presentation and correct extension handling.
 7. Prove one synthetic DVD CHD end to end through inspect, mount preparation,
    unaligned reads, hunk-boundary reads, and reads near end-of-file.
-8. Validate the mounted share with a current OPL build over SMB.
+8. Optionally validate the mounted share with a current OPL build over SMB.
 
-## Remaining validation
+## External integration
 
-The generated fixture is a small, uncompressed CHD v5 image. It deliberately
-keeps the repository and test suite independent of `chdman`, while exercising
-the real CHD parser, metadata iterator, hunk map, decode/normalize/encode
-contracts, VFS backing, and mount-session preparation.
+The generated fixture keeps the repository and test suite independent of
+`chdman`, while exercising the real CHD parser, metadata iterator, hunk map,
+decode/normalize/encode contracts, VFS backing, and mount-session preparation.
+Representative compressed-image validation has also been completed.
 
-Before calling the consumer spike complete:
-
-1. Test a representative, `chdman`-created and compressed PS2 DVD CHD to
-   confirm codec and real-world metadata compatibility.
-2. Mount the resulting `DVD/<title>.iso` view, export it over SMB, and confirm a
-   current OPL build can list and launch it.
+Mounting the resulting `DVD/<title>.iso` view, exporting it over SMB, and
+confirming that a particular OPL client can list and launch it remain useful
+deployment checks. They are not required to establish the Retromount pipeline
+contract and are outside this spike's acceptance scope.
 
 ## Acceptance criteria for the first target
 
@@ -418,7 +418,6 @@ The spike is implemented when:
 * memory use is bounded independently of total ISO size;
 * invalid CHD, unsupported media, decompression failure, and out-of-range reads
   produce actionable behavior;
-* an OPL SMB client lists and launches the test image;
 * no fixed CHD→OPL pipeline, extraction command, or whole-image cache is
   introduced.
 

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -7,6 +7,7 @@ use crate::input::chd_disc_decoder::ChdDiscDecoder;
 use crate::input::decode::InputDecoder;
 use crate::input::decoder_registry::DecoderRegistry;
 use crate::input::identify::InputIdentifier;
+use crate::input::iso_disc_decoder::IsoDiscDecoder;
 use crate::output::presentation_spec::PresentationSpec;
 use crate::policy::PolicySet;
 use crate::RetromountError;
@@ -34,6 +35,9 @@ pub fn pipeline_components(presentation_name: &str) -> Result<PipelineComponents
 
     let mut decoder = DecoderRegistry::new();
     decoder.register(ChdDiscDecoder::new());
+    if presentation_name == "opl" {
+        decoder.register(IsoDiscDecoder::new(crate::core::content::DiscMedia::Dvd));
+    }
     decoder.register(BasicInputDecoder::new());
 
     let normalization = if presentation_name == "opl" {

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -80,7 +80,10 @@ impl InputDecoder for BasicInputDecoder {
                 source: object.source.clone(),
                 size,
             }),
-            InputIdentity::Directory | InputIdentity::Archive | InputIdentity::ChdDisc => {
+            InputIdentity::Directory
+            | InputIdentity::Archive
+            | InputIdentity::ChdDisc
+            | InputIdentity::IsoDisc => {
                 return Ok(Vec::new());
             }
         };

--- a/src/input/basic_identifier.rs
+++ b/src/input/basic_identifier.rs
@@ -24,6 +24,7 @@ impl InputIdentifier for BasicInputIdentifier {
         let identity = match path.extension().and_then(|ext| ext.to_str()) {
             Some(ext) if ext.eq_ignore_ascii_case("cue") => InputIdentity::DiscImage,
             Some(ext) if ext.eq_ignore_ascii_case("chd") => InputIdentity::ChdDisc,
+            Some(ext) if ext.eq_ignore_ascii_case("iso") => InputIdentity::IsoDisc,
             Some(ext)
                 if ext.eq_ignore_ascii_case("txt")
                     || ext.eq_ignore_ascii_case("md")
@@ -79,6 +80,20 @@ mod tests {
         assert_eq!(
             identifier.identify(&object).unwrap(),
             InputIdentity::ChdDisc
+        );
+    }
+
+    #[test]
+    fn identifies_iso_as_a_distinct_disc_format() {
+        let identifier = BasicInputIdentifier::new();
+        let object = SourceObject {
+            source: SourceRef::new("/tmp/game.ISO"),
+            name: "game.ISO".to_string(),
+        };
+
+        assert_eq!(
+            identifier.identify(&object).unwrap(),
+            InputIdentity::IsoDisc
         );
     }
 }

--- a/src/input/identify.rs
+++ b/src/input/identify.rs
@@ -8,6 +8,7 @@ pub enum InputIdentity {
     Archive,
     DiscImage,
     ChdDisc,
+    IsoDisc,
     Text,
     Unknown,
 }

--- a/src/input/iso_disc_decoder.rs
+++ b/src/input/iso_disc_decoder.rs
@@ -1,0 +1,153 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::core::content::{ContentId, DecodedContent, DecodedDiscContent, DiscMedia, LogicalDisc};
+use crate::core::reader_handle::ReaderHandle;
+use crate::core::source::SourceObject;
+use crate::input::decode::InputDecoder;
+use crate::input::identify::InputIdentity;
+use crate::readers::dir_reader::DirReader;
+
+const ISO_SECTOR_SIZE: u32 = 2048;
+
+/// Decodes a filesystem ISO using an explicit media hint supplied by the
+/// application composition.
+///
+/// ISO contains a logical filesystem image, but does not reliably identify the
+/// physical carrier from which it came. The decoder therefore must not infer
+/// CD or DVD solely from the file extension or size.
+#[derive(Debug, Clone, Copy)]
+pub struct IsoDiscDecoder {
+    media: DiscMedia,
+}
+
+impl IsoDiscDecoder {
+    pub fn new(media: DiscMedia) -> Self {
+        Self { media }
+    }
+
+    fn logical_disc(path: PathBuf, media: DiscMedia) -> io::Result<LogicalDisc> {
+        let logical_bytes = fs::metadata(&path)?.len();
+
+        if logical_bytes == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ISO image must not be empty",
+            ));
+        }
+        if !logical_bytes.is_multiple_of(u64::from(ISO_SECTOR_SIZE)) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("ISO size must contain whole {ISO_SECTOR_SIZE}-byte sectors"),
+            ));
+        }
+
+        let reader_path = path.clone();
+        let handle_id = format!("iso:{}", path.to_string_lossy());
+
+        Ok(LogicalDisc {
+            media,
+            sector_size: ISO_SECTOR_SIZE,
+            sector_count: logical_bytes / u64::from(ISO_SECTOR_SIZE),
+            content: ReaderHandle::new(handle_id, move || {
+                Ok(Box::new(DirReader::open(&reader_path)?))
+            }),
+        })
+    }
+}
+
+impl InputDecoder for IsoDiscDecoder {
+    fn supports(&self, identity: &InputIdentity) -> bool {
+        matches!(identity, InputIdentity::IsoDisc)
+    }
+
+    fn decode(
+        &self,
+        object: &SourceObject,
+        identity: &InputIdentity,
+    ) -> Result<Vec<DecodedContent>, io::Error> {
+        if !self.supports(identity) {
+            return Ok(Vec::new());
+        }
+
+        let path = PathBuf::from(object.source.0.as_ref());
+        let logical_disc = Self::logical_disc(path.clone(), self.media)?;
+        let title = Path::new(&object.name)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or(&object.name)
+            .to_string();
+
+        Ok(vec![DecodedContent::Disc(DecodedDiscContent {
+            id: ContentId::new(object.name.clone()),
+            source: object.source.clone(),
+            title,
+            disc_number: 1,
+            consumed_sources: Vec::new(),
+            logical_disc: Some(logical_disc),
+        })])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::source::SourceRef;
+
+    #[test]
+    fn builds_a_live_logical_disc_from_valid_iso_geometry() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        fs::write(file.path(), vec![0; ISO_SECTOR_SIZE as usize * 3]).unwrap();
+
+        let disc = IsoDiscDecoder::logical_disc(file.path().to_path_buf(), DiscMedia::Dvd).unwrap();
+
+        assert_eq!(disc.media, DiscMedia::Dvd);
+        assert_eq!(disc.sector_size, ISO_SECTOR_SIZE);
+        assert_eq!(disc.sector_count, 3);
+        assert_eq!(disc.byte_len(), Some(6144));
+        assert!(disc.content.id().starts_with("iso:"));
+    }
+
+    #[test]
+    fn rejects_empty_and_partial_sector_images() {
+        let empty = tempfile::NamedTempFile::new().unwrap();
+        let partial = tempfile::NamedTempFile::new().unwrap();
+        fs::write(partial.path(), vec![0; ISO_SECTOR_SIZE as usize + 1]).unwrap();
+
+        assert_eq!(
+            IsoDiscDecoder::logical_disc(empty.path().to_path_buf(), DiscMedia::Dvd)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            IsoDiscDecoder::logical_disc(partial.path().to_path_buf(), DiscMedia::Dvd)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn decodes_with_the_explicit_media_hint() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        fs::write(file.path(), vec![0; ISO_SECTOR_SIZE as usize]).unwrap();
+        let object = SourceObject {
+            source: SourceRef::new(file.path().to_string_lossy().into_owned()),
+            name: "Game.iso".to_string(),
+        };
+
+        let decoded = IsoDiscDecoder::new(DiscMedia::Dvd)
+            .decode(&object, &InputIdentity::IsoDisc)
+            .unwrap();
+        let DecodedContent::Disc(disc) = &decoded[0] else {
+            panic!("ISO should decode as a disc");
+        };
+
+        assert_eq!(
+            disc.logical_disc.as_ref().map(|disc| disc.media),
+            Some(DiscMedia::Dvd)
+        );
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -6,5 +6,6 @@ pub mod decoder_registry;
 pub mod directory_source;
 pub mod file_source;
 pub mod identify;
+pub mod iso_disc_decoder;
 pub mod source;
 pub mod zip_source;

--- a/tests/iso_opl_integration.rs
+++ b/tests/iso_opl_integration.rs
@@ -1,0 +1,138 @@
+use std::fs;
+
+use retromount::core::content::{DecodedContent, DiscMedia, GamePart, NormalizedContent, Platform};
+use retromount::core::normalizer::NormalizationOptions;
+use retromount::core::vfs_resolver::open_file;
+use retromount::engine::components::pipeline_components;
+use retromount::engine::mount::prepare_mount_session;
+use retromount::engine::pipeline::{run_pipeline_with_presentation_options, PipelineOptions};
+use retromount::input::file_source::FileInputSource;
+use retromount::mount::session::MountNodeKind;
+
+const SECTOR_SIZE: usize = 2048;
+const SECTOR_COUNT: usize = 4;
+const LOGICAL_SIZE: usize = SECTOR_SIZE * SECTOR_COUNT;
+
+#[test]
+fn presents_a_filesystem_iso_through_the_live_opl_dvd_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let iso_path = temp_dir.path().join("Test Game.iso");
+    fs::write(&iso_path, iso_fixture()).unwrap();
+
+    let trace = run_opl(&iso_path).unwrap();
+
+    assert!(trace.objects[0].supported);
+    let DecodedContent::Disc(decoded_disc) = &trace.objects[0].decoded[0] else {
+        panic!("ISO should decode as a disc");
+    };
+    let logical_disc = decoded_disc
+        .logical_disc
+        .as_ref()
+        .expect("decoded ISO should retain live content");
+    assert_eq!(logical_disc.media, DiscMedia::Dvd);
+    assert_eq!(logical_disc.sector_size, SECTOR_SIZE as u32);
+    assert_eq!(logical_disc.sector_count, SECTOR_COUNT as u64);
+
+    let NormalizedContent::Game(game) = &trace.normalized[0] else {
+        panic!("decoded ISO should normalize as a game");
+    };
+    assert_eq!(game.platform, Platform::Ps2);
+    assert!(matches!(
+        &game.parts[0],
+        GamePart::Disc(part) if part.logical_disc.as_ref() == Some(logical_disc)
+    ));
+
+    let file = trace
+        .output_vfs
+        .find_file("DVD/Test Game.iso")
+        .expect("OPL ISO should be present");
+    assert_eq!(file.size, LOGICAL_SIZE as u64);
+
+    let mut reader = open_file(&trace.output_vfs, "DVD/Test Game.iso").unwrap();
+    assert_read(&mut *reader, 3, 19);
+    assert_read(&mut *reader, SECTOR_SIZE - 7, 23);
+    assert_read(&mut *reader, LOGICAL_SIZE - 5, 5);
+
+    let mut eof = [0; 8];
+    assert_eq!(reader.read_at(LOGICAL_SIZE as u64, &mut eof).unwrap(), 0);
+}
+
+#[test]
+fn prepares_a_mount_session_for_a_filesystem_iso() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let iso_path = temp_dir.path().join("Test Game.iso");
+    fs::write(&iso_path, iso_fixture()).unwrap();
+
+    let session = prepare_mount_session(&iso_path, "opl").unwrap();
+    let dvd = session
+        .lookup_child(session.root_inode(), "DVD")
+        .expect("mount root should contain the OPL DVD directory");
+    let iso = session
+        .lookup_child(dvd.inode, "Test Game.iso")
+        .expect("DVD directory should contain the live ISO");
+    let MountNodeKind::File { file } = &iso.kind else {
+        panic!("OPL entry should be a file");
+    };
+
+    assert_eq!(file.size, LOGICAL_SIZE as u64);
+    let mut reader = retromount::core::vfs_reader::open_vfs_file(file).unwrap();
+    assert_read(&mut *reader, SECTOR_SIZE + 11, 31);
+}
+
+#[test]
+fn rejects_invalid_iso_geometry() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let empty_path = temp_dir.path().join("Empty.iso");
+    fs::write(&empty_path, []).unwrap();
+    let empty_error = run_opl(&empty_path).unwrap_err();
+    assert_eq!(empty_error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(empty_error.to_string().contains("must not be empty"));
+
+    let partial_path = temp_dir.path().join("Partial.iso");
+    fs::write(&partial_path, vec![0; SECTOR_SIZE + 1]).unwrap();
+    let partial_error = run_opl(&partial_path).unwrap_err();
+    assert_eq!(partial_error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(partial_error
+        .to_string()
+        .contains("whole 2048-byte sectors"));
+}
+
+fn run_opl(path: &std::path::Path) -> std::io::Result<retromount::engine::pipeline::PipelineTrace> {
+    let components = pipeline_components("opl").unwrap();
+    let source = FileInputSource::new(path);
+    let options = PipelineOptions {
+        normalization: NormalizationOptions {
+            platform_hint: Some(Platform::Ps2),
+        },
+        plugin_registry: None,
+    };
+
+    run_pipeline_with_presentation_options(
+        &source,
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &components.presentation,
+        &components.policy,
+        &options,
+    )
+}
+
+fn iso_fixture() -> Vec<u8> {
+    (0..LOGICAL_SIZE).map(fixture_byte).collect()
+}
+
+fn assert_read(reader: &mut dyn retromount::core::reader::Reader, offset: usize, length: usize) {
+    let mut bytes = vec![0; length];
+    assert_eq!(reader.read_at(offset as u64, &mut bytes).unwrap(), length);
+    assert_eq!(
+        bytes,
+        (offset..offset + length)
+            .map(fixture_byte)
+            .collect::<Vec<_>>()
+    );
+}
+
+fn fixture_byte(offset: usize) -> u8 {
+    ((offset * 29 + 7) % 251) as u8
+}


### PR DESCRIPTION
## Summary

- define the optical-media contract and staged capability roadmap
- mark the PS2 DVD CHD milestone complete within Retromount's scope
- identify and decode filesystem ISO inputs as live logical discs
- feed ISO inputs through the existing PS2 DVD and OPL presentation path
- validate exact size, arbitrary reads, mount preparation, and invalid geometry

## Why

Retromount needs to expand beyond its first CHD path without conflating source containers, disc formats, media semantics, platforms, and presentations. This change records those boundaries and proves decoder interchangeability with a deliberately narrow filesystem ISO to PS2 DVD to OPL slice.

Because ISO does not reliably identify its original physical carrier, the decoder receives an explicit DVD hint from the OPL composition rather than inferring DVD from the extension or file size.

## Impact

A filesystem ISO can now be mounted through the OPL view as `DVD/<title>.iso` using reader-backed content without creating an ISO-sized copy. The next roadmap milestone is the live input-content boundary and ZIP replacement.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `markdownlint-cli2 README.md 'docs/**/*.md'`
- `git diff --check`
