### PR TITLE
Define the PS1 presentation roadmap

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -71,6 +71,10 @@ This structure ensures that:
 * `adr-012-ps2-cd-opl-contract.md` — defines cooked ISO and CUE/BIN PlayStation
   2 CD input, live raw-sector projection, track and audio preservation, the OPL
   `CD/` compatibility boundary, and declarative sibling CD/DVD directories
+* `adr-013-ps1-duckstation-presentation-contract.md` — defines the first
+  PlayStation 1 presentation for DuckStation as generated CUE plus live
+  per-track BIN artifacts, including the required CD timing-model refinement
+  and deliberately deferred CHD, SBI, and multi-disc increments
 
 ---
 

--- a/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
+++ b/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
@@ -1,0 +1,338 @@
+# ADR-013: Present PlayStation CDs to DuckStation Without Flattening Tracks
+
+## Status
+
+Accepted
+
+## Context
+
+The PlayStation 2 CD milestone introduced a live, track-aware `CdDisc` model
+and CUE/BIN decoding. Its OPL presentation deliberately accepts only discs
+that can be exposed as one logical 2048-byte ISO. That is not a suitable
+default for PlayStation 1 media.
+
+PlayStation discs commonly use raw 2352-byte sectors, mixed data and CD-DA
+tracks, pregaps, and multiple source files. A PS1 presentation must retain
+those semantics rather than reuse OPL's lossy compatibility boundary.
+
+The first presentation needs a named consumer. DuckStation is selected because
+its documented inputs include BIN/CUE and MAME CHD, it supports multi-disc
+game-list grouping, and it can use adjacent SBI subchannel sidecars for
+affected PAL titles. This makes it a useful concrete contract without making
+its full input catalog the scope of the first implementation.
+
+Primary references:
+
+* [DuckStation README and supported disc formats][duckstation-readme]
+* [DuckStation LibCrypt and SBI guidance][duckstation-sbi]
+
+The current presentation model assumes that one selected item requests one
+output artifact. A faithful CUE/BIN disc instead produces a related artifact
+set: one generated CUE file and one or more reader-backed BIN files. Their
+names and CUE references must be planned together.
+
+The current `CdTrack` model also combines declared `PREGAP` and file-backed
+`INDEX 00` duration into one count, while its data range begins at `INDEX 01`.
+That is enough to reject lossy OPL projections, but not enough to reproduce a
+faithful CUE/BIN layout. PS1 output requires those two pregap forms and their
+source extents to remain distinguishable.
+
+## Decision
+
+Add a built-in `duckstation` presentation whose first vertical slice exposes
+single-disc PS1 CUE/BIN content as a lossless CUE/BIN artifact set.
+
+The first implementation will consume the existing CUE/BIN decoder. It will
+not add CHD or ISO input in the same slice.
+
+### Consumer filesystem contract
+
+For each supported single-disc PS1 game, the presentation will request:
+
+```text
+PS1/<game>/<disc>.cue
+PS1/<game>/<disc> (Track 01).bin
+PS1/<game>/<disc> (Track 02).bin
+...
+```
+
+`<game>` uses the policy-derived game name. `<disc>` uses the part name so the
+layout can later accommodate multiple discs without renaming the first-slice
+artifacts. Track numbers are zero-padded canonical track numbers.
+
+The CUE file and every BIN it references must be siblings. Generated CUE paths
+must contain filenames only, use quoted names, and must not contain host paths,
+container addresses, absolute paths, or parent traversal.
+
+The dedicated `PS1/` root is presentation data, not decoder behavior.
+DuckStation can scan the root recursively; Retromount does not write into a
+DuckStation configuration directory.
+
+### Selection contract
+
+The presentation matches only normalized `Platform::Ps1` disc games backed by
+a `CdDisc`.
+
+The first slice accepts exactly one disc per normalized game. PS2 and unknown
+CDs do not match. A PS1 `LogicalDisc` alone is insufficient because it cannot
+represent audio tracks or the encoded raw-sector layout.
+
+Platform identity remains explicit composition or normalization context. CUE,
+BIN, ISO, and CHD extensions do not establish PS1 identity.
+
+### CUE/BIN artifact-set contract
+
+One selected disc produces one atomic artifact set:
+
+* a small generated UTF-8 CUE document;
+* one reader-backed BIN artifact per canonical track;
+* internal references from the CUE document to those planned BIN names.
+
+The plan must resolve names and conflicts for the complete set before adding
+any member to the VFS. A partial set must never be exposed.
+
+This requires an explicit multi-file or artifact-set output contract.
+Presentation YAML declares the desired CUE/BIN representation; it does not
+list a variable number of tracks or embed CUE generation logic. The encoder
+expands the selected `CdDisc` into the related files.
+
+Capability resolution remains representation-based. The presentation requests
+a lossless track-aware CUE/BIN disc artifact set, not a named Rust encoder.
+
+### Track BIN contract
+
+Each track BIN exposes the encoded sectors for that track without converting
+data sectors to 2048-byte logical sectors and without decoding audio.
+
+The output preserves:
+
+* track number and order;
+* data versus audio kind;
+* `MODE1/2048`, `MODE1/2352`, `MODE2/2352`, or `AUDIO`;
+* every sector byte represented by the canonical track extent;
+* file-backed `INDEX 00` content;
+* declared synthetic pregaps;
+* `INDEX 01` and any other supported index positions.
+
+Each BIN is a bounded, random-access view over its source content. Tracks that
+shared one input BIN may be presented as separate live ranges; no whole-disc
+or whole-track copy is required.
+
+Splitting tracks into separate BIN files gives every generated CUE file a
+uniform layout and avoids reconstructing the original source-file grouping.
+This is lossless because CUE file grouping is a container arrangement, while
+track sectors and timing are the media semantics that must be preserved.
+
+### CUE generation contract
+
+The generated CUE contains one `FILE ... BINARY` section per output track,
+followed by its `TRACK` and timing directives.
+
+For a track with file-backed pregap content, the BIN begins at that track's
+`INDEX 00` extent and the CUE expresses:
+
+```text
+INDEX 00 00:00:00
+INDEX 01 <file-backed-pregap-duration>
+```
+
+For a track with only a declared synthetic pregap, the BIN begins at
+`INDEX 01`, the CUE emits `PREGAP`, and `INDEX 01` is `00:00:00`.
+
+When both forms exist, both are expressed. Index times are recalculated
+relative to the per-track output BIN. Minute/second/frame values use 75 frames
+per second and must be checked for overflow.
+
+The generator must reject a layout if the canonical model cannot distinguish
+or reproduce its timing. It must not invent zero-filled sectors to conceal
+missing file-backed content.
+
+### Canonical model refinement
+
+Before implementing the encoder, evolve `CdTrack` so it explicitly retains:
+
+* the encoded source extent beginning at the earliest preserved index;
+* the file-backed pregap sector count;
+* the declared synthetic pregap sector count;
+* index positions in one documented coordinate system;
+* the playable `INDEX 01` position within the preserved extent.
+
+The model must not store CUE output filenames or DuckStation-specific fields.
+These refinements describe CD semantics and are reusable by later Sega CD,
+PC Engine CD, and other track-aware presentations.
+
+Existing OPL logical projection continues to start at the track's playable
+data and excludes pregap content.
+
+### Serialized presentation change
+
+The presentation schema needs a representation for one rule producing a
+related file set. The intended shape is:
+
+```yaml
+version: 1
+name: duckstation
+
+layout:
+  type: literal_root
+  path: PS1
+
+files:
+  - select:
+      type: single_disc_games_by_platform
+      platform: ps1
+    naming:
+      type: part_name
+    artifact:
+      content_type: disc
+      format: cue_bin
+      required_features:
+        - lossless
+        - random_access
+        - multi_file
+```
+
+The exact field spelling may be adjusted during implementation, but these
+semantics are fixed:
+
+* platform-specific selection does not require a CD/DVD guess;
+* `cue_bin` means one coherent multi-file disc representation;
+* track expansion belongs to encoding/materialization;
+* the presentation remains serializable data.
+
+`multi_file` describes one artifact producing related output files. It is
+distinct from the existing `multi_source` capability, which describes an
+encoder consuming more than one input source.
+
+### Tracked follow-up capabilities
+
+The capabilities deferred from the first slice are required follow-up
+milestones, not an open-ended backlog:
+
+| ID | Capability | Required outcome |
+| --- | --- | --- |
+| PS1-2 | CHD input | Decode complete CHD track semantics into `CdDisc` and present them through DuckStation |
+| PS1-3 | SBI sidecars | Preserve source-backed SBI files and couple their basename to the presented disc |
+| PS1-4 | Multi-disc M3U | Present all discs and generate a relative M3U playlist with stable names |
+| PS1-5 | Cooked ISO input | Accept only the explicitly safe data-only subset without implying missing track or subchannel data |
+| PS1-6 | CHD output | Provide native lossless CHD only after its bounded materialization and random-access behavior is specified and measured |
+| PS1-7 | Extend OPL with POPS | Add PS1 VCD content below `POPS/` to the existing OPL library presentation |
+
+CHD input must not be represented only as a 2048-byte `LogicalDisc`; doing so
+would discard the track, audio, pregap, and subchannel semantics needed by the
+PS1 consumer.
+
+Each item has acceptance criteria in the optical-media capability roadmap.
+Closing the first DuckStation slice does not close the PS1 milestone group.
+
+### OPL POPS follow-up contract
+
+POPS support will extend the existing `opl` presentation. A user mounting an
+OPL library for a PS2 should receive one coherent consumer view:
+
+```text
+DVD/   # PlayStation 2 DVD games
+CD/    # PlayStation 2 CD games
+POPS/  # PlayStation 1 games for the selected POPS integration
+```
+
+POPS is not a standalone presentation and is not an alias for the DuckStation
+presentation. It is a new artifact rule within `opl`: PS1 discs require a
+converted VCD representation and consumer-specific `POPS/` layout, while PS2
+discs retain the existing ISO rules.
+
+The VCD encoder remains an independent representation capability. The
+presentation requests that capability for matching PS1 content; neither the CD
+decoder nor the encoder owns the complete OPL directory layout.
+
+The implementation must begin with a compatibility spike that selects and
+records the exact supported combination of OPL, POPStarter, or POPSLoader and
+storage backend. The spike must confirm:
+
+* the VCD container header, sector, audio, and multi-track requirements;
+* whether conversion can be live and random-access or requires bounded
+  materialization;
+* required and optional files below `POPS/`;
+* game, VCD, launcher, configuration, and artwork naming coupling;
+* single-disc and multi-disc behavior;
+* differences between USB, MX4SIO, MMCE, HDD, and SMB where relevant;
+* which launcher or Sony runtime assets must be supplied by the user and must
+  never be distributed or synthesized by Retromount.
+
+Until that spike is accepted, Retromount must not label a generic VCD or
+`POPS/` layout as OPL-compatible or add an unverified POPS rule to the built-in
+`opl` document.
+
+### ZIP behavior
+
+Filesystem and stored-ZIP CUE/BIN inputs follow the same presentation path.
+Compressed ZIP track members remain rejected until the bounded random-access
+cache from [ADR-011](adr-011-compressed-container-random-access.md) is
+implemented.
+
+The output remains live and does not create an extracted or converted disc.
+
+## Non-goals
+
+The first implementation does not add:
+
+* CHD, ISO, ECM, MDS/MDF, CCD, PBP, or physical-disc input;
+* CHD encoding;
+* M3U generation or multi-disc presentation;
+* SBI parsing, synthesis, or passthrough;
+* subchannel synthesis or repair;
+* audio decoding, resampling, or WAV output;
+* merging tracks into one BIN;
+* restoration of source CUE comments or cosmetic formatting;
+* automatic PS1 identification from extension or disc filesystem;
+* DuckStation configuration or game-list mutation;
+* compressed ZIP random-access caching.
+
+These are deferred capabilities, not reasons to weaken the canonical CD model
+or the first CUE/BIN contract.
+
+## Consequences
+
+### Positive
+
+* The first PS1 presentation has a testable consumer contract.
+* Mixed-mode and audio discs exercise the track-aware architecture directly.
+* Output is lossless and reader-backed without a converted whole-disc image.
+* Generated CUE references cannot leak source or container paths.
+* Artifact-set planning is reusable for sidecars and other multi-file formats.
+* The CD model gains the timing precision required by future platforms.
+
+### Negative
+
+* Presentation planning and materialization must support one-to-many output.
+* The current combined pregap model requires refinement.
+* Separate per-track BIN files differ from some source CUE file grouping.
+* The first slice does not immediately make existing CHD or ISO collections
+  available to the PS1 presentation.
+* Extending OPL with POPS needs its own researched conversion and filesystem
+  contract.
+
+## Implementation sequence
+
+1. Refine `CdTrack` pregap, index, and encoded-extent semantics, preserving OPL
+   behavior and adding mixed-mode regression coverage.
+2. Add serialized platform-only single-disc selection.
+3. Add the `cue_bin` format and multi-file artifact-set planning contract.
+4. Implement bounded per-track encoded readers and deterministic set naming.
+5. Generate CUE documents from canonical track timing.
+6. Add `presentations/duckstation.yaml` to the built-in catalog.
+7. Add integration fixtures for:
+   * single-track raw data;
+   * mixed data and audio tracks;
+   * file-backed `INDEX 00`;
+   * declared `PREGAP`;
+   * single-file and multi-file source CUE layouts;
+   * filesystem and stored-ZIP parity;
+   * PS2 and unknown-platform exclusion;
+   * atomic naming-conflict handling;
+   * arbitrary and unaligned BIN reads.
+8. Validate the mounted result with DuckStation on a representative,
+   user-owned PS1 image and document the result.
+
+[duckstation-readme]: https://github.com/stenzek/duckstation/blob/master/README.md
+[duckstation-sbi]: https://github.com/stenzek/duckstation/blob/master/README.md#libcrypt-protection-and-sbi-files

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -169,6 +169,23 @@ reliably identify its original carrier. Track-aware CUE/BIN inputs provide CD
 media semantics directly, but mixed-mode, audio, and other layouts without a
 safe 2048-byte logical projection are rejected by the OPL composition.
 
