### PR TITLE
Add the DuckStation PS1 CUE/BIN presentation

### DIFF
--- a/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
+++ b/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
@@ -334,5 +334,21 @@ or the first CUE/BIN contract.
 8. Validate the mounted result with DuckStation on a representative,
    user-owned PS1 image and document the result.
 
+## Implementation status
+
+The software implementation is complete. It includes:
+
+* canonical file-backed and declared pregap separation;
+* track-relative indexes and complete encoded source extents;
+* platform-specific single-disc selection;
+* atomic multi-file artifact-set planning and materialization;
+* a lossless, random-access CUE/BIN encoder;
+* generated CUE timing and sibling per-track BIN names;
+* an embedded `duckstation` presentation rooted at `PS1/`;
+* mixed-mode filesystem and stored-ZIP integration coverage.
+
+Representative real-DuckStation validation remains to be documented before
+the milestone is considered operationally verified.
+
 [duckstation-readme]: https://github.com/stenzek/duckstation/blob/master/README.md
 [duckstation-sbi]: https://github.com/stenzek/duckstation/blob/master/README.md#libcrypt-protection-and-sbi-files

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -118,13 +118,15 @@ Supported `select.type` values:
 * `games`
 * `games_without_parts`
 * `single_disc_games`
+* `single_disc_games_by_platform`
 * `single_disc_games_by_platform_and_media`
 * `multi_disc_games`
 * `single_rom_games`
 * `bytes`
 * `text`
 
-`single_disc_games_by_platform_and_media` also requires `platform` and `media`.
+`single_disc_games_by_platform` requires `platform`.
+`single_disc_games_by_platform_and_media` requires `platform` and `media`.
 Schema version 1 supports the platforms and media kinds already present in the
 normalized content model.
 
@@ -151,17 +153,24 @@ Each rule declares a `content_type` and may declare:
 A feature cannot be required or preferred while also forbidden. Capability
 resolution selects an encoder after the presentation has compiled.
 
+`format: cue_bin` requests one atomic multi-file disc artifact. Its encoder
+produces a generated CUE and live per-track BIN files inside one game
+directory. The `multi_file` feature describes that one-to-many output and is
+distinct from `multi_source`, which describes multiple encoder inputs.
+
 ## Built-in catalog
 
 The built-in catalog currently contains:
 
 * `flat`
 * `grouped`
+* `duckstation`
 * `opl`
 
-OPL is loaded from an embedded copy of `presentations/opl.yaml`. Flat and
-grouped remain code-constructed declarative values until their shared rule set
-is migrated without unnecessary duplication.
+DuckStation and OPL are loaded from embedded copies of
+`presentations/duckstation.yaml` and `presentations/opl.yaml`. Flat and grouped
+remain code-constructed declarative values until their shared rule set is
+migrated without unnecessary duplication.
 
 The OPL presentation declares sibling `DVD/` and `CD/` rules. ISO inputs need
 an explicit `media: dvd` or `media: cd` composition hint because ISO does not
@@ -169,14 +178,12 @@ reliably identify its original carrier. Track-aware CUE/BIN inputs provide CD
 media semantics directly, but mixed-mode, audio, and other layouts without a
 safe 2048-byte logical projection are rejected by the OPL composition.
 
-The next built-in presentation is the accepted `duckstation` contract defined
-by
+The `duckstation` contract is defined by
 [ADR-013](architecture/adr-013-ps1-duckstation-presentation-contract.md).
-Unlike OPL, it will consume the complete track-aware PS1 CD and produce one
+Unlike OPL, it consumes the complete track-aware PS1 CD and produces one
 coherent artifact set containing a generated CUE and live per-track BIN files.
-That implementation requires a schema extension for multi-file artifacts; it
-is documented here as planned behavior and is not yet available in the
-built-in catalog.
+The first implementation supports single-disc CUE/BIN input; the roadmap
+tracks CHD, SBI, multi-disc M3U, cooked ISO, and native CHD output separately.
 
 The PS1 roadmap also commits to extending the existing `opl` presentation with
 POPS support. The resulting PS2 library view will retain PS2 games below

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -204,7 +204,7 @@ an item.
 
 #### PS1-1: DuckStation CUE/BIN presentation
 
-**Status:** Contract accepted
+**Status:** Implemented
 
 Implement the first slice described above.
 

--- a/presentations/duckstation.yaml
+++ b/presentations/duckstation.yaml
@@ -1,0 +1,20 @@
+version: 1
+name: duckstation
+
+layout:
+  type: literal_root
+  path: PS1
+
+files:
+  - select:
+      type: single_disc_games_by_platform
+      platform: ps1
+    naming:
+      type: part_name
+    artifact:
+      content_type: disc
+      format: cue_bin
+      required_features:
+        - lossless
+        - random_access
+        - multi_file

--- a/src/core/cd.rs
+++ b/src/core/cd.rs
@@ -37,18 +37,41 @@ pub struct CdTrack {
     pub number: u8,
     pub kind: CdTrackKind,
     pub sector_format: CdSectorFormat,
+    /// Number of encoded sectors in the preserved track extent. The extent
+    /// begins at `source_offset` and includes file-backed INDEX 00 content.
     pub sector_count: u64,
     pub source: SourceRef,
+    /// Byte offset of the earliest preserved index in the encoded source.
     pub source_offset: u64,
     pub encoded_content: ReaderHandle,
     pub logical_content: Option<ReaderHandle>,
+    /// Index positions relative to the beginning of the preserved extent.
     pub indexes: Vec<CdIndex>,
-    pub pregap_sectors: u64,
+    /// File-backed sectors between INDEX 00 and INDEX 01.
+    pub file_backed_pregap_sectors: u64,
+    /// Synthetic pregap declared with the CUE PREGAP directive.
+    pub declared_pregap_sectors: u64,
 }
 
 impl CdTrack {
     pub fn encoded_len(&self) -> Option<u64> {
         u64::from(self.sector_format.encoded_sector_size()).checked_mul(self.sector_count)
+    }
+
+    pub fn index_one_sector(&self) -> Option<u64> {
+        self.indexes
+            .iter()
+            .find(|index| index.number == 1)
+            .map(|index| index.sector)
+    }
+
+    pub fn playable_sector_count(&self) -> Option<u64> {
+        self.sector_count.checked_sub(self.index_one_sector()?)
+    }
+
+    pub fn total_pregap_sectors(&self) -> Option<u64> {
+        self.file_backed_pregap_sectors
+            .checked_add(self.declared_pregap_sectors)
     }
 }
 
