### PR TITLE
Load declarative presentations from YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Retromount is under active development and progressing through a structured road
 * Phase 4D — Extensibility and configuration layer
 * Phase 5 — Runtime encoder plugin architecture
 * Phase 6 — Declarative presentation specifications
+* Versioned YAML presentation files and external presentation loading
 
 ### In Progress
 
@@ -110,7 +111,8 @@ RetroMount can expose a collection as a read-only filesystem using FUSE.
 
 ```bash
 retromount mount <input> <mountpoint>
-retromount mount "/roms/ps2/Test Game.chd" /mnt/retromount/ps2 --view opl
+retromount mount "/roms/ps2/Test Game.chd" /mnt/retromount/ps2 \
+  --presentation opl
 ```
 
 ### Example
@@ -146,14 +148,14 @@ Create a file called `retromount.yaml`:
   source: /roms/ps1/Ridge Racer.cue
   mount: /mnt/retromount/ps1
   platform: ps1
-  presenter: grouped
+  presentation: grouped
   encoder: basic
 
 - name: ps2-opl
   source: /roms/ps2/Test Game.chd
   mount: /mnt/retromount/ps2
   platform: ps2
-  presenter: opl
+  presentation: opl
 
 - name: snes
   source: /roms/snes
@@ -164,19 +166,19 @@ Create a file called `retromount.yaml`:
   source: /roms/megadrive
   mount: /mnt/retromount/megadrive
   platform: megadrive
-  presenter: flat
+  presentation: flat
 ```
 
 Fields:
 
-| Field       | Description                                                |
-| ----------- | ---------------------------------------------------------- |
-| `name`      | Logical name for the mounted view                          |
-| `source`    | Source directory, archive, or disc image                   |
-| `mount`     | Mount point for the virtual filesystem                     |
-| `platform`  | Target platform (e.g. `ps1`, `ps2`, `snes`, `megadrive`)   |
-| `presenter` | Layout (`grouped`, `flat`, `opl`; default: `grouped`)      |
-| `encoder`   | File representation strategy (default: `basic`)            |
+| Field          | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| `name`         | Logical name for the mounted view                          |
+| `source`       | Source directory, archive, or disc image                   |
+| `mount`        | Mount point for the virtual filesystem                     |
+| `platform`     | Target platform (e.g. `ps1`, `ps2`, `snes`, `megadrive`)   |
+| `presentation` | Built-in name or YAML file path (default: `grouped`)       |
+| `encoder`      | File representation strategy (default: `basic`)            |
 
 Platform names are **case-insensitive** and accept friendly aliases.
 
@@ -191,7 +193,9 @@ Each configured view is composed of:
 
 If not specified:
 
-* the legacy `presenter` config field selects a presentation and defaults to `grouped`
+* `presentation` selects a built-in name or versioned YAML file and defaults
+  to `grouped`
+* the legacy `presenter` field remains a compatibility alias
 * `encoder` defaults to `basic`
 
 This allows different views to present the same underlying data in different layouts without duplicating files.
@@ -276,6 +280,7 @@ Output-specific filtering will be implemented in the **view/output layer** in a 
 ## Documentation
 
 * [Consumer Views (Phase 4B)](docs/consumer-views.md)
+* [Presentation files](docs/presentations.md)
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -60,6 +60,8 @@ This structure ensures that:
 * `review-findings.md` — findings discovered during architecture review
 * `decisions.md` — architectural decisions made during the review
 * `cleanup-tracker.md` — concrete cleanup and refactor tasks arising from findings
+* `../presentations.md` — versioned YAML presentation schema, selection, and
+  authoring reference
 
 ---
 

--- a/docs/consumer-views.md
+++ b/docs/consumer-views.md
@@ -70,21 +70,23 @@ Super Mario World.sfc
 
 ## CLI Usage
 
-Presenter selection is exposed via the `--view` flag:
+Presentation selection is exposed via the `--presentation` flag:
 
 ```bash
-retromount inspect <input> --view grouped
-retromount inspect <input> --view flat
+retromount inspect <input> --presentation grouped
+retromount inspect <input> --presentation flat
 
-retromount mount <input> <mountpoint> --view grouped
-retromount mount <input> <mountpoint> --view flat
+retromount mount <input> <mountpoint> --presentation grouped
+retromount mount <input> <mountpoint> --presentation flat
 ```
 
 Default:
 
 ```bash
