### PR TITLE
Add live source-content boundary and ZIP-backed disc input

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Retromount is under active development and progressing through a structured road
 ### In Progress
 
 * Optical-media capability expansion — filesystem ISO input through the PS2
-  DVD OPL path is implemented; the live input-content boundary and revised ZIP
-  integration are next
+  DVD OPL path and the live filesystem/ZIP input-content boundary are
+  implemented; PS2 CD requirements for OPL are next
 
 ### Planned
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -65,6 +65,9 @@ This structure ensures that:
 * `adr-010-optical-media-contract.md` — separates source containers, input
   formats, media semantics, platforms, output representations, and
   presentations for the next optical-media capability slices
+* `adr-011-compressed-container-random-access.md` — permits explicit,
+  disk-backed source-entry caching for non-seekable container members while
+  preserving the prohibition on hidden output conversion
 
 ---
 

--- a/docs/architecture/adr-011-compressed-container-random-access.md
+++ b/docs/architecture/adr-011-compressed-container-random-access.md
@@ -1,0 +1,177 @@
+# ADR-011: Cache Non-Seekable Container Entries on Disk
+
+## Status
+
+Accepted
+
+## Context
+
+Retromount can expose disc content through live, random-access readers without
+creating a converted copy of the output image. This is required for workloads
+such as CHD-to-logical-ISO presentation, where consumers issue arbitrary and
+out-of-order reads.
+
+The live input-content boundary distinguishes between inputs that provide
+efficient random access and inputs that are effectively sequential:
+
+* filesystem files provide random access;
+* stored ZIP entries provide random access into the archive file;
+* Deflate-compressed ZIP entries are stream-oriented.
+
+Reading an arbitrary offset from a Deflate stream normally requires
+decompressing from the beginning of that stream. Repeating this operation for
+disc access patterns would produce unacceptable latency and repeated CPU work.
+Keeping the complete decompressed entry in memory would violate Retromount's
+bounded-memory goals.
+
+The current implementation therefore supports compressed ZIP entries for
+ordinary ROM, text, and other sequential-friendly paths, but rejects compressed
+ISO and CHD entries whose decoders require efficient random access.
+
+This creates an apparent tension with the existing rule that Retromount must
+not create a whole-disc intermediate. A distinction is needed between:
+
+* converting decoded media into a consumer output ahead of the mount; and
+* making the encoded source entry seekable so its decoder can operate.
+
+## Decision
+
+Retromount may use a managed, disk-backed source-entry cache to make an
+otherwise non-seekable container entry available to a random-access decoder.
+
+This is a source/container concern. It is not an encoder, presentation, or
+media-conversion mechanism.
+
+### Current behavior
+
+Until the cache is implemented:
+
+* stored ZIP entries may satisfy random-access decoder requirements;
+* compressed ZIP entries remain supported for content paths that do not
+  require efficient random access;
+* compressed ISO and CHD entries fail early with an actionable unsupported
+  error;
+* Retromount must not silently extract a compressed disc entry.
+
+Diagnostics should explain that users can repackage the entry with ZIP's
+`stored` method to obtain immediate live support.
+
+### Initial cache strategy
+
+The first implementation should use eager, disk-backed entry materialization:
+
+1. resolve the requested container entry;
+2. validate configured cache policy and available budget;
+3. decompress the encoded entry into a temporary file;
+4. verify its expected length and container checksum;
+5. publish the completed cache entry atomically;
+6. expose the cache file through the normal random-access input handle.
+
+The initial implementation should prefer predictable behavior over speculative
+lazy decompression.
+
+For a Deflate-compressed ISO, the cache entry is the complete ISO source entry.
+For a Deflate-compressed CHD, the cache entry is the CHD source entry, not a
+decoded or converted ISO.
+
+### Cache requirements
+
+The cache must:
+
+* be explicitly enabled rather than silently consuming disk;
+* have a configurable total disk budget;
+* reject an entry that cannot fit within the permitted budget;
+* never retain the complete entry solely in memory;
+* use stable invalidation inputs such as archive identity, member name,
+  compressed and uncompressed sizes, CRC, and archive modification metadata;
+* prevent incomplete files from being observed as valid entries;
+* coordinate concurrent requests for the same entry;
+* define lifecycle and eviction behavior;
+* provide actionable diagnostics for materialization and verification failure;
+* remain independent of the requested presentation and output encoder.
+
+Cache entries may be reused across mount sessions when persistent caching is
+enabled and validation succeeds.
+
+### Relationship to the no-intermediate rule
+
+Retromount continues to prohibit whole-image output conversion as a hidden
+mount prerequisite. In particular, CHD-to-ISO presentation must not create or
+cache a decoded ISO.
+
+Materializing an encoded container member is permitted only because the source
+container cannot provide the access semantics required by its decoder. The
+cached bytes must be byte-equivalent to the original uncompressed member.
+
+```text
+Allowed:
+  deflated ZIP member → cached original ISO member → ISO decoder
+  deflated ZIP member → cached original CHD member → CHD decoder
+
+Prohibited:
+  CHD → cached converted ISO → OPL presentation
+```
+
+### Deferred strategies
+
+Lazy materialization may be considered after the eager cache is implemented
+and measured. It would progressively decompress into a disk-backed file and
+coordinate readers waiting for later ranges.
+
+Deflate seek indexing may also be investigated later. Such an implementation
+would need restart checkpoints, dictionary state, compressed bit positions, and
+bounded index storage. It is not required for initial compressed-ZIP support.
+
+## Consequences
+
+### Positive
+
+* Compressed ZIP disc entries can eventually work without unbounded memory.
+* CHD remains compressed as CHD rather than expanding into a cached ISO.
+* Cache behavior is explicit, bounded, testable, and independent of consumers.
+* The existing live decoder and VFS contracts remain unchanged after source
+  resolution.
+* Users who do not want caching can continue using stored ZIP entries.
+
+### Negative
+
+* A compressed ISO may require cache space equal to its full uncompressed size.
+* The first access must wait for complete entry materialization.
+* Cache invalidation, concurrency, accounting, and eviction introduce
+  operational complexity.
+* A source-entry cache creates local persistent or temporary state that must be
+  documented and managed.
+
+## Alternatives considered
+
+### Repeatedly decompress from the start for every read
+
+Rejected. Random disc workloads would repeat increasing amounts of work and
+could become unusably slow.
+
+### Keep the complete decompressed entry in memory
+
+Rejected. Memory use would scale with disc size and violate bounded-resource
+requirements.
+
+### Silently extract every compressed disc entry
+
+Rejected. Disk consumption and startup latency must be explicit and governed by
+user-selected policy.
+
+### Implement Deflate seek indexing first
+
+Deferred. It is substantially more complex than disk-backed materialization and
+should be justified by measurements after a correct baseline exists.
+
+### Never support compressed disc entries
+
+Rejected as the long-term policy. Compressed ZIP collections are common enough
+to warrant a safe compatibility path, even though stored entries remain the
+preferred representation for immediate random access.
+
+## Implementation timing
+
+The cache belongs to the performance, caching, and optimization phase. The
+current live input-content milestone should retain early rejection for
+compressed random-access disc entries and provide repacking guidance.