@@ -93,7 +116,8 @@ mod tests {
                 number: 1,
                 sector: 0,
             }],
-            pregap_sectors: 0,
+            file_backed_pregap_sectors: 0,
+            declared_pregap_sectors: 0,
         };
         let audio = CdTrack {
             number: 2,
@@ -114,5 +138,35 @@ mod tests {
         .opl_logical_track()
         .is_none());
         assert!(CdDisc { tracks: vec![] }.opl_logical_track().is_none());
+    }
+
+    #[test]
+    fn reports_playable_and_pregap_sector_counts() {
+        let track = CdTrack {
+            number: 2,
+            kind: CdTrackKind::Audio,
+            sector_format: CdSectorFormat::Audio2352,
+            sector_count: 12,
+            source: SourceRef::new("file:game.bin"),
+            source_offset: 2352,
+            encoded_content: handle("encoded"),
+            logical_content: None,
+            indexes: vec![
+                CdIndex {
+                    number: 0,
+                    sector: 0,
+                },
+                CdIndex {
+                    number: 1,
+                    sector: 2,
+                },
+            ],
+            file_backed_pregap_sectors: 2,
+            declared_pregap_sectors: 3,
+        };
+
+        assert_eq!(track.playable_sector_count(), Some(10));
+        assert_eq!(track.total_pregap_sectors(), Some(5));
+        assert_eq!(track.encoded_len(), Some(12 * 2352));
     }
 }

--- a/src/engine/bootstrap.rs
+++ b/src/engine/bootstrap.rs
@@ -8,8 +8,9 @@ use crate::output::presentation_spec::{
     ArtifactSpec, FileRuleSpec, LayoutSpec, NamingSpec, PresentationSpec, SelectSpec,
 };
 
-const BUILT_IN_PRESENTATIONS: [&str; 3] = ["flat", "grouped", "opl"];
+const BUILT_IN_PRESENTATIONS: [&str; 4] = ["duckstation", "flat", "grouped", "opl"];
 const OPL_PRESENTATION: &str = include_str!("../../presentations/opl.yaml");