+The next built-in presentation is the accepted `duckstation` contract defined
+by
+[ADR-013](architecture/adr-013-ps1-duckstation-presentation-contract.md).
+Unlike OPL, it will consume the complete track-aware PS1 CD and produce one
+coherent artifact set containing a generated CUE and live per-track BIN files.
+That implementation requires a schema extension for multi-file artifacts; it
+is documented here as planned behavior and is not yet available in the
+built-in catalog.
+
+The PS1 roadmap also commits to extending the existing `opl` presentation with
+POPS support. The resulting PS2 library view will retain PS2 games below
+`DVD/` and `CD/` and add PS1 VCD content below `POPS/`; there will not be a
+standalone POPS presentation. VCD conversion is still a separate encoder
+capability and does not reuse DuckStation's CUE/BIN artifact contract. The
+exact OPL, POPStarter, or POPSLoader compatibility target and storage backend
+require a dedicated research ADR before the new OPL rule is fixed.
+
 ## Scope and extension
 
 Schema version 1 intentionally exposes only concepts supported by the current

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -172,37 +172,146 @@ PS2 CD source formats.
 
 ## Milestone 4: First PS1 vertical slice
 
+**Status:** Contract accepted
+
 ### Milestone 4 purpose
 
 Introduce a track-aware optical-media use case and the first dedicated PS1
 consumer presentation.
 