---view grouped
+--presentation grouped
 ```
+
+The legacy `--view` spelling remains available as a compatibility alias.
 
 ---
 

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -1,0 +1,148 @@
+# Presentation Files
+
+Retromount presentations describe filesystem layout, content selection, naming,
+and output artifact requirements as versioned YAML data. The generic
+presentation compiler turns this data into a `PresentationPlan`; encoders then
+materialize the requested artifacts.
+
+Presentation files do not contain executable logic and do not select input
+formats or named encoders.
+
+## Selecting a presentation
+
+Use a built-in presentation name:
+
+```bash
+retromount inspect /roms --presentation grouped
+retromount mount /roms/ps2/Game.chd /mnt/retromount --presentation opl
+```
+
+Or provide a YAML file:
+
+```bash
+retromount inspect /roms --presentation ./my-presentation.yaml
+retromount mount /roms /mnt/retromount \
+  --presentation ./my-presentation.yaml
+```
+
+The older `--view` flag remains an alias for compatibility.
+
+Configured views use the same name-or-path value:
+
+```yaml
+- name: custom
+  source: /roms
+  mount: /mnt/retromount
+  platform: ps2
+  presentation: ./my-presentation.yaml
+```
+
+The older `presenter` field remains supported as a legacy alias. A view must not
+define both fields.
+
+## Schema version 1
+
+Every file declares its schema version and presentation name:
+
+```yaml
+version: 1
+name: opl
+```
+
+Unknown versions and unknown fields are rejected. This prevents misspellings
+from silently changing output.
+
+### Complete example
+
+```yaml
+version: 1
+name: opl
+
+layout:
+  type: literal_root
+  path: DVD
+
+files:
+  - select:
+      type: single_disc_games_by_platform_and_media
+      platform: ps2
+      media: dvd
+    naming:
+      type: game_title
+    artifact:
+      content_type: disc
+      format: iso
+      required_features:
+        - random_access
+        - lossless
+```
+
+The repository version of this presentation is
+[`presentations/opl.yaml`](../presentations/opl.yaml).
+
+## Layouts
+
+Supported `layout.type` values:
+
+* `flat`
+* `grouped_by_platform_and_game`
+* `literal_root`, with a non-empty `path`
+
+## Selection rules
+
+Supported `select.type` values:
+
+* `games`
+* `games_without_parts`
+* `single_disc_games`
+* `single_disc_games_by_platform_and_media`
+* `multi_disc_games`
+* `single_rom_games`
+* `bytes`
+* `text`
+
+`single_disc_games_by_platform_and_media` also requires `platform` and `media`.
+Schema version 1 supports the platforms and media kinds already present in the
+normalized content model.
+
+## Naming rules
+
+Supported `naming.type` values:
+
+* `game_title`
+* `game_name`
+* `part_name`
+* `playlist_name`
+* `source_name`
+* `literal`, with a non-empty `value`
+
+## Artifact requirements
+
+Each rule declares a `content_type` and may declare:
+
+* `format`
+* `required_features`
+* `preferred_features`
+* `forbidden_features`
+
+A feature cannot be required or preferred while also forbidden. Capability
+resolution selects an encoder after the presentation has compiled.
+
+## Built-in catalog
+
+The built-in catalog currently contains:
+
+* `flat`
+* `grouped`
+* `opl`
+
+OPL is loaded from an embedded copy of `presentations/opl.yaml`. Flat and
+grouped remain code-constructed declarative values until their shared rule set
+is migrated without unnecessary duplication.
+
+## Scope and extension
+
+Schema version 1 intentionally exposes only concepts supported by the current
+generic compiler. New fields and rule types should be added in response to a
+real presentation requirement, then covered by validation and compilation
+tests.

--- a/docs/roadmap/presentation-serialization.md
+++ b/docs/roadmap/presentation-serialization.md
@@ -1,0 +1,43 @@
+# Presentation Serialization
+
+## Status
+
+Implemented for schema version 1.
+
+## Goal
+
+Make declarative presentations authorable as versioned YAML rather than only
+as `PresentationSpec` values constructed in Rust.
+
+## Delivered
+
+* a versioned YAML document schema;
+* strict parsing with unknown-field rejection;
+* semantic validation with actionable errors;
+* name-or-file presentation lookup;
+* `--presentation <name|file>` for inspect and mount;
+* legacy `--view` compatibility;
+* `presentation: <name|file>` in configured views;
+* legacy `presenter` compatibility with conflict detection;
+* OPL migrated to `presentations/opl.yaml` and embedded in the binary;
+* separation between the external schema and internal runtime types.
+
+## Constraints
+
+* Presentation files operate on normalized content.
+* Presentation files cannot execute arbitrary code.
+* Presentation files request output capabilities rather than named encoders.
+* Unknown schema versions and fields fail closed.
+* The file schema may evolve independently from the Rust representation.
+
+## Follow-up
+
+Before adding new target-specific Rust presentation construction:
+
+1. extend schema version 1 only when a concrete consumer needs another generic
+   rule;
+2. express PS2 CD and the first PS1 presentation as YAML;
+3. decide whether flat and grouped should move to separate YAML files or share
+   a reusable rule mechanism;
+4. introduce a user presentation search path only when name-based discovery of
+   external files is required.

--- a/presentations/opl.yaml
+++ b/presentations/opl.yaml
@@ -1,0 +1,20 @@
+version: 1
+name: opl
+
+layout:
+  type: literal_root
+  path: DVD
+
+files:
+  - select:
+      type: single_disc_games_by_platform_and_media
+      platform: ps2
+      media: dvd
+    naming:
+      type: game_title
+    artifact:
+      content_type: disc
+      format: iso
+      required_features:
+        - random_access
+        - lossless

--- a/retromount.yaml.example
+++ b/retromount.yaml.example
@@ -4,20 +4,20 @@
 # platform accepts friendly names like ps1, snes, megadrive, playstation, etc.
 #
 # Each view can optionally specify:
-#   presenter → filesystem layout (default: grouped)
-#   encoder   → file representation (default: basic)
+#   presentation → built-in name or YAML presentation path (default: grouped)
+#   encoder      → file representation (default: basic)
 
 - name: ps2-opl
   source: /roms/ps2/Test Game.chd
   mount: /mnt/retromount/ps2
   platform: ps2
-  presenter: opl
+  presentation: opl
 
 - name: ps1
   source: /roms/ps1/Ridge Racer.cue
   mount: /mnt/retromount/ps1
   platform: ps1
-  presenter: grouped
+  presentation: grouped
   encoder: basic
 
 # Directory source example (uses defaults: grouped + basic)
@@ -26,9 +26,9 @@
   mount: /mnt/retromount/snes
   platform: snes
 
-# ZIP-based ROM collection example with alternate presenter
+# ZIP-based ROM collection example with alternate presentation
 - name: megadrive
   source: /roms/megadrive
   mount: /mnt/retromount/megadrive
   platform: megadrive
-  presenter: flat
+  presentation: flat

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -1,44 +1,59 @@
-use crate::core::content::{DiscMedia, Platform};
-use crate::output::capabilities::{CapabilityFeature, ContentType, Format};
+use std::path::Path;
+
+use crate::output::capabilities::{ContentType, Format};
+use crate::output::presentation_file::{
+    load_presentation_file, parse_presentation_yaml, PresentationDocument,
+};
 use crate::output::presentation_spec::{
     ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
 };
 
 const BUILT_IN_PRESENTATIONS: [&str; 3] = ["flat", "grouped", "opl"];
+const OPL_PRESENTATION: &str = include_str!("../../presentations/opl.yaml");
 
 pub fn built_in_presentation_names() -> &'static [&'static str] {
     &BUILT_IN_PRESENTATIONS
 }
 
 pub fn build_presentation_spec(name: &str) -> Result<PresentationSpec, String> {
-    match name {
-        "flat" => Ok(PresentationSpec::new(
-            LayoutSpec::Flat,
-            built_in_file_rules(),
-        )),
-        "grouped" => Ok(PresentationSpec::new(
-            LayoutSpec::GroupedByPlatformAndGame,
-            built_in_file_rules(),
-        )),
-        "opl" => Ok(PresentationSpec::new(
-            LayoutSpec::LiteralRoot("DVD".to_string()),
-            vec![FileRuleSpec::new(
-                SelectSpec::SingleDiscGamesByPlatformAndMedia {
-                    platform: Platform::Ps2,
-                    media: DiscMedia::Dvd,
-                },
-                NamingSpec::GameTitle,
-                ArtifactSpec::new(ContentType::Disc)
-                    .with_format(Format::Iso)
-                    .require_feature(CapabilityFeature::RandomAccess)
-                    .require_feature(CapabilityFeature::Lossless),
-            )],
-        )),
+    Ok(load_presentation(name)?.spec)
+}
+
+pub fn load_presentation(reference: &str) -> Result<PresentationDocument, String> {
+    match reference {
+        "flat" => Ok(PresentationDocument {
+            name: "flat".to_string(),
+            spec: PresentationSpec::new(LayoutSpec::Flat, built_in_file_rules()),
+        }),
+        "grouped" => Ok(PresentationDocument {
+            name: "grouped".to_string(),
+            spec: PresentationSpec::new(
+                LayoutSpec::GroupedByPlatformAndGame,
+                built_in_file_rules(),
+            ),
+        }),
+        "opl" => parse_presentation_yaml(OPL_PRESENTATION)
+            .map_err(|error| format!("built-in presentation 'opl' failed validation: {error}")),
+        _ if looks_like_presentation_path(reference) => {
+            load_presentation_file(Path::new(reference))
+                .map_err(|error| format!("failed to load presentation '{}': {error}", reference))
+        }
         _ => Err(format!(
-            "unsupported view '{name}'; expected one of: {}",
+            "unsupported view or presentation file '{reference}'; expected one of: {}",
             built_in_presentation_names().join(", ")
         )),
     }
+}
+
+fn looks_like_presentation_path(reference: &str) -> bool {
+    let path = Path::new(reference);
+    path.is_file()
+        || path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| {
+                extension.eq_ignore_ascii_case("yaml") || extension.eq_ignore_ascii_case("yml")
+            })
 }
 
 fn built_in_file_rules() -> Vec<FileRuleSpec> {
@@ -85,7 +100,8 @@ fn built_in_file_rules() -> Vec<FileRuleSpec> {
 mod tests {
     use super::*;
     use crate::core::content::{
-        ContentId, DiscPart, GameContent, GamePart, LogicalDisc, NormalizedContent, Platform,
+        ContentId, DiscMedia, DiscPart, GameContent, GamePart, LogicalDisc, NormalizedContent,
+        Platform,
     };
     use crate::core::reader_handle::ReaderHandle;
     use crate::core::source::SourceRef;
@@ -122,8 +138,44 @@ mod tests {
         let error = build_presentation_spec("unknown").unwrap_err();
         assert_eq!(
             error,
-            "unsupported view 'unknown'; expected one of: flat, grouped, opl"
+            "unsupported view or presentation file 'unknown'; expected one of: flat, grouped, opl"
         );
+    }
+
+    #[test]
+    fn reports_a_missing_presentation_file_as_a_read_error() {
+        let error = load_presentation("/missing/presentation.yaml").unwrap_err();
+
+        assert!(error.contains("failed to read presentation"));
+        assert!(error.contains("/missing/presentation.yaml"));
+    }
+
+    #[test]
+    fn loads_an_external_presentation_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"
+version: 1
+name: external-flat
+layout:
+  type: flat
+files:
+  - select:
+      type: bytes
+    naming:
+      type: source_name
+    artifact:
+      content_type: bytes
+      format: bin
+"#,
+        )
+        .unwrap();
+
+        let document = load_presentation(file.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(document.name, "external-flat");
+        assert_eq!(document.spec.layout, LayoutSpec::Flat);
     }
 
     #[test]

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -1,6 +1,6 @@
 use crate::core::content::Platform;
 use crate::core::normalizer::NormalizationOptions;
-use crate::engine::bootstrap::build_presentation_spec;
+use crate::engine::bootstrap::load_presentation;
 use crate::input::basic_decoder::BasicInputDecoder;
 use crate::input::basic_identifier::BasicInputIdentifier;
 use crate::input::chd_disc_decoder::ChdDiscDecoder;
@@ -29,8 +29,7 @@ pub fn default_pipeline_components() -> Result<PipelineComponents, RetromountErr
 }
 
 pub fn pipeline_components(presentation_name: &str) -> Result<PipelineComponents, RetromountError> {
-    let presentation =
-        build_presentation_spec(presentation_name).map_err(RetromountError::LoadError)?;
+    let document = load_presentation(presentation_name).map_err(RetromountError::LoadError)?;
 
     let mut decoder = DecoderRegistry::new();
     decoder.register(ChdDiscDecoder::new());
@@ -47,7 +46,7 @@ pub fn pipeline_components(presentation_name: &str) -> Result<PipelineComponents
     Ok(PipelineComponents {
         identifier: Box::new(BasicInputIdentifier::new()),
         decoder: Box::new(decoder),
-        presentation,
+        presentation: document.spec,
         normalization,
         policy: PolicySet::default(),
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@ pub struct ViewConfig {
     pub platform: Platform,
 
     #[serde(default)]
+    pub presentation: Option<String>,
+
+    /// Legacy alias for `presentation`.
+    #[serde(default)]
     pub presenter: Option<String>,
 
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use retromount::core::content::{
 };
 use retromount::core::normalizer::NormalizationOptions;
 use retromount::core::platform::Platform as ConfigPlatform;
-use retromount::engine::bootstrap::{build_presentation_spec, built_in_presentation_names};
+use retromount::engine::bootstrap::load_presentation;
 use retromount::engine::components::pipeline_components;
 use retromount::engine::inspect::{run_phase3_inspect, run_phase3_inspect_with_plugins};
 use retromount::engine::mount::{run_mount_command, run_mount_command_with_plugins};
@@ -50,19 +50,19 @@ fn main() -> Result<(), RetromountError> {
             run_phase3_inspect(&path, true, "grouped")
         }
         [command, path, view_flag, view]
-            if command.to_string_lossy() == "inspect" && view_flag.to_string_lossy() == "--view" =>
+            if command.to_string_lossy() == "inspect" && is_presentation_flag(view_flag) =>
         {
             let path = PathBuf::from(path);
-            let presentation_name = parse_presentation_name(view)?;
+            let presentation_name = parse_presentation_reference(view)?;
             run_phase3_inspect(&path, false, &presentation_name)
         }
         [command, path, flag, view_flag, view]
             if command.to_string_lossy() == "inspect"
                 && flag.to_string_lossy() == "--json"
-                && view_flag.to_string_lossy() == "--view" =>
+                && is_presentation_flag(view_flag) =>
         {
             let path = PathBuf::from(path);
-            let presentation_name = parse_presentation_name(view)?;
+            let presentation_name = parse_presentation_reference(view)?;
             run_phase3_inspect(&path, true, &presentation_name)
         }
         [command, path, plugin_flag, plugin_dir]
@@ -86,11 +86,11 @@ fn main() -> Result<(), RetromountError> {
         }
         [command, path, view_flag, view, plugin_flag, plugin_dir]
             if command.to_string_lossy() == "inspect"
-                && view_flag.to_string_lossy() == "--view"
+                && is_presentation_flag(view_flag)
                 && plugin_flag.to_string_lossy() == "--plugin-dir" =>
         {
             let path = PathBuf::from(path);
-            let presentation_name = parse_presentation_name(view)?;
+            let presentation_name = parse_presentation_reference(view)?;
             let plugin_dir = PathBuf::from(plugin_dir);
             let plugin_registry = load_plugin_registry(&plugin_dir)?;
             run_phase3_inspect_with_plugins(&path, false, &presentation_name, Some(&plugin_registry))
@@ -98,11 +98,11 @@ fn main() -> Result<(), RetromountError> {
         [command, path, json_flag, view_flag, view, plugin_flag, plugin_dir]
             if command.to_string_lossy() == "inspect"
                 && json_flag.to_string_lossy() == "--json"
-                && view_flag.to_string_lossy() == "--view"
+                && is_presentation_flag(view_flag)
                 && plugin_flag.to_string_lossy() == "--plugin-dir" =>
         {
             let path = PathBuf::from(path);
-            let presentation_name = parse_presentation_name(view)?;
+            let presentation_name = parse_presentation_reference(view)?;
             let plugin_dir = PathBuf::from(plugin_dir);
             let plugin_registry = load_plugin_registry(&plugin_dir)?;
             run_phase3_inspect_with_plugins(&path, true, &presentation_name, Some(&plugin_registry))
@@ -114,11 +114,11 @@ fn main() -> Result<(), RetromountError> {
             run_mount_command(&input, &mountpoint, "grouped")
         }
         [command, input, mountpoint, view_flag, view]
-            if command.to_string_lossy() == "mount" && view_flag.to_string_lossy() == "--view" =>
+            if command.to_string_lossy() == "mount" && is_presentation_flag(view_flag) =>
         {
             let input = PathBuf::from(input);
             let mountpoint = PathBuf::from(mountpoint);
-            let presentation_name = parse_presentation_name(view)?;
+            let presentation_name = parse_presentation_reference(view)?;
             run_mount_command(&input, &mountpoint, &presentation_name)
         }
         [command, input, mountpoint, plugin_flag, plugin_dir]
@@ -133,12 +133,12 @@ fn main() -> Result<(), RetromountError> {
         }
         [command, input, mountpoint, view_flag, view, plugin_flag, plugin_dir]
             if command.to_string_lossy() == "mount"
-                && view_flag.to_string_lossy() == "--view"
+                && is_presentation_flag(view_flag)
                 && plugin_flag.to_string_lossy() == "--plugin-dir" =>
         {
             let input = PathBuf::from(input);
             let mountpoint = PathBuf::from(mountpoint);
-            let presentation_name = parse_presentation_name(view)?;
+            let presentation_name = parse_presentation_reference(view)?;
             let plugin_dir = PathBuf::from(plugin_dir);
             let plugin_registry = load_plugin_registry(&plugin_dir)?;
             run_mount_command_with_plugins(
@@ -150,23 +150,25 @@ fn main() -> Result<(), RetromountError> {
         }
 
         _ => Err(RetromountError::LoadError(
-            "usage:\n  retromount\n  retromount phase3-preview <path> [--plugin-dir <dir>]\n  retromount inspect <path> [--json] [--view <grouped|flat|opl>] [--plugin-dir <dir>]\n  retromount mount <input> <mountpoint> [--view <grouped|flat|opl>] [--plugin-dir <dir>]"
+            "usage:\n  retromount\n  retromount phase3-preview <path> [--plugin-dir <dir>]\n  retromount inspect <path> [--json] [--presentation <name|file>] [--plugin-dir <dir>]\n  retromount mount <input> <mountpoint> [--presentation <name|file>] [--plugin-dir <dir>]"
                 .to_string(),
         )),
     }
 }
 
-fn parse_presentation_name(value: &std::ffi::OsStr) -> Result<String, RetromountError> {
+fn is_presentation_flag(value: &std::ffi::OsStr) -> bool {
+    matches!(
+        value.to_string_lossy().as_ref(),
+        "--presentation" | "--view"
+    )
+}
+
+fn parse_presentation_reference(value: &std::ffi::OsStr) -> Result<String, RetromountError> {
     let value = value.to_string_lossy().to_string();
 
-    if build_presentation_spec(&value).is_ok() {
-        Ok(value)
-    } else {
-        Err(RetromountError::LoadError(format!(
-            "unsupported view '{value}'; expected one of: {}",
-            built_in_presentation_names().join(", ")
-        )))
-    }
+    load_presentation(&value)
+        .map(|_| value)
+        .map_err(RetromountError::LoadError)
 }
 
 fn run_configured_views() -> Result<(), RetromountError> {
@@ -179,7 +181,7 @@ fn run_configured_views() -> Result<(), RetromountError> {
     info!("Loaded {} view(s) from config", config.len());
 
     for view in &config {
-        let presentation_name = view.presenter.as_deref().unwrap_or("grouped");
+        let presentation_name = presentation_reference_for_view(view)?;
 
         info!("View: {}", view.name);
         info!("  Source: {}", view.source.display());
@@ -218,6 +220,18 @@ fn run_configured_views() -> Result<(), RetromountError> {
     }
 
     Ok(())
+}
+
+fn presentation_reference_for_view(view: &ViewConfig) -> Result<&str, RetromountError> {
+    match (&view.presentation, &view.presenter) {
+        (Some(_), Some(_)) => Err(RetromountError::LoadError(format!(
+            "view '{}' defines both 'presentation' and legacy 'presenter'; use only 'presentation'",
+            view.name
+        ))),
+        (Some(presentation), None) => Ok(presentation),
+        (None, Some(presenter)) => Ok(presenter),
+        (None, None) => Ok("grouped"),
+    }
 }
 
 fn pipeline_options_for_view(view: &ViewConfig) -> PipelineOptions<'static> {
@@ -264,5 +278,51 @@ fn log_content_summary(content: &NormalizedContent) {
             info!("    ID: {}", other.id());
             info!("    Source: {}", other.source());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn view_config(presentation: Option<&str>, presenter: Option<&str>) -> ViewConfig {
+        serde_yaml::from_str(&format!(
+            r#"
+name: test
+source: /roms
+mount: /mnt/roms
+platform: ps2
+{}{}
+"#,
+            presentation
+                .map(|value| format!("presentation: {value}\n"))
+                .unwrap_or_default(),
+            presenter
+                .map(|value| format!("presenter: {value}\n"))
+                .unwrap_or_default(),
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn configured_view_prefers_the_presentation_field() {
+        let view = view_config(Some("custom.yaml"), None);
+
+        assert_eq!(
+            presentation_reference_for_view(&view).unwrap(),
+            "custom.yaml"
+        );
+    }
+
+    #[test]
+    fn configured_view_supports_legacy_presenter_and_rejects_both_fields() {
+        let legacy = view_config(None, Some("flat"));
+        assert_eq!(presentation_reference_for_view(&legacy).unwrap(), "flat");
+
+        let conflicting = view_config(Some("grouped"), Some("flat"));
+        assert!(presentation_reference_for_view(&conflicting)
+            .unwrap_err()
+            .to_string()
+            .contains("defines both"));
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -16,5 +16,6 @@ pub mod plugin_runtime;
 pub mod plugin_runtime_error;
 pub mod presentation_compile;
 pub mod presentation_expansion;
+pub mod presentation_file;
 pub mod presentation_spec;
 pub mod resolution;

--- a/src/output/presentation_file.rs
+++ b/src/output/presentation_file.rs
@@ -89,9 +89,8 @@ impl TryFrom<SerializedPresentation> for PresentationDocument {
             .into_iter()
             .enumerate()
             .map(|(index, rule)| {
-                rule.into_rule().map_err(|message| {
-                    PresentationFileError::Invalid(format!("files[{}]: {message}", index))
-                })
+                rule.into_rule()
+                    .map_err(|message| invalid_file_rule(index, message))
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -100,6 +99,10 @@ impl TryFrom<SerializedPresentation> for PresentationDocument {
             spec: PresentationSpec::new(layout, files),
         })
     }
+}
+
+fn invalid_file_rule(index: usize, message: String) -> PresentationFileError {
+    PresentationFileError::Invalid(format!("files[{index}]: {message}"))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/output/presentation_file.rs
+++ b/src/output/presentation_file.rs
@@ -1,0 +1,453 @@
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs::File;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::core::content::{DiscMedia, Platform};
+use crate::output::capabilities::{CapabilityFeature, ContentType, Format};
+use crate::output::presentation_spec::{
+    ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
+};
+
+pub const PRESENTATION_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PresentationDocument {
+    pub name: String,
+    pub spec: PresentationSpec,
+}
+
+#[derive(Debug)]
+pub enum PresentationFileError {
+    Read(std::io::Error),
+    Parse(serde_yaml::Error),
+    Invalid(String),
+}
+
+impl fmt::Display for PresentationFileError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read(error) => write!(formatter, "failed to read presentation: {error}"),
+            Self::Parse(error) => write!(formatter, "failed to parse presentation YAML: {error}"),
+            Self::Invalid(message) => write!(formatter, "invalid presentation: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for PresentationFileError {}
+
+pub fn load_presentation_file(path: &Path) -> Result<PresentationDocument, PresentationFileError> {
+    let file = File::open(path).map_err(PresentationFileError::Read)?;
+    let document: SerializedPresentation =
+        serde_yaml::from_reader(file).map_err(PresentationFileError::Parse)?;
+    document.try_into()
+}
+
+pub fn parse_presentation_yaml(yaml: &str) -> Result<PresentationDocument, PresentationFileError> {
+    let document: SerializedPresentation =
+        serde_yaml::from_str(yaml).map_err(PresentationFileError::Parse)?;
+    document.try_into()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SerializedPresentation {
+    version: u32,
+    name: String,
+    layout: SerializedLayout,
+    files: Vec<SerializedFileRule>,
+}
+
+impl TryFrom<SerializedPresentation> for PresentationDocument {
+    type Error = PresentationFileError;
+
+    fn try_from(document: SerializedPresentation) -> Result<Self, Self::Error> {
+        if document.version != PRESENTATION_SCHEMA_VERSION {
+            return Err(PresentationFileError::Invalid(format!(
+                "unsupported schema version {}; expected {}",
+                document.version, PRESENTATION_SCHEMA_VERSION
+            )));
+        }
+
+        let name = document.name.trim();
+        if name.is_empty() {
+            return Err(PresentationFileError::Invalid(
+                "name must not be empty".to_string(),
+            ));
+        }
+        if document.files.is_empty() {
+            return Err(PresentationFileError::Invalid(
+                "files must contain at least one rule".to_string(),
+            ));
+        }
+
+        let layout = document.layout.try_into()?;
+        let files = document
+            .files
+            .into_iter()
+            .enumerate()
+            .map(|(index, rule)| {
+                rule.into_rule().map_err(|message| {
+                    PresentationFileError::Invalid(format!("files[{}]: {message}", index))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(PresentationDocument {
+            name: name.to_string(),
+            spec: PresentationSpec::new(layout, files),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum SerializedLayout {
+    Flat,
+    GroupedByPlatformAndGame,
+    LiteralRoot { path: String },
+}
+
+impl TryFrom<SerializedLayout> for LayoutSpec {
+    type Error = PresentationFileError;
+
+    fn try_from(layout: SerializedLayout) -> Result<Self, Self::Error> {
+        match layout {
+            SerializedLayout::Flat => Ok(Self::Flat),
+            SerializedLayout::GroupedByPlatformAndGame => Ok(Self::GroupedByPlatformAndGame),
+            SerializedLayout::LiteralRoot { path } if path.trim().is_empty() => Err(
+                PresentationFileError::Invalid("layout.path must not be empty".to_string()),
+            ),
+            SerializedLayout::LiteralRoot { path } => Ok(Self::LiteralRoot(path)),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SerializedFileRule {
+    select: SerializedSelect,
+    naming: SerializedNaming,
+    artifact: SerializedArtifact,
+}
+
+impl SerializedFileRule {
+    fn into_rule(self) -> Result<FileRuleSpec, String> {
+        Ok(FileRuleSpec::new(
+            self.select.into_select(),
+            self.naming.into_naming()?,
+            self.artifact.into_artifact()?,
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum SerializedSelect {
+    Games,
+    GamesWithoutParts,
+    SingleDiscGames,
+    SingleDiscGamesByPlatformAndMedia {
+        platform: SerializedPlatform,
+        media: SerializedDiscMedia,
+    },
+    MultiDiscGames,
+    SingleRomGames,
+    Bytes,
+    Text,
+}
+
+impl SerializedSelect {
+    fn into_select(self) -> SelectSpec {
+        match self {
+            Self::Games => SelectSpec::Games,
+            Self::GamesWithoutParts => SelectSpec::GamesWithoutParts,
+            Self::SingleDiscGames => SelectSpec::SingleDiscGames,
+            Self::SingleDiscGamesByPlatformAndMedia { platform, media } => {
+                SelectSpec::SingleDiscGamesByPlatformAndMedia {
+                    platform: platform.into(),
+                    media: media.into(),
+                }
+            }
+            Self::MultiDiscGames => SelectSpec::MultiDiscGames,
+            Self::SingleRomGames => SelectSpec::SingleRomGames,
+            Self::Bytes => SelectSpec::Bytes,
+            Self::Text => SelectSpec::Text,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum SerializedNaming {
+    GameTitle,
+    GameName,
+    PartName,
+    PlaylistName,
+    SourceName,
+    Literal { value: String },
+}
+
+impl SerializedNaming {
+    fn into_naming(self) -> Result<NamingSpec, String> {
+        match self {
+            Self::GameTitle => Ok(NamingSpec::GameTitle),
+            Self::GameName => Ok(NamingSpec::GameName),
+            Self::PartName => Ok(NamingSpec::PartName),
+            Self::PlaylistName => Ok(NamingSpec::PlaylistName),
+            Self::SourceName => Ok(NamingSpec::SourceName),
+            Self::Literal { value } if value.trim().is_empty() => {
+                Err("naming.value must not be empty".to_string())
+            }
+            Self::Literal { value } => Ok(NamingSpec::Literal(value)),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SerializedArtifact {
+    content_type: SerializedContentType,
+    #[serde(default)]
+    format: Option<SerializedFormat>,
+    #[serde(default)]
+    required_features: BTreeSet<SerializedCapabilityFeature>,
+    #[serde(default)]
+    preferred_features: BTreeSet<SerializedCapabilityFeature>,
+    #[serde(default)]
+    forbidden_features: BTreeSet<SerializedCapabilityFeature>,
+}
+
+impl SerializedArtifact {
+    fn into_artifact(self) -> Result<ArtifactSpec, String> {
+        let required_features = convert_features(self.required_features);
+        let preferred_features = convert_features(self.preferred_features);
+        let forbidden_features = convert_features(self.forbidden_features);
+
+        if let Some(feature) = required_features.intersection(&forbidden_features).next() {
+            return Err(format!(
+                "feature {feature:?} cannot be both required and forbidden"
+            ));
+        }
+        if let Some(feature) = preferred_features.intersection(&forbidden_features).next() {
+            return Err(format!(
+                "feature {feature:?} cannot be both preferred and forbidden"
+            ));
+        }
+
+        Ok(ArtifactSpec {
+            content_type: self.content_type.into(),
+            format: self.format.map(Into::into),
+            required_features,
+            preferred_features,
+            forbidden_features,
+        })
+    }
+}
+
+fn convert_features(
+    features: BTreeSet<SerializedCapabilityFeature>,
+) -> BTreeSet<CapabilityFeature> {
+    features.into_iter().map(Into::into).collect()
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+enum SerializedCapabilityFeature {
+    MultiSource,
+    Streaming,
+    Lossless,
+    RandomAccess,
+    SupportsPartial,
+}
+
+impl From<SerializedCapabilityFeature> for CapabilityFeature {
+    fn from(feature: SerializedCapabilityFeature) -> Self {
+        match feature {
+            SerializedCapabilityFeature::MultiSource => Self::MultiSource,
+            SerializedCapabilityFeature::Streaming => Self::Streaming,
+            SerializedCapabilityFeature::Lossless => Self::Lossless,
+            SerializedCapabilityFeature::RandomAccess => Self::RandomAccess,
+            SerializedCapabilityFeature::SupportsPartial => Self::SupportsPartial,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SerializedContentType {
+    Rom,
+    Disc,
+    Playlist,
+    Archive,
+    Directory,
+    Bytes,
+    Text,
+    Game,
+}
+
+impl From<SerializedContentType> for ContentType {
+    fn from(content_type: SerializedContentType) -> Self {
+        match content_type {
+            SerializedContentType::Rom => Self::Rom,
+            SerializedContentType::Disc => Self::Disc,
+            SerializedContentType::Playlist => Self::Playlist,
+            SerializedContentType::Archive => Self::Archive,
+            SerializedContentType::Directory => Self::Directory,
+            SerializedContentType::Bytes => Self::Bytes,
+            SerializedContentType::Text => Self::Text,
+            SerializedContentType::Game => Self::Game,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SerializedFormat {
+    Iso,
+    Chd,
+    Zip,
+    M3u,
+    Directory,
+    Bin,
+    Text,
+}
+
+impl From<SerializedFormat> for Format {
+    fn from(format: SerializedFormat) -> Self {
+        match format {
+            SerializedFormat::Iso => Self::Iso,
+            SerializedFormat::Chd => Self::Chd,
+            SerializedFormat::Zip => Self::Zip,
+            SerializedFormat::M3u => Self::M3u,
+            SerializedFormat::Directory => Self::Directory,
+            SerializedFormat::Bin => Self::Bin,
+            SerializedFormat::Text => Self::Text,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SerializedPlatform {
+    Snes,
+    Ps1,
+    Ps2,
+    Nes,
+    Megadrive,
+    Unknown,
+}
+
+impl From<SerializedPlatform> for Platform {
+    fn from(platform: SerializedPlatform) -> Self {
+        match platform {
+            SerializedPlatform::Snes => Self::Snes,
+            SerializedPlatform::Ps1 => Self::Ps1,
+            SerializedPlatform::Ps2 => Self::Ps2,
+            SerializedPlatform::Nes => Self::Nes,
+            SerializedPlatform::Megadrive => Self::Megadrive,
+            SerializedPlatform::Unknown => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SerializedDiscMedia {
+    Cd,
+    Dvd,
+}
+
+impl From<SerializedDiscMedia> for DiscMedia {
+    fn from(media: SerializedDiscMedia) -> Self {
+        match media {
+            SerializedDiscMedia::Cd => Self::Cd,
+            SerializedDiscMedia::Dvd => Self::Dvd,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = r#"
+version: 1
+name: opl
+layout:
+  type: literal_root
+  path: DVD
+files:
+  - select:
+      type: single_disc_games_by_platform_and_media
+      platform: ps2
+      media: dvd
+    naming:
+      type: game_title
+    artifact:
+      content_type: disc
+      format: iso
+      required_features:
+        - random_access
+        - lossless
+"#;
+
+    #[test]
+    fn parses_a_versioned_opl_presentation() {
+        let document = parse_presentation_yaml(VALID).unwrap();
+
+        assert_eq!(document.name, "opl");
+        assert_eq!(
+            document.spec.layout,
+            LayoutSpec::LiteralRoot("DVD".to_string())
+        );
+        assert_eq!(document.spec.files.len(), 1);
+        assert_eq!(
+            document.spec.files[0].select,
+            SelectSpec::SingleDiscGamesByPlatformAndMedia {
+                platform: Platform::Ps2,
+                media: DiscMedia::Dvd,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_schema_versions_and_fields() {
+        let version_error =
+            parse_presentation_yaml(&VALID.replace("version: 1", "version: 2")).unwrap_err();
+        assert!(version_error
+            .to_string()
+            .contains("unsupported schema version 2"));
+
+        let field_error =
+            parse_presentation_yaml(&VALID.replace("name: opl", "name: opl\nsurprise: true"))
+                .unwrap_err();
+        assert!(field_error.to_string().contains("unknown field `surprise`"));
+    }
+
+    #[test]
+    fn rejects_empty_rules_and_conflicting_features() {
+        let empty = r#"
+version: 1
+name: empty
+layout:
+  type: flat
+files: []
+"#;
+        assert!(parse_presentation_yaml(empty)
+            .unwrap_err()
+            .to_string()
+            .contains("at least one rule"));
+
+        let conflicting = VALID.replace(
+            "        - lossless",
+            "        - lossless\n      forbidden_features:\n        - lossless",
+        );
+        assert!(parse_presentation_yaml(&conflicting)
+            .unwrap_err()
+            .to_string()
+            .contains("both required and forbidden"));
+    }
+}

--- a/tests/presentation_file_integration.rs
+++ b/tests/presentation_file_integration.rs
@@ -1,0 +1,84 @@
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn inspect_accepts_an_external_yaml_presentation() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_path = temp_dir.path().join("payload.dat");
+    let presentation_path = temp_dir.path().join("bytes.yaml");
+
+    fs::write(&input_path, b"external presentation bytes").unwrap();
+    fs::write(
+        &presentation_path,
+        r#"
+version: 1
+name: external-bytes
+layout:
+  type: literal_root
+  path: Files
+files:
+  - select:
+      type: bytes
+    naming:
+      type: source_name
+    artifact:
+      content_type: bytes
+      format: bin
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_retromount"))
+        .arg("inspect")
+        .arg(&input_path)
+        .arg("--presentation")
+        .arg(&presentation_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "inspect failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Output VFS:"));
+    assert!(stdout.contains("Files/"));
+    assert!(
+        stdout.contains("payload.dat"),
+        "unexpected output:\n{stdout}"
+    );
+}
+
+#[test]
+fn inspect_reports_external_presentation_validation_errors() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_path = temp_dir.path().join("payload.dat");
+    let presentation_path = temp_dir.path().join("invalid.yaml");
+
+    fs::write(&input_path, b"bytes").unwrap();
+    fs::write(
+        &presentation_path,
+        r#"
+version: 99
+name: invalid
+layout:
+  type: flat
+files: []
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_retromount"))
+        .arg("inspect")
+        .arg(&input_path)
+        .arg("--presentation")
+        .arg(&presentation_path)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("unsupported schema version 99"));
+    assert!(stderr.contains(presentation_path.to_str().unwrap()));
+}

--- a/tests/presentation_file_integration.rs
+++ b/tests/presentation_file_integration.rs
@@ -80,5 +80,6 @@ files: []
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("unsupported schema version 99"));
-    assert!(stderr.contains(presentation_path.to_str().unwrap()));
+    assert!(stderr.contains("failed to load presentation"));
+    assert!(stderr.contains("invalid.yaml"));
 }


### PR DESCRIPTION
## Summary

- define a strict, versioned YAML schema for declarative presentations
- load external presentation files through the existing generic compiler
- add `--presentation <name|file>` and configured `presentation: <name|file>`
- retain `--view` and `presenter` as compatibility aliases
- migrate the built-in OPL specification to `presentations/opl.yaml`
- document the schema, validation rules, and authoring workflow

## Why

Phase 6 established presentations as declarative data, but the data was still constructed in Rust. Adding more consumer views that way would preserve a code-only authoring bottleneck. This change supplies the missing serialization and loading layer before PS2 CD and PS1 presentations are developed.

The external schema is intentionally separate from the internal Rust types so schema compatibility can evolve independently of implementation details.

## Impact

Users can select either a built-in presentation or a YAML file:

```bash
retromount inspect /roms --presentation ./my-presentation.yaml
retromount mount /roms /mnt/retromount --presentation opl
```

Configured views use the same name-or-file contract through the preferred `presentation` field. Unknown schema versions, unknown fields, invalid empty values, and conflicting capability requirements fail with actionable errors.

## Validation

- 183 library tests
- 2 binary configuration tests
- 26 integration tests
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `markdownlint-cli2 README.md 'docs/**/*.md'`
- `cargo package --allow-dirty --list`
- `git diff --check`