--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -38,6 +38,21 @@ Key components:
 * `InputSource`
 * `DirectoryInputSource`
 * `ZipInputSource`
+* `InputContent`
+* `SourceOrigin`
+* `source_resolver`
+
+Each enumerated `SourceObject` carries:
+
+* a stable `SourceRef` identity;
+* a structured source origin for relative resolution;
+* an opaque live reader handle;
+* its encoded byte length;
+* a declared sequential or random-access capability.
+
+Filesystem and container addressing is resolved at this boundary. Identifiers
+and decoders must not parse encoded ZIP source strings or reopen filesystem
+paths independently.
 
 This stage answers:
 

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -76,7 +76,7 @@ and feed the same output presentation.
 
 ## Milestone 2: Live input-content boundary and ZIP replacement
 
-**Status:** Next
+**Status:** Implemented
 
 ### Milestone 2 purpose
 
@@ -109,6 +109,12 @@ Until a bounded strategy is designed and measured, a decoder that requires
 efficient random access may reject a compressed ZIP entry with an actionable
 diagnostic. It must not silently extract a complete disc, repeatedly decompress
 unbounded data, or retain a complete decompressed image in memory.
+
+The implemented boundary represents encoded input as an opaque reader handle,
+known length, declared access capability, and structured source origin.
+Filesystem files and stored ZIP entries advertise random access. Compressed ZIP
+entries remain available to ordinary sequential-friendly content paths but are
+rejected by ISO and CHD decoders, which require efficient random access.
 
 ### Milestone 2 acceptance criteria
 

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -116,6 +116,10 @@ Filesystem files and stored ZIP entries advertise random access. Compressed ZIP
 entries remain available to ordinary sequential-friendly content paths but are
 rejected by ISO and CHD decoders, which require efficient random access.
 
+[ADR-011](../architecture/adr-011-compressed-container-random-access.md)
+defines the future opt-in, bounded disk cache that will make compressed disc
+entries seekable without introducing a converted output image.
+
 ### Milestone 2 acceptance criteria
 
 * The same decoder consumes filesystem and supported ZIP-backed content.

--- a/src/core/input_content.rs
+++ b/src/core/input_content.rs
@@ -1,0 +1,57 @@
+use std::fmt;
+use std::io;
+
+use serde::Serialize;
+
+use crate::core::reader::Reader;
+use crate::core::reader_handle::ReaderHandle;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum InputAccess {
+    Sequential,
+    RandomAccess,
+}
+
+/// Opaque, clonable access to the encoded bytes of one input object.
+#[derive(Clone, PartialEq, Eq, Serialize)]
+pub struct InputContent {
+    pub size: u64,
+    pub access: InputAccess,
+    pub handle: ReaderHandle,
+}
+
+impl InputContent {
+    pub fn new(size: u64, access: InputAccess, handle: ReaderHandle) -> Self {
+        Self {
+            size,
+            access,
+            handle,
+        }
+    }
+
+    pub fn open(&self) -> io::Result<Box<dyn Reader>> {
+        self.handle.open()
+    }
+
+    pub fn open_random_access(&self) -> io::Result<Box<dyn Reader>> {
+        if self.access != InputAccess::RandomAccess {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "input does not provide efficient random access",
+            ));
+        }
+
+        self.open()
+    }
+}
+
+impl fmt::Debug for InputContent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("InputContent")
+            .field("size", &self.size)
+            .field("access", &self.access)
+            .field("handle", &self.handle)
+            .finish()
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,13 +1,16 @@
 pub mod content;
 pub mod cue;
 pub mod disc;
+pub mod input_content;
 pub mod normalizer;
 pub mod platform;
 pub mod reader;
+pub mod reader_cursor;
 pub mod reader_factory;
 pub mod reader_handle;
 pub mod reader_registry;
 pub mod source;
+pub mod source_resolver;
 pub mod track;
 pub mod vfs;
 pub mod vfs_reader;