-### Milestone 4 required decisions
+[ADR-013](../architecture/adr-013-ps1-duckstation-presentation-contract.md)
+selects DuckStation as the first named consumer. The first implementation
+presents a single PS1 CUE/BIN disc as a generated CUE file and live per-track
+BIN files.
 
-Choose a named consumer before fixing the output contract. The design must
-then determine:
+### Milestone 4 scope
 
-* accepted filesystem layout and artifact formats;
-* treatment of data and audio tracks;
-* sector formats, pregaps, indexes, and information that must be preserved;
-* single-disc and multi-disc behavior;
-* whether CUE, BIN, CHD, and M3U artifacts are source-backed, generated, or
-  transformed.
+* refine the canonical CD model to distinguish file-backed and declared
+  pregaps and retain complete encoded track extents;
+* add platform-specific single-disc selection without requiring CD/DVD media
+  projection;
+* add a multi-file CUE/BIN artifact-set contract;
+* generate deterministic CUE documents with sibling per-track BIN references;
+* expose every track BIN as a bounded live view over encoded sectors;
+* add a serialized built-in `duckstation` presentation rooted at `PS1/`;
+* prove mixed data/audio, pregap, filesystem, and stored-ZIP behavior.
 
-### Milestone 4 initial implementation
+### Milestone 4 delivery sequence
 