+const DUCKSTATION_PRESENTATION: &str = include_str!("../../presentations/duckstation.yaml");
 
 pub fn built_in_presentation_names() -> &'static [&'static str] {
     &BUILT_IN_PRESENTATIONS
@@ -21,6 +22,9 @@ pub fn build_presentation_spec(name: &str) -> Result<PresentationSpec, String> {
 
 pub fn load_presentation(reference: &str) -> Result<PresentationDocument, String> {
     match reference {
+        "duckstation" => parse_presentation_yaml(DUCKSTATION_PRESENTATION).map_err(|error| {
+            format!("built-in presentation 'duckstation' failed validation: {error}")
+        }),
         "flat" => Ok(PresentationDocument {
             name: "flat".to_string(),
             spec: PresentationSpec::new(LayoutSpec::Flat, built_in_file_rules()),
@@ -114,7 +118,10 @@ mod tests {
 
     #[test]
     fn exposes_stable_built_in_presentation_names() {
-        assert_eq!(built_in_presentation_names(), &["flat", "grouped", "opl"]);
+        assert_eq!(
+            built_in_presentation_names(),
+            &["duckstation", "flat", "grouped", "opl"]
+        );
     }
 
     #[test]
@@ -128,6 +135,10 @@ mod tests {
             LayoutSpec::GroupedByPlatformAndGame
         );
         assert_eq!(
+            build_presentation_spec("duckstation").unwrap().layout,
+            LayoutSpec::LiteralRoot("PS1".to_string())
+        );
+        assert_eq!(
             build_presentation_spec("opl").unwrap().layout,
             LayoutSpec::Flat
         );
@@ -138,7 +149,7 @@ mod tests {
         let error = build_presentation_spec("unknown").unwrap_err();
         assert_eq!(
             error,
-            "unsupported view or presentation file 'unknown'; expected one of: flat, grouped, opl"
+            "unsupported view or presentation file 'unknown'; expected one of: duckstation, flat, grouped, opl"
         );
     }
 

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -54,12 +54,14 @@ pub fn pipeline_components_with_media(
     }
     decoder.register(BasicInputDecoder::new());
 
-    let normalization = if presentation_name == "opl" {
-        NormalizationOptions {
+    let normalization = match presentation_name {
+        "opl" => NormalizationOptions {
             platform_hint: Some(Platform::Ps2),
-        }
-    } else {
-        NormalizationOptions::default()
+        },
+        "duckstation" => NormalizationOptions {
+            platform_hint: Some(Platform::Ps1),
+        },
+        _ => NormalizationOptions::default(),
     };
 
     Ok(PipelineComponents {

--- a/src/input/cue_disc_decoder.rs
+++ b/src/input/cue_disc_decoder.rs
@@ -110,7 +110,9 @@ impl InputDecoder for CueDiscDecoder {
         let logical_disc = cd_disc.opl_logical_track().map(|track| LogicalDisc {
             media: DiscMedia::Cd,
             sector_size: 2048,
-            sector_count: track.sector_count,
+            sector_count: track
+                .playable_sector_count()
+                .expect("OPL-compatible track must have INDEX 01"),
             content: track
                 .logical_content
                 .clone()
@@ -177,23 +179,33 @@ fn build_track(
     }
 
     let file_sectors = content.size / sector_size;
+    let extent_start = entry
+        .indexes
+        .iter()
+        .find(|index| index.number == 0)
+        .map(|index| index.sector)
+        .unwrap_or(index_one);
     let end_sector = next_start.unwrap_or(file_sectors);
-    if index_one >= end_sector || end_sector > file_sectors {
+    if extent_start > index_one || index_one >= end_sector || end_sector > file_sectors {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("CUE track {:02} has an invalid source range", entry.number),
         ));
     }
 
-    let sector_count = end_sector - index_one;
-    let source_offset = index_one
+    let sector_count = end_sector - extent_start;
+    let playable_sector_count = end_sector - index_one;
+    let source_offset = extent_start
+        .checked_mul(sector_size)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CUE track offset overflow"))?;
+    let logical_source_offset = index_one
         .checked_mul(sector_size)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CUE track offset overflow"))?;
     let logical_content = logical_track_handle(
         &content,
         &source,
-        source_offset,
-        sector_count,
+        logical_source_offset,
+        playable_sector_count,
         sector_format,
     )?;
     let file_backed_pregap = entry
@@ -210,9 +222,7 @@ fn build_track(
         })
         .transpose()?
         .unwrap_or(0);
-    let pregap_sectors = file_backed_pregap
-        .checked_add(entry.pregap_sectors.unwrap_or(0))
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CUE pregap overflow"))?;
+    let declared_pregap_sectors = entry.pregap_sectors.unwrap_or(0);
 
     Ok(CdTrack {
         number: entry.number,
@@ -226,12 +236,23 @@ fn build_track(
         indexes: entry
             .indexes
             .iter()
-            .map(|index| CdIndex {
-                number: index.number,
-                sector: index.sector,
+            .map(|index| {
+                Ok(CdIndex {
+                    number: index.number,
+                    sector: index.sector.checked_sub(extent_start).ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "CUE track {:02} index precedes its preserved extent",
+                                entry.number
+                            ),
+                        )
+                    })?,
+                })
             })
-            .collect(),
-        pregap_sectors,
+            .collect::<io::Result<Vec<_>>>()?,
+        file_backed_pregap_sectors: file_backed_pregap,
+        declared_pregap_sectors,
     })
 }
 
@@ -473,7 +494,9 @@ mod tests {
 
         assert_eq!(cd.tracks.len(), 2);
         assert_eq!(cd.tracks[1].kind, CdTrackKind::Audio);
-        assert_eq!(cd.tracks[1].pregap_sectors, 150);
+        assert_eq!(cd.tracks[1].file_backed_pregap_sectors, 0);
+        assert_eq!(cd.tracks[1].declared_pregap_sectors, 150);
+        assert_eq!(cd.tracks[1].total_pregap_sectors(), Some(150));
         assert!(disc.logical_disc.is_none());
     }
 
@@ -541,9 +564,12 @@ mod tests {
 
         assert_eq!(tracks.len(), 2);
         assert_eq!(tracks[0].sector_count, 1);
-        assert_eq!(tracks[1].source_offset, 2 * 2352);
-        assert_eq!(tracks[1].sector_count, 1);
-        assert_eq!(tracks[1].pregap_sectors, 1);
+        assert_eq!(tracks[1].source_offset, 2352);
+        assert_eq!(tracks[1].sector_count, 2);
+        assert_eq!(tracks[1].file_backed_pregap_sectors, 1);
+        assert_eq!(tracks[1].declared_pregap_sectors, 0);
+        assert_eq!(tracks[1].index_one_sector(), Some(1));
+        assert_eq!(tracks[1].playable_sector_count(), Some(1));
         assert_eq!(tracks[0].source, tracks[1].source);
         assert!(disc.logical_disc.is_none());
     }

--- a/src/output/capabilities.rs
+++ b/src/output/capabilities.rs
@@ -20,6 +20,7 @@ pub enum Format {
     M3u,
     Directory,
     Bin,
+    CueBin,
     Text,
 }
 
@@ -30,6 +31,7 @@ pub enum CapabilityFeature {
     Lossless,
     RandomAccess,
     SupportsPartial,
+    MultiFile,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/output/cue_bin_encoder.rs
+++ b/src/output/cue_bin_encoder.rs
@@ -1,0 +1,193 @@
+use std::io;
+
+use crate::core::cd::{CdSectorFormat, CdTrack};
+use crate::core::reader_handle::ReaderHandle;
+use crate::output::capabilities::{CapabilityFeature, ContentType, EncoderCapability, Format};
+use crate::output::encode::{
+    MaterializationContext, MaterializedArtifact, MaterializedNamedArtifact, OutputEncoder,
+};
+use crate::output::plan::{ArtifactRequest, ContentArtifact, PlannedArtifactKind};
+use crate::readers::range_reader::RangeReader;
+
+pub struct CueBinEncoder;
+
+impl CueBinEncoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CueBinEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OutputEncoder for CueBinEncoder {
+    fn plugin_id(&self) -> &str {
+        "cue-bin"
+    }
+
+    fn capabilities(&self) -> Vec<EncoderCapability> {
+        vec![
+            EncoderCapability::new(self.plugin_id(), "disc.cue-bin", ContentType::Disc)
+                .supports_format(Format::CueBin)
+                .with_feature(CapabilityFeature::Lossless)
+                .with_feature(CapabilityFeature::RandomAccess)
+                .with_feature(CapabilityFeature::MultiFile),
+        ]
+    }
+
+    fn materialize(
+        &self,
+        _file_name: &str,
+        _artifact: &ArtifactRequest,
+        selected_capability_id: &str,
+        _context: &MaterializationContext,
+    ) -> Result<MaterializedArtifact, io::Error> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("capability '{selected_capability_id}' produces an artifact set"),
+        ))
+    }
+
+    fn materialize_set(
+        &self,
+        artifact_name: &str,
+        artifact: &ArtifactRequest,
+        selected_capability_id: &str,
+        _context: &MaterializationContext,
+    ) -> Result<Vec<MaterializedNamedArtifact>, io::Error> {
+        if selected_capability_id != "disc.cue-bin" {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unsupported capability '{selected_capability_id}'"),
+            ));
+        }
+        if artifact_name.is_empty() || artifact_name.contains('"') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CUE/BIN artifact name must be non-empty and contain no quotes",
+            ));
+        }
+        let PlannedArtifactKind::ContentBacked(ContentArtifact::CdDisc(disc)) = &artifact.kind
+        else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CUE/BIN encoding requires track-aware CD content",
+            ));
+        };
+        if disc.tracks.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "CUE/BIN encoding requires at least one track",
+            ));
+        }
+
+        let mut cue = String::new();
+        let mut members = Vec::with_capacity(disc.tracks.len() + 1);
+        for track in &disc.tracks {
+            validate_track(track)?;
+            let bin_name = format!("{artifact_name} (Track {:02}).bin", track.number);
+            cue.push_str(&format!("FILE \"{bin_name}\" BINARY\n"));
+            cue.push_str(&format!(
+                "  TRACK {:02} {}\n",
+                track.number,
+                cue_track_mode(track.sector_format)
+            ));
+            if track.declared_pregap_sectors > 0 {
+                cue.push_str(&format!(
+                    "    PREGAP {}\n",
+                    cue_time(track.declared_pregap_sectors)?
+                ));
+            }
+            for index in &track.indexes {
+                cue.push_str(&format!(
+                    "    INDEX {:02} {}\n",
+                    index.number,
+                    cue_time(index.sector)?
+                ));
+            }
+
+            let size = track.encoded_len().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "encoded track length overflow")
+            })?;
+            let source = track.encoded_content.clone();
+            let offset = track.source_offset;
+            let handle = ReaderHandle::new(
+                format!("cue-bin:{}:{offset}:{size}", track.source),
+                move || Ok(Box::new(RangeReader::new(source.open()?, offset, size)?)),
+            );
+            members.push(MaterializedNamedArtifact::new(
+                bin_name,
+                MaterializedArtifact::ReaderBacked { handle, size },
+            ));
+        }
+
+        members.insert(
+            0,
+            MaterializedNamedArtifact::new(
+                format!("{artifact_name}.cue"),
+                MaterializedArtifact::Inline(cue.into_bytes()),
+            ),
+        );
+        Ok(members)
+    }
+}
+
+fn validate_track(track: &CdTrack) -> io::Result<()> {
+    let index_one = track.index_one_sector().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("CD track {:02} has no INDEX 01", track.number),
+        )
+    })?;
+    if index_one != track.file_backed_pregap_sectors {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "CD track {:02} INDEX 01 does not match its file-backed pregap",
+                track.number
+            ),
+        ));
+    }
+    if track
+        .indexes
+        .iter()
+        .any(|index| index.sector >= track.sector_count)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "CD track {:02} has an index outside its extent",
+                track.number
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn cue_track_mode(format: CdSectorFormat) -> &'static str {
+    match format {
+        CdSectorFormat::Mode1_2048 => "MODE1/2048",
+        CdSectorFormat::Mode1_2352 => "MODE1/2352",
+        CdSectorFormat::Mode2_2352 => "MODE2/2352",
+        CdSectorFormat::Audio2352 => "AUDIO",
+    }
+}
+
+fn cue_time(sectors: u64) -> io::Result<String> {
+    let minutes = sectors / (75 * 60);
+    if minutes > 99 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "CUE time exceeds two-digit minute range",
+        ));
+    }
+    let remainder = sectors % (75 * 60);
+    Ok(format!(
+        "{minutes:02}:{:02}:{:02}",
+        remainder / 75,
+        remainder % 75
+    ))
+}