--- a/src/core/reader_cursor.rs
+++ b/src/core/reader_cursor.rs
@@ -1,0 +1,69 @@
+use std::io::{self, Read, Seek, SeekFrom};
+
+use crate::core::reader::Reader;
+
+/// Adapts Retromount's offset-based reader contract to `Read + Seek` consumers.
+pub struct ReaderCursor {
+    reader: Box<dyn Reader>,
+    position: u64,
+}
+
+impl ReaderCursor {
+    pub fn new(reader: Box<dyn Reader>) -> Self {
+        Self {
+            reader,
+            position: 0,
+        }
+    }
+}
+
+impl Read for ReaderCursor {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let bytes_read = self.reader.read_at(self.position, buffer)?;
+        self.position = self
+            .position
+            .checked_add(bytes_read as u64)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "reader position overflow")
+            })?;
+        Ok(bytes_read)
+    }
+}
+
+impl Seek for ReaderCursor {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        let next = match position {
+            SeekFrom::Start(offset) => i128::from(offset),
+            SeekFrom::Current(offset) => i128::from(self.position) + i128::from(offset),
+            SeekFrom::End(offset) => i128::from(self.reader.len()) + i128::from(offset),
+        };
+
+        self.position = u64::try_from(next).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "cannot seek before the start of input",
+            )
+        })?;
+        Ok(self.position)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::readers::inline_reader::InlineReader;
+
+    #[test]
+    fn adapts_offset_reads_to_read_and_seek() {
+        let mut cursor = ReaderCursor::new(Box::new(InlineReader::new(b"abcdef".to_vec())));
+        let mut bytes = [0; 3];
+
+        cursor.seek(SeekFrom::Start(2)).unwrap();
+        cursor.read_exact(&mut bytes).unwrap();
+        assert_eq!(&bytes, b"cde");
+
+        cursor.seek(SeekFrom::End(-2)).unwrap();
+        cursor.read_exact(&mut bytes[..2]).unwrap();
+        assert_eq!(&bytes[..2], b"ef");
+    }
+}

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -112,11 +112,15 @@ mod tests {
     #[test]
     fn resolves_relative_paths_from_structured_origins() {
         let filesystem = SourceOrigin::Filesystem(PathBuf::from("/roms/ps1/game.cue"));
+        let expected_filesystem_source = PathBuf::from("/roms/ps1")
+            .join("game.bin")
+            .to_string_lossy()
+            .into_owned();
         assert_eq!(
             filesystem
                 .resolve_relative(Path::new("game.bin"))
                 .to_string(),
-            "/roms/ps1/game.bin"
+            expected_filesystem_source
         );
 
         let zip = SourceOrigin::ZipEntry {

--- a/src/core/source.rs
+++ b/src/core/source.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+use crate::core::input_content::InputContent;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct SourceRef(pub Arc<str>);
@@ -32,6 +35,56 @@ impl fmt::Display for SourceRef {
 pub struct SourceObject {
     pub source: SourceRef,
     pub name: String,
+    pub origin: SourceOrigin,
+    pub content: InputContent,
+}
+
+impl SourceObject {
+    pub fn resolve_relative(&self, referenced_path: &Path) -> SourceRef {
+        self.origin.resolve_relative(referenced_path)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum SourceOrigin {
+    Filesystem(PathBuf),
+    ZipEntry {
+        archive_path: PathBuf,
+        entry_name: String,
+    },
+}
+
+impl SourceOrigin {
+    fn resolve_relative(&self, referenced_path: &Path) -> SourceRef {
+        match self {
+            Self::Filesystem(path) => {
+                let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
+                SourceRef::new(
+                    base_dir
+                        .join(referenced_path)
+                        .to_string_lossy()
+                        .into_owned(),
+                )
+            }
+            Self::ZipEntry {
+                archive_path,
+                entry_name,
+            } => {
+                let base_dir = Path::new(entry_name)
+                    .parent()
+                    .unwrap_or_else(|| Path::new(""));
+                let resolved = normalize_virtual_path(base_dir.join(referenced_path));
+                SourceRef::new(format!("zip:{}#{resolved}", archive_path.to_string_lossy()))
+            }
+        }
+    }
+}
+
+fn normalize_virtual_path(path: PathBuf) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 #[cfg(test)]
@@ -54,5 +107,25 @@ mod tests {
     fn derives_file_name_from_zip_member_source() {
         let source = SourceRef::new("zip:/roms/megadrive.zip#Sonic the Hedgehog.bin");
         assert_eq!(source.file_name(), "Sonic the Hedgehog.bin");
+    }
+
+    #[test]
+    fn resolves_relative_paths_from_structured_origins() {
+        let filesystem = SourceOrigin::Filesystem(PathBuf::from("/roms/ps1/game.cue"));
+        assert_eq!(
+            filesystem
+                .resolve_relative(Path::new("game.bin"))
+                .to_string(),
+            "/roms/ps1/game.bin"
+        );
+
+        let zip = SourceOrigin::ZipEntry {
+            archive_path: PathBuf::from("/roms/ps1.zip"),
+            entry_name: "games/game.cue".to_string(),
+        };
+        assert_eq!(
+            zip.resolve_relative(Path::new("game.bin")).to_string(),
+            "zip:/roms/ps1.zip#games/game.bin"
+        );
     }
 }

--- a/src/core/source_resolver.rs
+++ b/src/core/source_resolver.rs
@@ -1,0 +1,80 @@
+use std::io;
+use std::path::Path;
+
+use crate::core::input_content::{InputAccess, InputContent};
+use crate::core::reader::Reader;
+use crate::core::reader_handle::ReaderHandle;
+use crate::core::source::SourceRef;
+use crate::readers::dir_reader::DirReader;
+use crate::readers::zip_reader::ZipReader;
+
+pub fn filesystem_content(path: &Path) -> io::Result<InputContent> {
+    let size = std::fs::metadata(path)?.len();
+    let reader_path = path.to_path_buf();
+
+    Ok(InputContent::new(
+        size,
+        InputAccess::RandomAccess,
+        ReaderHandle::new(format!("file:{}", path.to_string_lossy()), move || {
+            Ok(Box::new(DirReader::open(&reader_path)?))
+        }),
+    ))
+}
+
+pub fn zip_entry_content(
+    archive_path: &Path,
+    entry_name: &str,
+    size: u64,
+    access: InputAccess,
+) -> InputContent {
+    let reader_archive_path = archive_path.to_path_buf();
+    let reader_entry_name = entry_name.to_string();
+
+    InputContent::new(
+        size,
+        access,
+        ReaderHandle::new(
+            format!(
+                "zip:{}#{}",
+                reader_archive_path.to_string_lossy(),
+                reader_entry_name
+            ),
+            move || {
+                Ok(Box::new(ZipReader::open(
+                    &reader_archive_path,
+                    &reader_entry_name,
+                )?))
+            },
+        ),
+    )
+}
+
+/// Resolves stable downstream source identities through the same central
+/// filesystem/container boundary used during input enumeration.
+pub fn open_source_ref(source: &SourceRef) -> io::Result<Box<dyn Reader>> {
+    let source = source.0.as_ref();
+
+    if let Some(remainder) = source.strip_prefix("zip:") {
+        let (archive_path, entry_name) = remainder.split_once('#').ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid ZIP source ref: {source}"),
+            )
+        })?;
+
+        return Ok(Box::new(ZipReader::open(
+            Path::new(archive_path),
+            entry_name,
+        )?));
+    }
+
+    let path = if let Some(path) = source.strip_prefix("file:") {
+        path
+    } else if let Some(path) = source.strip_prefix("cue:") {
+        path
+    } else {
+        source
+    };
+
+    Ok(Box::new(DirReader::open(Path::new(path))?))
+}

--- a/src/core/vfs_reader.rs
+++ b/src/core/vfs_reader.rs
@@ -1,12 +1,9 @@
 use std::io;
-use std::path::Path;
 
 use crate::core::reader::Reader;
-use crate::core::source::SourceRef;
+use crate::core::source_resolver::open_source_ref;
 use crate::core::vfs::{FileBacking, VfsFile};
-use crate::readers::dir_reader::DirReader;
 use crate::readers::inline_reader::InlineReader;
-use crate::readers::zip_reader::ZipReader;
 
 pub fn open_vfs_file(file: &VfsFile) -> Result<Box<dyn Reader>, io::Error> {
     match &file.backing {
@@ -16,38 +13,11 @@ pub fn open_vfs_file(file: &VfsFile) -> Result<Box<dyn Reader>, io::Error> {
     }
 }
 
-fn open_source_ref(source: &SourceRef) -> Result<Box<dyn Reader>, io::Error> {
-    let source = source.0.as_ref();
-
-    if let Some(remainder) = source.strip_prefix("zip:") {
-        let (archive_path, entry_name) = remainder.split_once('#').ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("invalid ZIP source ref: {source}"),
-            )
-        })?;
-
-        return Ok(Box::new(ZipReader::open(
-            Path::new(archive_path),
-            entry_name,
-        )?));
-    }
-
-    let path = if let Some(path) = source.strip_prefix("file:") {
-        path
-    } else if let Some(path) = source.strip_prefix("cue:") {
-        path
-    } else {
-        source
-    };
-
-    Ok(Box::new(DirReader::open(Path::new(path))?))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::core::reader_handle::ReaderHandle;
+    use crate::core::source::SourceRef;
     use crate::core::vfs::VfsFile;
     use std::fs;
     use std::io::Write;

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -1,17 +1,13 @@
-use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::core::content::{
     BytesContent, ContentId, DecodedContent, DecodedDiscContent, DecodedRomContent, TextContent,
 };
 use crate::core::cue::parse_cue;
-use crate::core::reader::Reader;
 use crate::core::source::{SourceObject, SourceRef};
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
-use crate::readers::dir_reader::DirReader;
-use crate::readers::zip_reader::ZipReader;
 
 #[derive(Debug, Default)]
 pub struct BasicInputDecoder;
@@ -93,21 +89,7 @@ impl InputDecoder for BasicInputDecoder {
 }
 
 fn content_size_for(object: &SourceObject) -> Result<u64, io::Error> {
-    if let Some((archive_path, entry_name)) = parse_zip_source(object) {
-        let reader = ZipReader::open(Path::new(&archive_path), &entry_name)?;
-        return Ok(reader.len());
-    }
-
-    let path = Path::new(object.source.0.as_ref());
-    Ok(fs::metadata(path)?.len())
-}
-
-fn parse_zip_source(object: &SourceObject) -> Option<(String, String)> {
-    let source = object.source.0.as_ref();
-    let remainder = source.strip_prefix("zip:")?;
-    let (archive_path, entry_name) = remainder.split_once('#')?;
-
-    Some((archive_path.to_string(), entry_name.to_string()))
+    Ok(object.content.size)
 }
 
 fn consumed_sources_for_disc_image(object: &SourceObject) -> Result<Vec<SourceRef>, io::Error> {
@@ -125,18 +107,7 @@ fn consumed_sources_for_disc_image(object: &SourceObject) -> Result<Vec<SourceRe
 }
 
 fn read_text_from_source(object: &SourceObject) -> Result<String, io::Error> {
-    if let Some((archive_path, entry_name)) = parse_zip_source(object) {
-        let mut reader = ZipReader::open(Path::new(&archive_path), &entry_name)?;
-        let mut bytes = vec![0; reader.len() as usize];
-        let bytes_read = reader.read_at(0, &mut bytes)?;
-        bytes.truncate(bytes_read);
-
-        return String::from_utf8(bytes)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err));
-    }
-
-    let path = Path::new(object.source.0.as_ref());
-    let mut reader = DirReader::open(path)?;
+    let mut reader = object.content.open()?;
     let mut bytes = vec![0; reader.len() as usize];
     let bytes_read = reader.read_at(0, &mut bytes)?;
     bytes.truncate(bytes_read);
@@ -145,26 +116,7 @@ fn read_text_from_source(object: &SourceObject) -> Result<String, io::Error> {
 }
 
 fn resolve_relative_source(object: &SourceObject, referenced_path: &Path) -> SourceRef {
-    if let Some((archive_path, entry_name)) = parse_zip_source(object) {
-        let entry_path = Path::new(&entry_name);
-        let base_dir = entry_path.parent().unwrap_or_else(|| Path::new(""));
-        let resolved = normalize_virtual_path(base_dir.join(referenced_path));
-
-        return SourceRef::new(format!("zip:{archive_path}#{resolved}"));
-    }
-
-    let cue_path = Path::new(object.source.0.as_ref());
-    let base_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
-    let resolved = base_dir.join(referenced_path);
-
-    SourceRef::new(resolved.to_string_lossy().into_owned())
-}
-
-fn normalize_virtual_path(path: PathBuf) -> String {
-    path.components()
-        .map(|component| component.as_os_str().to_string_lossy())
-        .collect::<Vec<_>>()
-        .join("/")
+    object.resolve_relative(referenced_path)
 }
 
 fn looks_like_rom_name(name: &str) -> bool {
@@ -249,7 +201,16 @@ mod tests {
     use super::*;
     use std::fs;
 
-    use crate::core::source::{SourceObject, SourceRef};
+    use crate::core::source::SourceObject;
+    use crate::input::file_source::FileInputSource;
+    use crate::input::source::InputSource;
+    use crate::input::zip_source::ZipInputSource;
+
+    fn filesystem_object(path: &Path, name: &str) -> SourceObject {
+        let mut object = FileInputSource::new(path).enumerate().unwrap().remove(0);
+        object.name = name.to_string();
+        object
+    }
 
     #[test]
     fn decodes_text_file_as_text_content() {
@@ -258,10 +219,7 @@ mod tests {
         fs::write(&path, b"hello").unwrap();
 
         let decoder = BasicInputDecoder::new();
-        let object = SourceObject {
-            source: SourceRef::new(path.to_string_lossy().into_owned()),
-            name: "readme.txt".to_string(),
-        };
+        let object = filesystem_object(&path, "readme.txt");
 
         let content = decoder.decode(&object, &InputIdentity::Text).unwrap();
         assert_eq!(content.len(), 1);
@@ -275,10 +233,7 @@ mod tests {
         fs::write(&path, b"romdata").unwrap();
 
         let decoder = BasicInputDecoder::new();
-        let object = SourceObject {
-            source: SourceRef::new(path.to_string_lossy().into_owned()),
-            name: "game.sfc".to_string(),
-        };
+        let object = filesystem_object(&path, "game.sfc");
 
         let content = decoder.decode(&object, &InputIdentity::File).unwrap();
         assert_eq!(content.len(), 1);
@@ -311,10 +266,10 @@ mod tests {
         }
 
         let decoder = BasicInputDecoder::new();
-        let object = SourceObject {
-            source: SourceRef::new(format!("zip:{}#roms/sonic.bin", zip_path.to_string_lossy())),
-            name: "sonic.bin".to_string(),
-        };
+        let object = ZipInputSource::new(&zip_path)
+            .enumerate()
+            .unwrap()
+            .remove(0);
 
         let content = decoder.decode(&object, &InputIdentity::File).unwrap();
         assert_eq!(content.len(), 1);
@@ -343,10 +298,7 @@ FILE "game.bin" BINARY
         .unwrap();
 
         let decoder = BasicInputDecoder::new();
-        let object = SourceObject {
-            source: SourceRef::new(cue_path.to_string_lossy().into_owned()),
-            name: "game.cue".to_string(),
-        };
+        let object = filesystem_object(&cue_path, "game.cue");
 
         let content = decoder.decode(&object, &InputIdentity::DiscImage).unwrap();
         assert_eq!(content.len(), 1);
@@ -393,10 +345,12 @@ FILE "game.bin" BINARY
         }
 
         let decoder = BasicInputDecoder::new();
-        let object = SourceObject {
-            source: SourceRef::new(format!("zip:{}#ps1/game.cue", zip_path.to_string_lossy())),
-            name: "ps1/game.cue".to_string(),
-        };
+        let object = ZipInputSource::new(&zip_path)
+            .enumerate()
+            .unwrap()
+            .into_iter()
+            .find(|object| object.name == "ps1/game.cue")
+            .unwrap();
 
         let content = decoder.decode(&object, &InputIdentity::DiscImage).unwrap();
         assert_eq!(content.len(), 1);
@@ -453,10 +407,7 @@ FILE "game.bin" BINARY
         fs::write(&path, b"hello").unwrap();
 
         let decoder = BasicInputDecoder::new();
-        let object = SourceObject {
-            source: SourceRef::new(path.to_string_lossy().into_owned()),
-            name: "mixed/notes.txt".to_string(),
-        };
+        let object = filesystem_object(&path, "mixed/notes.txt");
 
         let content = decoder.decode(&object, &InputIdentity::Text).unwrap();
 
@@ -473,10 +424,7 @@ FILE "game.bin" BINARY
         fs::write(&path, b"hello").unwrap();
 
         let decoder = BasicInputDecoder::new();
-        let object = SourceObject {
-            source: SourceRef::new(path.to_string_lossy().into_owned()),
-            name: "roms/snes/game.nfo".to_string(),
-        };
+        let object = filesystem_object(&path, "roms/snes/game.nfo");
 
         let content = decoder.decode(&object, &InputIdentity::Text).unwrap();
 

--- a/src/input/basic_identifier.rs
+++ b/src/input/basic_identifier.rs
@@ -15,7 +15,7 @@ impl BasicInputIdentifier {
 
 impl InputIdentifier for BasicInputIdentifier {
     fn identify(&self, object: &SourceObject) -> Result<InputIdentity, io::Error> {
-        let path = Path::new(object.source.0.as_ref());
+        let path = Path::new(&object.name);
 
         if path.is_dir() {
             return Ok(InputIdentity::Directory);
@@ -43,15 +43,30 @@ impl InputIdentifier for BasicInputIdentifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::source::{SourceObject, SourceRef};
+    use crate::core::input_content::{InputAccess, InputContent};
+    use crate::core::reader_handle::ReaderHandle;
+    use crate::core::source::{SourceObject, SourceOrigin, SourceRef};
+    use crate::readers::inline_reader::InlineReader;
+
+    fn object(name: &str) -> SourceObject {
+        SourceObject {
+            source: SourceRef::new(format!("/tmp/{name}")),
+            name: name.to_string(),
+            origin: SourceOrigin::Filesystem(format!("/tmp/{name}").into()),
+            content: InputContent::new(
+                0,
+                InputAccess::RandomAccess,
+                ReaderHandle::new(format!("test:{name}"), || {
+                    Ok(Box::new(InlineReader::new(Vec::new())))
+                }),
+            ),
+        }
+    }
 
     #[test]
     fn identifies_text_file() {
         let identifier = BasicInputIdentifier::new();
-        let object = SourceObject {
-            source: SourceRef::new("/tmp/readme.txt"),
-            name: "readme.txt".to_string(),
-        };
+        let object = object("readme.txt");
 
         let identity = identifier.identify(&object).unwrap();
         assert_eq!(identity, InputIdentity::Text);
@@ -60,10 +75,7 @@ mod tests {
     #[test]
     fn identifies_disc_image() {
         let identifier = BasicInputIdentifier::new();
-        let object = SourceObject {
-            source: SourceRef::new("/tmp/game.cue"),
-            name: "game.cue".to_string(),
-        };
+        let object = object("game.cue");
 
         let identity = identifier.identify(&object).unwrap();
         assert_eq!(identity, InputIdentity::DiscImage);
@@ -72,10 +84,7 @@ mod tests {
     #[test]
     fn identifies_chd_as_distinct_disc_container() {
         let identifier = BasicInputIdentifier::new();
-        let object = SourceObject {
-            source: SourceRef::new("/tmp/game.CHD"),
-            name: "game.CHD".to_string(),
-        };
+        let object = object("game.CHD");
 
         assert_eq!(
             identifier.identify(&object).unwrap(),
@@ -86,10 +95,7 @@ mod tests {
     #[test]
     fn identifies_iso_as_a_distinct_disc_format() {
         let identifier = BasicInputIdentifier::new();
-        let object = SourceObject {
-            source: SourceRef::new("/tmp/game.ISO"),
-            name: "game.ISO".to_string(),
-        };
+        let object = object("game.ISO");
 
         assert_eq!(
             identifier.identify(&object).unwrap(),

--- a/src/input/chd_disc_decoder.rs
+++ b/src/input/chd_disc_decoder.rs
@@ -1,12 +1,11 @@
-use std::fs::File;
 use std::io;
-use std::path::{Path, PathBuf};
 
 use chd::metadata::MetadataTag;
 use chd::{Chd, Error as ChdError};
 
 use crate::core::content::{ContentId, DecodedContent, DecodedDiscContent, DiscMedia, LogicalDisc};
-use crate::core::reader_handle::ReaderHandle;
+use crate::core::input_content::InputContent;
+use crate::core::reader_cursor::ReaderCursor;
 use crate::core::source::SourceObject;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
@@ -31,9 +30,9 @@ impl ChdDiscDecoder {
         Self
     }
 
-    fn inspect(path: &Path) -> io::Result<ChdDiscInfo> {
-        let file = File::open(path)?;
-        let mut chd = Chd::open(file, None).map_err(map_chd_open_error)?;
+    fn inspect(content: &InputContent) -> io::Result<ChdDiscInfo> {
+        let cursor = ReaderCursor::new(content.open_random_access()?);
+        let mut chd = Chd::open(cursor, None).map_err(map_chd_open_error)?;
         let header = chd.header();
         let has_parent = header.has_parent();
         let unit_bytes = header.unit_bytes();
@@ -50,7 +49,7 @@ impl ChdDiscDecoder {
         })
     }
 
-    fn logical_disc(path: PathBuf, info: ChdDiscInfo) -> io::Result<LogicalDisc> {
+    fn logical_disc(content: &InputContent, info: ChdDiscInfo) -> io::Result<LogicalDisc> {
         if info.has_parent {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
@@ -79,15 +78,15 @@ impl ChdDiscDecoder {
             ));
         }
 
-        let reader_path = path.clone();
-        let handle_id = format!("chd:{}", path.to_string_lossy());
+        let handle = content.handle.clone();
         Ok(LogicalDisc {
             media: DiscMedia::Dvd,
             sector_size: DVD_SECTOR_SIZE,
             sector_count: info.logical_bytes / u64::from(DVD_SECTOR_SIZE),
-            content: ReaderHandle::new(handle_id, move || {
-                Ok(Box::new(ChdReader::open(&reader_path)?))
-            }),
+            content: crate::core::reader_handle::ReaderHandle::new(
+                format!("chd:{}", content.handle.id()),
+                move || Ok(Box::new(ChdReader::open(&handle)?)),
+            ),
         })
     }
 }
@@ -123,9 +122,8 @@ impl InputDecoder for ChdDiscDecoder {
             return Ok(Vec::new());
         }
 
-        let path = PathBuf::from(object.source.0.as_ref());
-        let logical_disc = Self::logical_disc(path.clone(), Self::inspect(&path)?)?;
-        let title = path
+        let logical_disc = Self::logical_disc(&object.content, Self::inspect(&object.content)?)?;
+        let title = std::path::Path::new(&object.name)
             .file_stem()
             .and_then(|stem| stem.to_str())
             .unwrap_or(&object.name)
@@ -145,6 +143,17 @@ impl InputDecoder for ChdDiscDecoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::input_content::{InputAccess, InputContent};
+    use crate::core::reader_handle::ReaderHandle;
+    use crate::readers::inline_reader::InlineReader;
+
+    fn test_content() -> InputContent {
+        InputContent::new(
+            1,
+            InputAccess::RandomAccess,
+            ReaderHandle::new("test:chd", || Ok(Box::new(InlineReader::new(vec![0])))),
+        )
+    }
 
     fn valid_info() -> ChdDiscInfo {
         ChdDiscInfo {
@@ -157,14 +166,13 @@ mod tests {
 
     #[test]
     fn builds_a_live_logical_dvd_from_valid_geometry() {
-        let disc =
-            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), valid_info()).unwrap();
+        let disc = ChdDiscDecoder::logical_disc(&test_content(), valid_info()).unwrap();
 
         assert_eq!(disc.media, DiscMedia::Dvd);
         assert_eq!(disc.sector_size, DVD_SECTOR_SIZE);
         assert_eq!(disc.sector_count, 3);
         assert_eq!(disc.byte_len(), Some(6144));
-        assert_eq!(disc.content.id(), "chd:/tmp/game.chd");
+        assert_eq!(disc.content.id(), "chd:test:chd");
     }
 
     #[test]
@@ -179,13 +187,13 @@ mod tests {
         };
 
         assert_eq!(
-            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), parent)
+            ChdDiscDecoder::logical_disc(&test_content(), parent)
                 .unwrap_err()
                 .kind(),
             io::ErrorKind::Unsupported
         );
         assert_eq!(
-            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), non_dvd)
+            ChdDiscDecoder::logical_disc(&test_content(), non_dvd)
                 .unwrap_err()
                 .kind(),
             io::ErrorKind::Unsupported
@@ -204,13 +212,13 @@ mod tests {
         };
 
         assert_eq!(
-            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), wrong_unit)
+            ChdDiscDecoder::logical_disc(&test_content(), wrong_unit)
                 .unwrap_err()
                 .kind(),
             io::ErrorKind::InvalidData
         );
         assert_eq!(
-            ChdDiscDecoder::logical_disc(PathBuf::from("/tmp/game.chd"), partial_sector)
+            ChdDiscDecoder::logical_disc(&test_content(), partial_sector)
                 .unwrap_err()
                 .kind(),
             io::ErrorKind::InvalidData

--- a/src/input/decoder_registry.rs
+++ b/src/input/decoder_registry.rs
@@ -50,17 +50,36 @@ impl InputDecoder for DecoderRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::input_content::{InputAccess, InputContent};
+    use crate::core::reader_handle::ReaderHandle;
+    use crate::core::source::{SourceOrigin, SourceRef};
     use crate::input::basic_decoder::BasicInputDecoder;
+    use crate::readers::dir_reader::DirReader;
+
+    fn object_for(path: &std::path::Path, name: &str) -> SourceObject {
+        let reader_path = path.to_path_buf();
+        SourceObject {
+            source: SourceRef::new(path.to_string_lossy().into_owned()),
+            name: name.to_string(),
+            origin: SourceOrigin::Filesystem(path.to_path_buf()),
+            content: InputContent::new(
+                std::fs::metadata(path)
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0),
+                InputAccess::RandomAccess,
+                ReaderHandle::new(format!("test:{}", path.display()), move || {
+                    Ok(Box::new(DirReader::open(&reader_path)?))
+                }),
+            ),
+        }
+    }
 
     #[test]
     fn delegates_to_a_decoder_that_supports_the_identity() {
         let mut registry = DecoderRegistry::new();
         registry.register(BasicInputDecoder::new());
         let file = tempfile::NamedTempFile::new().unwrap();
-        let object = SourceObject {
-            source: crate::core::source::SourceRef::new(file.path().to_string_lossy().into_owned()),
-            name: "readme.txt".to_string(),
-        };
+        let object = object_for(file.path(), "readme.txt");
 
         let decoded = registry.decode(&object, &InputIdentity::Text).unwrap();
 
@@ -70,10 +89,8 @@ mod tests {
     #[test]
     fn rejects_an_identity_without_a_registered_decoder() {
         let registry = DecoderRegistry::new();
-        let object = SourceObject {
-            source: crate::core::source::SourceRef::new("/tmp/game.chd"),
-            name: "game.chd".to_string(),
-        };
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let object = object_for(file.path(), "game.chd");
 
         let error = registry
             .decode(&object, &InputIdentity::ChdDisc)

--- a/src/input/directory_source.rs
+++ b/src/input/directory_source.rs
@@ -2,7 +2,8 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use crate::core::source::{SourceObject, SourceRef};
+use crate::core::source::{SourceObject, SourceOrigin, SourceRef};
+use crate::core::source_resolver::filesystem_content;
 use crate::input::source::{InputSource, InputSourceKind};
 
 #[derive(Debug, Clone)]
@@ -44,7 +45,12 @@ impl DirectoryInputSource {
 
                 let source = SourceRef::new(path.to_string_lossy().into_owned());
 
-                objects.push(SourceObject { source, name });
+                objects.push(SourceObject {
+                    source,
+                    name,
+                    origin: SourceOrigin::Filesystem(path.clone()),
+                    content: filesystem_content(&path)?,
+                });
             }
         }
 

--- a/src/input/file_source.rs
+++ b/src/input/file_source.rs
@@ -1,7 +1,8 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
-use crate::core::source::{SourceObject, SourceRef};
+use crate::core::source::{SourceObject, SourceOrigin, SourceRef};
+use crate::core::source_resolver::filesystem_content;
 use crate::input::source::{InputSource, InputSourceKind};
 
 #[derive(Debug, Clone)]
@@ -35,6 +36,8 @@ impl InputSource for FileInputSource {
         Ok(vec![SourceObject {
             source: SourceRef::new(self.path.to_string_lossy().into_owned()),
             name,
+            origin: SourceOrigin::Filesystem(self.path.clone()),
+            content: filesystem_content(&self.path)?,
         }])
     }
 }
@@ -51,11 +54,14 @@ mod tests {
 
     #[test]
     fn enumerates_single_file_object() {
-        let source = FileInputSource::new("/tmp/game.cue");
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("game.cue");
+        std::fs::write(&path, b"FILE \"game.bin\" BINARY").unwrap();
+        let source = FileInputSource::new(&path);
         let objects = source.enumerate().unwrap();
 
         assert_eq!(objects.len(), 1);
         assert_eq!(objects[0].name, "game.cue");
-        assert_eq!(objects[0].source.to_string(), "/tmp/game.cue");
+        assert_eq!(objects[0].source.to_string(), path.to_string_lossy());
     }
 }

--- a/src/input/iso_disc_decoder.rs
+++ b/src/input/iso_disc_decoder.rs
@@ -1,17 +1,15 @@
-use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::core::content::{ContentId, DecodedContent, DecodedDiscContent, DiscMedia, LogicalDisc};
-use crate::core::reader_handle::ReaderHandle;
+use crate::core::input_content::InputContent;
 use crate::core::source::SourceObject;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
-use crate::readers::dir_reader::DirReader;
 
 const ISO_SECTOR_SIZE: u32 = 2048;
 
-/// Decodes a filesystem ISO using an explicit media hint supplied by the
+/// Decodes a random-access ISO using an explicit media hint supplied by the
 /// application composition.
 ///
 /// ISO contains a logical filesystem image, but does not reliably identify the
@@ -27,8 +25,9 @@ impl IsoDiscDecoder {
         Self { media }
     }
 
-    fn logical_disc(path: PathBuf, media: DiscMedia) -> io::Result<LogicalDisc> {
-        let logical_bytes = fs::metadata(&path)?.len();
+    fn logical_disc(content: &InputContent, media: DiscMedia) -> io::Result<LogicalDisc> {
+        content.open_random_access()?;
+        let logical_bytes = content.size;
 
         if logical_bytes == 0 {
             return Err(io::Error::new(
@@ -43,16 +42,11 @@ impl IsoDiscDecoder {
             ));
         }
 
-        let reader_path = path.clone();
-        let handle_id = format!("iso:{}", path.to_string_lossy());
-
         Ok(LogicalDisc {
             media,
             sector_size: ISO_SECTOR_SIZE,
             sector_count: logical_bytes / u64::from(ISO_SECTOR_SIZE),
-            content: ReaderHandle::new(handle_id, move || {
-                Ok(Box::new(DirReader::open(&reader_path)?))
-            }),
+            content: content.handle.clone(),
         })
     }
 }
@@ -71,8 +65,7 @@ impl InputDecoder for IsoDiscDecoder {
             return Ok(Vec::new());
         }
 
-        let path = PathBuf::from(object.source.0.as_ref());
-        let logical_disc = Self::logical_disc(path.clone(), self.media)?;
+        let logical_disc = Self::logical_disc(&object.content, self.media)?;
         let title = Path::new(&object.name)
             .file_stem()
             .and_then(|stem| stem.to_str())
@@ -93,20 +86,30 @@ impl InputDecoder for IsoDiscDecoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::source::SourceRef;
+    use std::fs;
+
+    use crate::input::file_source::FileInputSource;
+    use crate::input::source::InputSource;
+
+    fn object_for(path: &Path, name: &str) -> SourceObject {
+        let mut object = FileInputSource::new(path).enumerate().unwrap().remove(0);
+        object.name = name.to_string();
+        object
+    }
 
     #[test]
     fn builds_a_live_logical_disc_from_valid_iso_geometry() {
         let file = tempfile::NamedTempFile::new().unwrap();
         fs::write(file.path(), vec![0; ISO_SECTOR_SIZE as usize * 3]).unwrap();
 
-        let disc = IsoDiscDecoder::logical_disc(file.path().to_path_buf(), DiscMedia::Dvd).unwrap();
+        let object = object_for(file.path(), "Game.iso");
+        let disc = IsoDiscDecoder::logical_disc(&object.content, DiscMedia::Dvd).unwrap();
 
         assert_eq!(disc.media, DiscMedia::Dvd);
         assert_eq!(disc.sector_size, ISO_SECTOR_SIZE);
         assert_eq!(disc.sector_count, 3);
         assert_eq!(disc.byte_len(), Some(6144));
-        assert!(disc.content.id().starts_with("iso:"));
+        assert!(disc.content.id().starts_with("file:"));
     }
 
     #[test]
@@ -116,15 +119,21 @@ mod tests {
         fs::write(partial.path(), vec![0; ISO_SECTOR_SIZE as usize + 1]).unwrap();
 
         assert_eq!(
-            IsoDiscDecoder::logical_disc(empty.path().to_path_buf(), DiscMedia::Dvd)
-                .unwrap_err()
-                .kind(),
+            IsoDiscDecoder::logical_disc(
+                &object_for(empty.path(), "Empty.iso").content,
+                DiscMedia::Dvd
+            )
+            .unwrap_err()
+            .kind(),
             io::ErrorKind::InvalidData
         );
         assert_eq!(
-            IsoDiscDecoder::logical_disc(partial.path().to_path_buf(), DiscMedia::Dvd)
-                .unwrap_err()
-                .kind(),
+            IsoDiscDecoder::logical_disc(
+                &object_for(partial.path(), "Partial.iso").content,
+                DiscMedia::Dvd,
+            )
+            .unwrap_err()
+            .kind(),
             io::ErrorKind::InvalidData
         );
     }
@@ -133,10 +142,7 @@ mod tests {
     fn decodes_with_the_explicit_media_hint() {
         let file = tempfile::NamedTempFile::new().unwrap();
         fs::write(file.path(), vec![0; ISO_SECTOR_SIZE as usize]).unwrap();
-        let object = SourceObject {
-            source: SourceRef::new(file.path().to_string_lossy().into_owned()),
-            name: "Game.iso".to_string(),
-        };
+        let object = object_for(file.path(), "Game.iso");
 
         let decoded = IsoDiscDecoder::new(DiscMedia::Dvd)
             .decode(&object, &InputIdentity::IsoDisc)

--- a/src/input/zip_source.rs
+++ b/src/input/zip_source.rs
@@ -2,7 +2,9 @@ use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use crate::core::source::{SourceObject, SourceRef};
+use crate::core::input_content::InputAccess;
+use crate::core::source::{SourceObject, SourceOrigin, SourceRef};
+use crate::core::source_resolver::zip_entry_content;
 use crate::input::source::{InputSource, InputSourceKind};
 
 #[derive(Debug, Clone)]
@@ -44,21 +46,29 @@ impl InputSource for ZipInputSource {
             }
 
             let entry_name = entry.name().to_string();
-            let display_name = Path::new(&entry_name)
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or(&entry_name)
-                .to_string();
+            let display_name = entry_name.clone();
+            let size = entry.size();
+            let access = if entry.compression() == zip::CompressionMethod::Stored {
+                InputAccess::RandomAccess
+            } else {
+                InputAccess::Sequential
+            };
 
             let source = SourceRef::new(format!(
                 "zip:{}#{}",
                 self.archive_path.to_string_lossy(),
                 entry_name
             ));
+            let content = zip_entry_content(&self.archive_path, &entry_name, size, access);
 
             objects.push(SourceObject {
                 source,
                 name: display_name,
+                origin: SourceOrigin::ZipEntry {
+                    archive_path: self.archive_path.clone(),
+                    entry_name,
+                },
+                content,
             });
         }
 
@@ -70,6 +80,7 @@ impl InputSource for ZipInputSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::input_content::InputAccess;
     use std::fs::File;
     use std::io::Write;
 
@@ -110,9 +121,12 @@ mod tests {
         let objects = source.enumerate().unwrap();
 
         let names: Vec<&str> = objects.iter().map(|o| o.name.as_str()).collect();
-        assert_eq!(names, vec!["readme.txt", "sonic.bin"]);
+        assert_eq!(names, vec!["docs/readme.txt", "roms/sonic.bin"]);
 
         assert!(objects[0].source.0.starts_with("zip:"));
         assert!(objects[1].source.0.starts_with("zip:"));
+        assert!(objects
+            .iter()
+            .all(|object| object.content.access == InputAccess::Sequential));
     }
 }

--- a/src/readers/chd_reader.rs
+++ b/src/readers/chd_reader.rs
@@ -1,11 +1,11 @@
 use std::collections::VecDeque;
-use std::fs::File;
 use std::io;
-use std::path::Path;
 
 use chd::Chd;
 
 use crate::core::reader::Reader;
+use crate::core::reader_cursor::ReaderCursor;
+use crate::core::reader_handle::ReaderHandle;
 
 const DEFAULT_CACHE_HUNKS: usize = 4;
 
@@ -16,7 +16,7 @@ trait HunkSource: Send + Sync {
 }
 
 struct ChdHunkSource {
-    chd: Chd<File>,
+    chd: Chd<ReaderCursor>,
     compressed: Vec<u8>,
 }
 
@@ -48,9 +48,9 @@ pub struct ChdReader {
 }
 
 impl ChdReader {
-    pub fn open(path: &Path) -> io::Result<Self> {
-        let file = File::open(path)?;
-        let chd = Chd::open(file, None)
+    pub fn open(handle: &ReaderHandle) -> io::Result<Self> {
+        let cursor = ReaderCursor::new(handle.open()?);
+        let chd = Chd::open(cursor, None)
             .map_err(|error| io::Error::other(format!("failed to open CHD: {error}")))?;
 
         Self::from_source(

--- a/tests/zip_live_content_integration.rs
+++ b/tests/zip_live_content_integration.rs
@@ -1,0 +1,89 @@
+use std::fs::File;
+use std::io::Write;
+
+use retromount::core::content::Platform;
+use retromount::core::normalizer::NormalizationOptions;
+use retromount::core::vfs_resolver::open_file;
+use retromount::engine::components::pipeline_components;
+use retromount::engine::pipeline::{run_pipeline_with_presentation_options, PipelineOptions};
+use retromount::input::zip_source::ZipInputSource;
+use zip::write::SimpleFileOptions;
+use zip::CompressionMethod;
+
+const SECTOR_SIZE: usize = 2048;
+const LOGICAL_SIZE: usize = SECTOR_SIZE * 3;
+
+#[test]
+fn presents_a_stored_zip_iso_through_the_live_opl_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let zip_path = temp_dir.path().join("library.zip");
+    write_iso_zip(&zip_path, CompressionMethod::Stored);
+
+    let trace = run_opl(&zip_path).unwrap();
+    let file = trace
+        .output_vfs
+        .find_file("DVD/Test Game.iso")
+        .expect("stored ZIP ISO should be present");
+    assert_eq!(file.size, LOGICAL_SIZE as u64);
+
+    let mut reader = open_file(&trace.output_vfs, "DVD/Test Game.iso").unwrap();
+    let mut bytes = [0; 31];
+    let offset = SECTOR_SIZE - 11;
+    assert_eq!(
+        reader.read_at(offset as u64, &mut bytes).unwrap(),
+        bytes.len()
+    );
+    assert_eq!(
+        bytes,
+        std::array::from_fn(|index| fixture_byte(offset + index))
+    );
+}
+
+#[test]
+fn rejects_a_compressed_zip_iso_that_cannot_supply_efficient_random_access() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let zip_path = temp_dir.path().join("library.zip");
+    write_iso_zip(&zip_path, CompressionMethod::Deflated);
+
+    let error = run_opl(&zip_path).unwrap_err();
+
+    assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+    assert!(error
+        .to_string()
+        .contains("does not provide efficient random access"));
+}
+
+fn run_opl(
+    zip_path: &std::path::Path,
+) -> std::io::Result<retromount::engine::pipeline::PipelineTrace> {
+    let components = pipeline_components("opl").unwrap();
+    let source = ZipInputSource::new(zip_path);
+
+    run_pipeline_with_presentation_options(
+        &source,
+        components.identifier.as_ref(),
+        components.decoder.as_ref(),
+        &components.presentation,
+        &components.policy,
+        &PipelineOptions {
+            normalization: NormalizationOptions {
+                platform_hint: Some(Platform::Ps2),
+            },
+            plugin_registry: None,
+        },
+    )
+}
+
+fn write_iso_zip(path: &std::path::Path, compression: CompressionMethod) {
+    let file = File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(compression);
+    zip.start_file("ps2/Test Game.iso", options).unwrap();
+    zip.write_all(&(0..LOGICAL_SIZE).map(fixture_byte).collect::<Vec<_>>())
+        .unwrap();
+    zip.finish().unwrap();
+}
+
+fn fixture_byte(offset: usize) -> u8 {
+    ((offset * 31 + 5) % 251) as u8
+}


### PR DESCRIPTION
## Summary

- add an opaque live `InputContent` boundary with declared access capabilities and independent reader cursors
- centralize filesystem and ZIP member resolution behind structured source origins
- migrate ISO and CHD decoding to live reader handles without whole-disc intermediates
- support stored ZIP ISO entries through the existing live OPL DVD path
- reject compressed ZIP disc entries early when efficient random access is unavailable
- preserve compressed ZIP support for sequential-friendly ROM and sidecar content
- document the optical-media boundary and the future opt-in disk-backed source-entry cache
- make the structured filesystem path test portable across Unix and Windows

## Why

Decoders previously depended too heavily on filesystem paths or container-specific parsing. The new boundary lets the same decoder consume supported filesystem and container-backed content while keeping source resolution, format decoding, and presentation concerns separate.

Compressed ZIP disc members remain unsupported for random-access decoding in this slice because Deflate is stream-oriented. ADR-011 defines a future bounded, explicit disk-backed cache that materializes the original ISO or CHD member without creating a converted output image.

## Impact

Filesystem ISO and CHD behavior remains live and bounded. Stored ZIP ISOs can now feed the same canonical DVD and OPL presentation path. Unsupported compressed disc members fail before mount preparation with repacking guidance.

## Validation

- `cargo test --locked --all-targets --all-features --verbose`
- `cargo fmt --all -- --check`
- `git diff --check`
- Markdown lint passed for the documentation changes
- real-world validation remains outside SMB and real OPL loading scope, as documented