-Implement one input format and one consumer output end to end. Add further PS1
-input formats only after the canonical CD representation is proven by that
-slice.
+Milestone 4 is a group of tracked vertical increments. It is complete only
+when PS1-1 through PS1-7 are implemented or a later ADR explicitly supersedes
+an item.
+
+#### PS1-1: DuckStation CUE/BIN presentation
+
+**Status:** Contract accepted
+
+Implement the first slice described above.
+
+#### PS1-2: CHD input
+
+**Status:** Planned
+
+Decode CHD metadata, tracks, sectors, audio, pregaps, and available subchannel
+information into the canonical `CdDisc`. Present the result through the
+DuckStation CUE/BIN view without flattening it to `LogicalDisc`.
+
+Acceptance requires mixed-mode and audio fixtures, bounded random access, and
+equivalent canonical semantics for matching CHD and CUE/BIN images.
+
+#### PS1-3: SBI sidecars
+
+**Status:** Planned
+
+Resolve and preserve optional source-backed SBI sidecars. Couple the output
+basename to the presented disc basename and reject ambiguous or mismatched
+sidecars.
+
+Acceptance requires filesystem and supported ZIP-backed sidecars, byte-exact
+live reads, and a DuckStation layout in which the SBI is adjacent to its disc
+entry with the same basename.
+
+#### PS1-4: Multi-disc M3U
+
+**Status:** Planned
+
+Present every disc in a normalized multi-disc PS1 game and generate an M3U
+whose relative entries reference the planned CUE or CHD artifacts.
+
+Acceptance requires deterministic disc ordering, atomic conflict resolution
+for the complete game artifact set, relative portable paths, and DuckStation
+validation of disc switching and game grouping.
+
+#### PS1-5: Cooked ISO input
+
+**Status:** Planned
+
+Accept cooked ISO only for the explicit data-only PS1 subset that it can
+represent. Require PS1 platform and CD media context; do not infer completeness
+from the extension or synthesize absent audio, raw-sector, or subchannel data.
+
+Acceptance requires byte-exact live reads, explicit rejection of incompatible
+claims, and presentation through a consumer representation that honestly
+describes the available sectors.
+
+#### PS1-6: Native CHD output
+
+**Status:** Planned
+
+Add lossless CHD output for DuckStation after specifying how a compression
+encoder fits a lazy, random-access VFS. The design must set bounded temporary
+storage, cancellation, cache lifetime, concurrency, and repeat-mount behavior.
+
+Acceptance requires round-trip track/layout verification, measured resource
+bounds, no untracked permanent intermediate, and useful random-read behavior
+after materialization.
+
+#### PS1-7: Extend the OPL presentation with POPS
+
+**Status:** Research required
+
+Extend the existing `opl` presentation so a PS2 library view contains PS2
+games below `DVD/` and `CD/` and PS1 games below `POPS/`. Do not create a
+standalone POPS presentation.
+
+First select the exact supported OPL, POPStarter, or POPSLoader compatibility
+target and storage backend. Record the VCD format, `POPS/` layout,
+launcher/runtime asset boundary, naming, multi-track, audio, and multi-disc
+requirements in a dedicated ADR.
+
+Acceptance requires:
+
+* a documented VCD byte and sector contract derived from the selected
+  implementation or its authoritative tooling;
+* a declarative `POPS/` rule in the existing serialized `opl` presentation
+  rather than consumer-specific decoder logic;
+* preservation of the existing PS2 `DVD/` and `CD/` behavior in the expanded
+  OPL view;
+* preservation or explicit compatibility treatment of data and audio tracks;
+* actionable handling of user-supplied launcher/runtime assets;
+* a representative real-consumer test on the selected PS2 storage backend;
+* documented exclusions for other forks or backends not covered by that test.
+
+The POPS rule must reuse canonical `CdDisc` semantics but must not reuse
+DuckStation's output artifact contract. VCD conversion remains a separately
+resolved encoder capability even though its result is composed into the OPL
+presentation.
 
 ### Milestone 4 acceptance criteria
 
 * PS1 and PS2 CDs remain semantically distinct.