--- a/src/output/encode.rs
+++ b/src/output/encode.rs
@@ -14,6 +14,21 @@ pub enum MaterializedArtifact {
     ReaderBacked { handle: ReaderHandle, size: u64 },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterializedNamedArtifact {
+    pub name: String,
+    pub artifact: MaterializedArtifact,
+}
+
+impl MaterializedNamedArtifact {
+    pub fn new(name: impl Into<String>, artifact: MaterializedArtifact) -> Self {
+        Self {
+            name: name.into(),
+            artifact,
+        }
+    }
+}
+
 impl MaterializedArtifact {
     pub fn to_vfs_file(&self, name: &str) -> VfsFile {
         match self {
@@ -45,4 +60,21 @@ pub trait OutputEncoder: Send + Sync {
         selected_capability_id: &str,
         context: &MaterializationContext,
     ) -> Result<MaterializedArtifact, io::Error>;
+
+    fn materialize_set(
+        &self,
+        _artifact_name: &str,
+        _artifact: &ArtifactRequest,
+        selected_capability_id: &str,
+        _context: &MaterializationContext,
+    ) -> Result<Vec<MaterializedNamedArtifact>, io::Error> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "encoder '{}' capability '{}' does not materialize artifact sets",
+                self.plugin_id(),
+                selected_capability_id
+            ),
+        ))
+    }
 }

--- a/src/output/encoder_registry.rs
+++ b/src/output/encoder_registry.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::output::basic_encoder::BasicEncoder;
+use crate::output::cue_bin_encoder::CueBinEncoder;
 use crate::output::encode::OutputEncoder;
 use crate::output::logical_disc_iso_encoder::LogicalDiscIsoEncoder;
 
@@ -52,6 +53,7 @@ impl Default for EncoderRegistry {
 pub fn default_encoder_registry() -> EncoderRegistry {
     let mut registry = EncoderRegistry::new();
     registry.register("basic", || Box::new(BasicEncoder::new()));
+    registry.register("cue-bin", || Box::new(CueBinEncoder::new()));
     registry.register(
         "logical-disc-iso",
         || Box::new(LogicalDiscIsoEncoder::new()),

--- a/src/output/logical_disc_iso_encoder.rs
+++ b/src/output/logical_disc_iso_encoder.rs
@@ -52,7 +52,12 @@ impl OutputEncoder for LogicalDiscIsoEncoder {
                 "logical ISO encoding requires a content-backed artifact",
             ));
         };
-        let disc = &content.logical_disc;
+        let crate::output::plan::ContentArtifact::LogicalDisc(disc) = content else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "logical ISO encoding requires logical disc content",
+            ));
+        };
 
         if disc.sector_size != 2048 {
             return Err(io::Error::new(

--- a/src/output/materialize.rs
+++ b/src/output/materialize.rs
@@ -5,7 +5,7 @@ use crate::core::vfs::{VfsDirectory, VfsNode};
 use crate::output::capabilities::EncoderCapability;
 use crate::output::encode::{MaterializationContext, OutputEncoder};
 use crate::output::encoder_registry::default_encoder_registry;
-use crate::output::plan::{ArtifactId, PlanEntry, PlanFile, PresentationPlan};
+use crate::output::plan::{ArtifactId, PlanArtifactSet, PlanEntry, PlanFile, PresentationPlan};
 use crate::output::plugin_registry::PluginRegistry;
 use crate::output::resolution::{CapabilityResolver, ResolutionResult};
 
@@ -60,6 +60,9 @@ fn collect_artifact_names_recursive(
             PlanEntry::File(file) => {
                 names.insert(file.artifact.id.clone(), file.name.clone());
             }
+            PlanEntry::ArtifactSet(set) => {
+                names.insert(set.artifact.id.clone(), set.directory_name.clone());
+            }
         }
     }
 }
@@ -87,10 +90,82 @@ fn materialize_entries(
                     encoders,
                 )?));
             }
+            PlanEntry::ArtifactSet(set) => {
+                children.push(VfsNode::Directory(materialize_artifact_set(
+                    set,
+                    artifact_names,
+                    encoders,
+                )?));
+            }
         }
     }
 
     Ok(children)
+}
+
+fn materialize_artifact_set(
+    set: &PlanArtifactSet,
+    artifact_names: &HashMap<ArtifactId, String>,
+    encoders: &[Box<dyn OutputEncoder>],
+) -> Result<VfsDirectory, io::Error> {
+    let capabilities = collect_capabilities(encoders);
+    let selected = match CapabilityResolver.resolve(&set.artifact, &capabilities) {
+        ResolutionResult::Resolved { selected, .. } => selected,
+        ResolutionResult::Unresolved { diagnostics } => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "no encoder could materialize artifact set '{}' ({:?})",
+                    set.directory_name, diagnostics
+                ),
+            ))
+        }
+    };
+    let encoder = encoders
+        .iter()
+        .find(|encoder| encoder.plugin_id() == selected.plugin_id)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("selected encoder '{}' is unavailable", selected.plugin_id),
+            )
+        })?;
+    let materialized = encoder.materialize_set(
+        &set.artifact_name,
+        &set.artifact,
+        &selected.capability_id,
+        &MaterializationContext {
+            artifact_names: artifact_names.clone(),
+        },
+    )?;
+
+    let mut names = std::collections::HashSet::new();
+    let mut children = Vec::with_capacity(materialized.len());
+    for member in materialized {
+        if member.name.is_empty()
+            || member.name.contains('/')
+            || member.name.contains('\\')
+            || !names.insert(member.name.clone())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "encoder '{}' returned an invalid or duplicate artifact-set member name '{}'",
+                    selected.plugin_id, member.name
+                ),
+            ));
+        }
+        children.push(VfsNode::File(member.artifact.to_vfs_file(&member.name)));
+    }
+
+    if children.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("artifact set '{}' is empty", set.directory_name),
+        ));
+    }
+
+    Ok(VfsDirectory::with_children(&set.directory_name, children))
 }
 
 fn materialize_file(

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,6 @@
 pub mod basic_encoder;
 pub mod capabilities;
+pub mod cue_bin_encoder;
 pub mod encode;
 pub mod encoder_registry;
 pub mod logical_disc_iso_encoder;

--- a/src/output/plan.rs
+++ b/src/output/plan.rs
@@ -1,3 +1,4 @@
+use crate::core::cd::CdDisc;
 use crate::core::content::LogicalDisc;
 use crate::core::source::SourceRef;
 use crate::output::capabilities::CapabilityRequirements;
@@ -23,6 +24,28 @@ impl PresentationPlan {
 pub enum PlanEntry {
     Directory(PlanDirectory),
     File(PlanFile),
+    ArtifactSet(PlanArtifactSet),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanArtifactSet {
+    pub directory_name: String,
+    pub artifact_name: String,
+    pub artifact: ArtifactRequest,
+}
+
+impl PlanArtifactSet {
+    pub fn new(
+        directory_name: impl Into<String>,
+        artifact_name: impl Into<String>,
+        artifact: ArtifactRequest,
+    ) -> Self {
+        Self {
+            directory_name: directory_name.into(),
+            artifact_name: artifact_name.into(),
+            artifact,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,13 +116,18 @@ pub enum PlannedArtifactKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ContentArtifact {
-    pub logical_disc: LogicalDisc,
+pub enum ContentArtifact {
+    LogicalDisc(LogicalDisc),
+    CdDisc(CdDisc),
 }
 
 impl ContentArtifact {
     pub fn logical_disc(logical_disc: LogicalDisc) -> Self {
-        Self { logical_disc }
+        Self::LogicalDisc(logical_disc)
+    }
+
+    pub fn cd_disc(cd_disc: CdDisc) -> Self {
+        Self::CdDisc(cd_disc)
     }
 }
 

--- a/src/output/plugin_protocol.rs
+++ b/src/output/plugin_protocol.rs
@@ -87,6 +87,7 @@ pub enum ProtocolFormat {
     M3u,
     Directory,
     Bin,
+    CueBin,
     Text,
 }
 
@@ -97,6 +98,7 @@ pub enum ProtocolCapabilityFeature {
     Lossless,
     RandomAccess,
     SupportsPartial,
+    MultiFile,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/output/plugin_protocol_conversion.rs
+++ b/src/output/plugin_protocol_conversion.rs
@@ -107,6 +107,7 @@ impl From<Format> for ProtocolFormat {
             Format::M3u => Self::M3u,
             Format::Directory => Self::Directory,
             Format::Bin => Self::Bin,
+            Format::CueBin => Self::CueBin,
             Format::Text => Self::Text,
         }
     }
@@ -121,6 +122,7 @@ impl From<ProtocolFormat> for Format {
             ProtocolFormat::M3u => Self::M3u,
             ProtocolFormat::Directory => Self::Directory,
             ProtocolFormat::Bin => Self::Bin,
+            ProtocolFormat::CueBin => Self::CueBin,
             ProtocolFormat::Text => Self::Text,
         }
     }
@@ -134,6 +136,7 @@ impl From<CapabilityFeature> for ProtocolCapabilityFeature {
             CapabilityFeature::Lossless => Self::Lossless,
             CapabilityFeature::RandomAccess => Self::RandomAccess,
             CapabilityFeature::SupportsPartial => Self::SupportsPartial,
+            CapabilityFeature::MultiFile => Self::MultiFile,
         }
     }
 }
@@ -146,6 +149,7 @@ impl From<ProtocolCapabilityFeature> for CapabilityFeature {
             ProtocolCapabilityFeature::Lossless => Self::Lossless,
             ProtocolCapabilityFeature::RandomAccess => Self::RandomAccess,
             ProtocolCapabilityFeature::SupportsPartial => Self::SupportsPartial,
+            ProtocolCapabilityFeature::MultiFile => Self::MultiFile,
         }
     }
 }

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -3,8 +3,8 @@ use crate::core::source::SourceRef;
 use crate::output::capabilities::{CapabilityRequirements, ContentType, Format};
 use crate::output::plan::{
     ArtifactId, ArtifactReference, ArtifactRequest, ContentArtifact, GeneratedArtifact,
-    PlanDirectory, PlanEntry, PlanFile, PlannedArtifactKind, PlaylistArtifact, PresentationPlan,
-    SourceArtifact,
+    PlanArtifactSet, PlanDirectory, PlanEntry, PlanFile, PlannedArtifactKind, PlaylistArtifact,
+    PresentationPlan, SourceArtifact,
 };
 use crate::output::presentation_expansion::{is_multi_disc_game, sorted_disc_parts};
 use crate::output::presentation_spec::{
@@ -52,9 +52,9 @@ fn compile_flat(
             let directory = ensure_directory(&mut root, &rule.directory, policy);
             let mut names = child_names(directory);
 
-            for file in try_compile_rule(rule, item, policy, &mut names) {
-                directory.entries.push(PlanEntry::File(file));
-            }
+            directory
+                .entries
+                .extend(try_compile_rule(rule, item, policy, &mut names));
         }
     }
 
@@ -82,9 +82,9 @@ fn compile_grouped_by_platform_and_game(
                     let directory = ensure_directory(game_dir, &rule.directory, policy);
                     let mut names = child_names(directory);
 
-                    for file in try_compile_rule(rule, item, policy, &mut names) {
-                        directory.entries.push(PlanEntry::File(file));
-                    }
+                    directory
+                        .entries
+                        .extend(try_compile_rule(rule, item, policy, &mut names));
                 }
             }
             NormalizedContent::Bytes(_) | NormalizedContent::Text(_) => {
@@ -95,9 +95,9 @@ fn compile_grouped_by_platform_and_game(
                     let directory = ensure_directory(content_directory, &rule.directory, policy);
                     let mut names = child_names(directory);
 
-                    for file in try_compile_rule(rule, item, policy, &mut names) {
-                        directory.entries.push(PlanEntry::File(file));
-                    }
+                    directory
+                        .entries
+                        .extend(try_compile_rule(rule, item, policy, &mut names));
                 }
             }
         }