-* The canonical model preserves everything required by the selected consumer.
-* A mixed-mode or multi-track fixture prevents regression to a DVD-like
-  contiguous-data assumption.
-* Multi-disc support is included only when required by the chosen first
-  consumer contract.
+* The canonical model preserves encoded track bytes, data/audio kinds, sector
+  formats, indexes, and both pregap forms required by generated CUE/BIN output.
+* A mixed-mode fixture is exposed as one generated CUE and complete live track
+  BINs without a whole-disc intermediate.
+* Generated CUE references are relative sibling filenames and match planned
+  VFS artifacts.
+* Filesystem and stored-ZIP inputs produce equivalent presentation semantics.
+* The complete artifact set is planned atomically and fails closed when timing
+  or naming cannot be represented.
+* PS2 and unknown CDs do not match the DuckStation rule.
+* Multi-disc support remains deferred from this first implementation.
+* PS1-2 through PS1-7 remain visible as planned work after PS1-1 merges.
 
 ## Milestone 5: Performance, caching, and optimization
 


### PR DESCRIPTION
## Summary

- define DuckStation as the first named PS1 consumer
- specify lossless single-disc CUE/BIN output as a generated CUE plus live per-track BIN artifact set
- identify the canonical CD timing refinements needed to preserve file-backed `INDEX 00` and declared `PREGAP` semantics
- track CHD input, SBI sidecars, multi-disc M3U, cooked ISO input, and native CHD output as explicit follow-up increments with acceptance criteria
- define POPS as a future `POPS/` rule within the existing OPL presentation, alongside its current `DVD/` and `CD/` rules

## Why

PS1 media commonly contains raw sectors, mixed data and audio tracks, indexes, and pregaps that cannot be represented by OPL's existing single logical ISO projection. This contract fixes a narrow first implementation while ensuring the deferred PS1 capabilities remain visible and testable roadmap commitments.

It also keeps the consumer boundary coherent: DuckStation receives its own CUE/BIN presentation, while PS2 users will eventually receive PS2 and PS1 content together through one expanded OPL library view.

## Scope

This PR contains documentation only. Implementation will follow on a separate feature branch after the contract is accepted.

## Validation

- `markdownlint-cli2 README.md 'docs/**/*.md'`
- `git diff --check`