@@ -111,7 +111,7 @@ fn try_compile_rule(
     item: &NormalizedContent,
     policy: &PolicySet,
     root_names: &mut Vec<String>,
-) -> Vec<PlanFile> {
+) -> Vec<PlanEntry> {
     if rule.select == SelectSpec::MultiDiscGames {
         return try_compile_multi_disc_rule(rule, item, policy, root_names);
     }
@@ -120,6 +120,9 @@ fn try_compile_rule(
         SelectSpec::Games => match_game(item),
         SelectSpec::GamesWithoutParts => match_game_without_parts(item),
         SelectSpec::SingleDiscGames => match_single_disc_game(item),
+        SelectSpec::SingleDiscGamesByPlatform { platform } => {
+            match_single_disc_game_by_platform(item, platform)
+        }
         SelectSpec::SingleDiscGamesByPlatformAndMedia { platform, media } => {
             match_single_disc_game_by_platform_and_media(item, platform, media)
         }
@@ -136,6 +139,29 @@ fn try_compile_rule(
     let Some(proposed_name) = build_name(&rule.naming, item, &rule.artifact, policy) else {
         return Vec::new();
     };
+    if rule.artifact.format == Some(Format::CueBin) {
+        let NormalizedContent::Game(game) = item else {
+            return Vec::new();
+        };
+        let Some(cd_disc) = match_result.cd_disc else {
+            return Vec::new();
+        };
+        let directory_name =
+            policy.resolve_name_conflict(&policy.naming().game_name(game), root_names);
+        root_names.push(directory_name.clone());
+        let artifact_name = strip_known_extension(&proposed_name, Some(Format::CueBin));
+        let artifact = ArtifactRequest::new(
+            build_artifact_id(&rule.select, item),
+            PlannedArtifactKind::ContentBacked(ContentArtifact::cd_disc(cd_disc)),
+            build_requirements(&rule.artifact),
+        );
+        return vec![PlanEntry::ArtifactSet(PlanArtifactSet::new(
+            directory_name,
+            artifact_name,
+            artifact,
+        ))];
+    }
+
     let proposed_name = apply_extension(proposed_name, rule.artifact.format);
     let allocated_name = policy.resolve_name_conflict(&proposed_name, root_names);
     root_names.push(allocated_name.clone());
@@ -154,7 +180,7 @@ fn try_compile_rule(
         build_requirements(&rule.artifact),
     );
 
-    vec![PlanFile::new(allocated_name, artifact)]
+    vec![PlanEntry::File(PlanFile::new(allocated_name, artifact))]
 }
 
 fn try_compile_multi_disc_rule(
@@ -162,7 +188,7 @@ fn try_compile_multi_disc_rule(
     item: &NormalizedContent,
     policy: &PolicySet,
     names: &mut Vec<String>,
-) -> Vec<PlanFile> {
+) -> Vec<PlanEntry> {
     let NormalizedContent::Game(game) = item else {
         return Vec::new();
     };
@@ -187,7 +213,7 @@ fn try_compile_multi_disc_rule(
 
                 let artifact_id =
                     ArtifactId::new(format!("game:{}:disc:{}", game.id, disc.disc_number));
-                Some(PlanFile::new(
+                Some(PlanEntry::File(PlanFile::new(
                     allocated_name,
                     ArtifactRequest::new(
                         artifact_id,
@@ -202,7 +228,7 @@ fn try_compile_multi_disc_rule(
                         },
                         build_requirements(&rule.artifact),
                     ),
-                ))
+                )))
             })
             .collect(),
         ContentType::Playlist => {
@@ -223,7 +249,7 @@ fn try_compile_multi_disc_rule(
                 })
                 .collect();
 
-            vec![PlanFile::new(
+            vec![PlanEntry::File(PlanFile::new(
                 allocated_name,
                 ArtifactRequest::new(
                     ArtifactId::new(format!("game:{}:playlist", game.id)),
@@ -232,7 +258,7 @@ fn try_compile_multi_disc_rule(
                     )),
                     build_requirements(&rule.artifact),
                 ),
-            )]
+            ))]
         }
         _ => Vec::new(),
     }
@@ -324,6 +350,7 @@ fn child_names(directory: &PlanDirectory) -> Vec<String> {
         .map(|entry| match entry {
             PlanEntry::Directory(directory) => directory.name.clone(),
             PlanEntry::File(file) => file.name.clone(),
+            PlanEntry::ArtifactSet(set) => set.directory_name.clone(),
         })
         .collect()
 }
@@ -332,6 +359,7 @@ struct SourceMatch {
     source: SourceRef,
     size: u64,
     logical_disc: Option<crate::core::content::LogicalDisc>,
+    cd_disc: Option<crate::core::cd::CdDisc>,
 }
 
 fn match_game(item: &NormalizedContent) -> Option<SourceMatch> {
@@ -340,6 +368,7 @@ fn match_game(item: &NormalizedContent) -> Option<SourceMatch> {
             source: game.source.clone(),
             size: 0,
             logical_disc: None,
+            cd_disc: None,
         }),
         _ => None,
     }
@@ -354,6 +383,7 @@ fn match_game_without_parts(item: &NormalizedContent) -> Option<SourceMatch> {
         source: game.source.clone(),
         size: 0,
         logical_disc: None,
+        cd_disc: None,
     })
 }
 
@@ -371,9 +401,22 @@ fn match_single_disc_game(item: &NormalizedContent) -> Option<SourceMatch> {
             source: disc.source.clone(),
             size: 0,
             logical_disc: disc.logical_disc.clone(),
+            cd_disc: disc.cd_disc.clone(),
         }),
         GamePart::Rom(_) => None,
     }
+}
+
+fn match_single_disc_game_by_platform(
+    item: &NormalizedContent,
+    platform: crate::core::content::Platform,
+) -> Option<SourceMatch> {
+    let NormalizedContent::Game(game) = item else {
+        return None;
+    };
+    (game.platform == platform)
+        .then(|| match_single_disc_game(item))
+        .flatten()
 }
 
 fn match_single_disc_game_by_platform_and_media(
@@ -407,6 +450,7 @@ fn match_single_rom_game(item: &NormalizedContent) -> Option<SourceMatch> {
             source: rom.source.clone(),
             size: rom.size,
             logical_disc: None,
+            cd_disc: None,
         }),
         GamePart::Disc(_) => None,
     }
@@ -418,6 +462,7 @@ fn match_bytes(item: &NormalizedContent) -> Option<SourceMatch> {
             source: bytes.source.clone(),
             size: bytes.size,
             logical_disc: None,
+            cd_disc: None,
         }),
         _ => None,
     }
@@ -429,6 +474,7 @@ fn match_text(item: &NormalizedContent) -> Option<SourceMatch> {
             source: text.source.clone(),
             size: text.size,
             logical_disc: None,
+            cd_disc: None,
         }),
         _ => None,
     }
@@ -543,6 +589,7 @@ fn extension_for_format(format: Option<Format>) -> Option<&'static str> {
         Some(Format::M3u) => Some("m3u"),
         Some(Format::Directory) => None,
         Some(Format::Bin) => Some("bin"),
+        Some(Format::CueBin) => Some("cue"),
         Some(Format::Text) => Some("txt"),
         None => None,
     }

--- a/src/output/presentation_file.rs
+++ b/src/output/presentation_file.rs
@@ -194,6 +194,9 @@ enum SerializedSelect {
     Games,
     GamesWithoutParts,
     SingleDiscGames,
+    SingleDiscGamesByPlatform {
+        platform: SerializedPlatform,
+    },
     SingleDiscGamesByPlatformAndMedia {
         platform: SerializedPlatform,
         media: SerializedDiscMedia,
@@ -210,6 +213,9 @@ impl SerializedSelect {
             Self::Games => SelectSpec::Games,
             Self::GamesWithoutParts => SelectSpec::GamesWithoutParts,
             Self::SingleDiscGames => SelectSpec::SingleDiscGames,
+            Self::SingleDiscGamesByPlatform { platform } => SelectSpec::SingleDiscGamesByPlatform {
+                platform: platform.into(),
+            },
             Self::SingleDiscGamesByPlatformAndMedia { platform, media } => {
                 SelectSpec::SingleDiscGamesByPlatformAndMedia {
                     platform: platform.into(),
@@ -306,6 +312,7 @@ enum SerializedCapabilityFeature {
     Lossless,
     RandomAccess,
     SupportsPartial,
+    MultiFile,
 }
 
 impl From<SerializedCapabilityFeature> for CapabilityFeature {
@@ -316,6 +323,7 @@ impl From<SerializedCapabilityFeature> for CapabilityFeature {
             SerializedCapabilityFeature::Lossless => Self::Lossless,
             SerializedCapabilityFeature::RandomAccess => Self::RandomAccess,
             SerializedCapabilityFeature::SupportsPartial => Self::SupportsPartial,
+            SerializedCapabilityFeature::MultiFile => Self::MultiFile,
         }
     }
 }
@@ -357,6 +365,7 @@ enum SerializedFormat {
     M3u,
     Directory,
     Bin,
+    CueBin,
     Text,
 }
 
@@ -369,6 +378,7 @@ impl From<SerializedFormat> for Format {
             SerializedFormat::M3u => Self::M3u,
             SerializedFormat::Directory => Self::Directory,
             SerializedFormat::Bin => Self::Bin,
+            SerializedFormat::CueBin => Self::CueBin,
             SerializedFormat::Text => Self::Text,
         }
     }

--- a/src/output/presentation_spec.rs
+++ b/src/output/presentation_spec.rs
@@ -64,6 +64,9 @@ pub enum SelectSpec {
     /// Match games with exactly one disc part.
     SingleDiscGames,
 
+    /// Match a single-disc game for a specific platform.
+    SingleDiscGamesByPlatform { platform: Platform },
+
     /// Match a single-disc game for a specific platform and media kind.
     SingleDiscGamesByPlatformAndMedia {
         platform: Platform,

--- a/tests/presentation_compile_flat.rs
+++ b/tests/presentation_compile_flat.rs
@@ -160,6 +160,9 @@ mod flat_parity_tests {
             .map(|entry| match entry {
                 PlanEntry::File(file) => file.name.as_str(),
                 PlanEntry::Directory(_) => panic!("flat plan should contain only files"),
+                PlanEntry::ArtifactSet(_) => {
+                    panic!("this flat fixture should contain only files")
+                }
             })
             .collect();
         assert_eq!(actual, expected);

--- a/tests/presentation_compile_grouped.rs
+++ b/tests/presentation_compile_grouped.rs
@@ -324,6 +324,10 @@ mod grouped_parity_tests {
                     let path = format!("{parent}{}", file.name);
                     paths.push(path);
                 }
+                PlanEntry::ArtifactSet(set) => {
+                    let path = format!("{parent}{}/", set.directory_name);
+                    paths.push(path);
+                }
             }
         }
     }

--- a/tests/ps1_duckstation_integration.rs
+++ b/tests/ps1_duckstation_integration.rs
@@ -1,0 +1,130 @@
+use std::fs;
+use std::io::Write;
+
+use retromount::core::vfs_reader::open_vfs_file;
+use retromount::engine::mount::prepare_mount_session;
+use zip::write::SimpleFileOptions;
+
+const SYNC: [u8; 12] = [
+    0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00,
+];
+
+fn mode1_sector(fill: u8) -> Vec<u8> {
+    let mut sector = vec![0; 2352];
+    sector[..SYNC.len()].copy_from_slice(&SYNC);
+    sector[15] = 1;
+    sector[16..16 + 2048].fill(fill);
+    sector
+}
+
+fn read_file(session: &retromount::mount::session::MountSession, inode: u64) -> Vec<u8> {
+    let file = session.file(inode).expect("mounted file");
+    let mut reader = open_vfs_file(file).unwrap();
+    let mut bytes = vec![0; file.size as usize];
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let read = reader.read_at(offset as u64, &mut bytes[offset..]).unwrap();
+        if read == 0 {
+            break;
+        }
+        offset += read;
+    }
+    bytes.truncate(offset);
+    bytes
+}
+
+#[test]
+fn presents_mixed_mode_ps1_as_generated_cue_and_live_track_bins() {
+    let directory = tempfile::tempdir().unwrap();
+    let cue_path = directory.path().join("Game.cue");
+    fs::write(
+        &cue_path,
+        concat!(
+            "FILE \"Game.bin\" BINARY\n",
+            "  TRACK 01 MODE1/2352\n",
+            "    INDEX 01 00:00:00\n",
+            "  TRACK 02 AUDIO\n",
+            "    PREGAP 00:02:00\n",
+            "    INDEX 00 00:00:01\n",
+            "    INDEX 01 00:00:02\n",
+        ),
+    )
+    .unwrap();
+
+    let data = mode1_sector(0x31);
+    let file_backed_pregap = vec![0x42; 2352];
+    let audio = vec![0x53; 2352];
+    let mut source = data.clone();
+    source.extend_from_slice(&file_backed_pregap);
+    source.extend_from_slice(&audio);
+    fs::write(directory.path().join("Game.bin"), source).unwrap();
+
+    let session = prepare_mount_session(&cue_path, "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "Game")
+        .expect("game artifact-set directory");
+    let cue = session
+        .lookup_child(game.inode, "Game (Disc 1).cue")
+        .expect("generated CUE");
+    let track1 = session
+        .lookup_child(game.inode, "Game (Disc 1) (Track 01).bin")
+        .expect("data track BIN");
+    let track2 = session
+        .lookup_child(game.inode, "Game (Disc 1) (Track 02).bin")
+        .expect("audio track BIN");
+
+    assert_eq!(read_file(&session, track1.inode), data);
+    let mut expected_track2 = file_backed_pregap;
+    expected_track2.extend_from_slice(&audio);
+    assert_eq!(read_file(&session, track2.inode), expected_track2);
+    assert_eq!(
+        String::from_utf8(read_file(&session, cue.inode)).unwrap(),
+        concat!(
+            "FILE \"Game (Disc 1) (Track 01).bin\" BINARY\n",
+            "  TRACK 01 MODE1/2352\n",
+            "    INDEX 01 00:00:00\n",
+            "FILE \"Game (Disc 1) (Track 02).bin\" BINARY\n",
+            "  TRACK 02 AUDIO\n",
+            "    PREGAP 00:02:00\n",
+            "    INDEX 00 00:00:00\n",
+            "    INDEX 01 00:00:01\n",
+        )
+    );
+}
+
+#[test]
+fn presents_stored_zip_cue_bin_through_the_same_duckstation_path() {
+    let archive = tempfile::NamedTempFile::new().unwrap();
+    let sector = mode1_sector(0x67);
+    {
+        let mut zip = zip::ZipWriter::new(archive.reopen().unwrap());
+        let stored =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("Zip Game.cue", stored).unwrap();
+        zip.write_all(
+            b"FILE \"Zip Game.bin\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+        zip.start_file("Zip Game.bin", stored).unwrap();
+        zip.write_all(&sector).unwrap();
+        zip.finish().unwrap();
+    }
+    let zip_path = archive.path().with_extension("zip");
+    fs::copy(archive.path(), &zip_path).unwrap();
+
+    let session = prepare_mount_session(&zip_path, "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "Zip Game")
+        .expect("stored ZIP game directory");
+    let track = session
+        .lookup_child(game.inode, "Zip Game (Disc 1) (Track 01).bin")
+        .expect("stored ZIP track BIN");
+
+    assert_eq!(read_file(&session, track.inode), sector);
+}


### PR DESCRIPTION
## Summary

- refine canonical CD tracks to preserve complete encoded extents, track-relative indexes, and distinct file-backed versus declared pregaps
- add generic atomic multi-file artifact-set planning and materialization
- add a lossless, random-access CUE/BIN encoder that generates a relative CUE and exposes one live bounded BIN per track
- add platform-only single-disc presentation selection and the `cue_bin` / `multi_file` capability contract
- add the serialized built-in `duckstation` presentation under `PS1/<game>/`
- cover mixed data/audio discs, `INDEX 00`, `PREGAP`, filesystem input, and stored-ZIP input

## Behaviour

A supported single-disc PS1 CUE/BIN input is presented as:

```text
PS1/
└── Game/
    ├── Game (Disc 1).cue
    ├── Game (Disc 1) (Track 01).bin
    └── Game (Disc 1) (Track 02).bin
```

The generated CUE references sibling filenames only. BIN files preserve encoded sector bytes and are reader-backed bounded source ranges, so mixed-mode and audio content are not flattened into an ISO or copied into a whole-disc intermediate.

Existing OPL logical projection continues to begin at playable `INDEX 01` data and its PS2 CD integration coverage remains green.

## Scope

This implements roadmap item PS1-1. CHD input, SBI sidecars, multi-disc M3U, cooked ISO input, native CHD output, and the future OPL `POPS/` rule remain separately tracked follow-up increments.

Representative validation with a user-owned image in real DuckStation remains an operational follow-up and is documented in ADR-013.

## Validation

- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `markdownlint-cli2 README.md 'docs/**/*.md'`
- `git diff --check`