### PR TITLE
Decode PlayStation CHD CD tracks

### DIFF
--- a/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
+++ b/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
@@ -4,6 +4,8 @@
 
 Accepted
 
+PS1-1 and PS1-2 implemented
+
 ## Context
 
 The PlayStation 2 CD milestone introduced a live, track-aware `CdDisc` model
@@ -290,6 +292,18 @@ The first implementation does not add:
 
 These are deferred capabilities, not reasons to weaken the canonical CD model
 or the first CUE/BIN contract.
+
+## PS1-2 implementation note
+
+CHD CD metadata is now decoded into the same `CdDisc` contract as CUE/BIN.
+Each 2448-byte CHD CD frame is exposed as a live main-sector view plus, when
+declared, a separate 96-byte subchannel view. CHD-only four-frame track padding
+is excluded, while physical and synthetic pregaps remain distinct.
+
+The CUE/BIN output encoder deliberately rejects any track carrying subchannel
+content. This keeps PS1-2 lossless at the canonical boundary without pretending
+that CUE/BIN can represent LibCrypt or other subchannel information. SBI
+sidecar presentation remains PS1-3.
 
 ## Consequences
 

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -182,8 +182,10 @@ The `duckstation` contract is defined by
 [ADR-013](architecture/adr-013-ps1-duckstation-presentation-contract.md).
 Unlike OPL, it consumes the complete track-aware PS1 CD and produces one
 coherent artifact set containing a generated CUE and live per-track BIN files.
-The first implementation supports single-disc CUE/BIN input; the roadmap
-tracks CHD, SBI, multi-disc M3U, cooked ISO, and native CHD output separately.
+It supports single-disc CUE/BIN and CHD input. CHD tracks are projected live
+from their interleaved sectors; CHDs containing subchannel data fail closed
+because CUE/BIN cannot preserve it. The roadmap tracks SBI, multi-disc M3U,
+cooked ISO, and native CHD output separately.
 
 The PS1 roadmap also commits to extending the existing `opl` presentation with
 POPS support. The resulting PS2 library view will retain PS2 games below

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -210,7 +210,7 @@ Implement the first slice described above.
 
 #### PS1-2: CHD input
 
-**Status:** Planned
+**Status:** Implemented
 
 Decode CHD metadata, tracks, sectors, audio, pregaps, and available subchannel
 information into the canonical `CdDisc`. Present the result through the
@@ -218,6 +218,15 @@ DuckStation CUE/BIN view without flattening it to `LogicalDisc`.
 
 Acceptance requires mixed-mode and audio fixtures, bounded random access, and
 equivalent canonical semantics for matching CHD and CUE/BIN images.
+
+The implementation reads CD frames live through the existing bounded CHD hunk
+reader, removes CHD's 96-byte interleaved subchannel area and per-track
+four-frame padding from the main track views, and preserves declared versus
+file-backed pregaps. Available `RW` and `RW_RAW` subchannel bytes are retained
+as separate canonical track content. Because CUE/BIN cannot carry those bytes,
+the DuckStation CUE/BIN encoder fails closed for such a CHD. PS1-3 adds
+source-backed SBI sidecars separately; embedded CHD subchannel conversion or a
+subchannel-capable output must be specified before this case can be presented.
 
 #### PS1-3: SBI sidecars
 
@@ -311,7 +320,7 @@ presentation.
   or naming cannot be represented.
 * PS2 and unknown CDs do not match the DuckStation rule.
 * Multi-disc support remains deferred from this first implementation.
-* PS1-2 through PS1-7 remain visible as planned work after PS1-1 merges.
+* PS1-3 through PS1-7 remain visible as planned work after PS1-2 merges.
 
 ## Milestone 5: Performance, caching, and optimization
 

--- a/src/core/cd.rs
+++ b/src/core/cd.rs
@@ -17,6 +17,12 @@ pub enum CdSectorFormat {
     Audio2352,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum CdSubchannelFormat {
+    Normal,
+    Raw,
+}
+
 impl CdSectorFormat {
     pub fn encoded_sector_size(self) -> u32 {
         match self {
@@ -45,6 +51,8 @@ pub struct CdTrack {
     pub source_offset: u64,
     pub encoded_content: ReaderHandle,
     pub logical_content: Option<ReaderHandle>,
+    pub subchannel_content: Option<ReaderHandle>,
+    pub subchannel_format: Option<CdSubchannelFormat>,
     /// Index positions relative to the beginning of the preserved extent.
     pub indexes: Vec<CdIndex>,
     /// File-backed sectors between INDEX 00 and INDEX 01.
@@ -112,6 +120,8 @@ mod tests {
             source_offset: 0,
             encoded_content: handle("encoded"),
             logical_content: Some(handle("logical")),
+            subchannel_content: None,
+            subchannel_format: None,
             indexes: vec![CdIndex {
                 number: 1,
                 sector: 0,
@@ -124,6 +134,8 @@ mod tests {
             kind: CdTrackKind::Audio,
             sector_format: CdSectorFormat::Audio2352,
             logical_content: None,
+            subchannel_content: None,
+            subchannel_format: None,
             ..data.clone()
         };
 
@@ -151,6 +163,8 @@ mod tests {
             source_offset: 2352,
             encoded_content: handle("encoded"),
             logical_content: None,
+            subchannel_content: None,
+            subchannel_format: None,
             indexes: vec![
                 CdIndex {
                     number: 0,

--- a/src/input/chd_disc_decoder.rs
+++ b/src/input/chd_disc_decoder.rs
@@ -1,28 +1,47 @@
 use std::io;
 
-use chd::metadata::MetadataTag;
+use chd::metadata::{KnownMetadata, Metadata, MetadataTag};
 use chd::{Chd, Error as ChdError};
 
+use crate::core::cd::{CdDisc, CdIndex, CdSectorFormat, CdSubchannelFormat, CdTrack, CdTrackKind};
 use crate::core::content::{ContentId, DecodedContent, DecodedDiscContent, DiscMedia, LogicalDisc};
 use crate::core::input_content::InputContent;
 use crate::core::reader_cursor::ReaderCursor;
+use crate::core::reader_handle::ReaderHandle;
 use crate::core::source::SourceObject;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
 use crate::readers::chd_reader::ChdReader;
+use crate::readers::interleaved_sector_reader::InterleavedSectorReader;
 
 const DVD_METADATA_TAG: u32 = u32::from_be_bytes(*b"DVD ");
 const DVD_SECTOR_SIZE: u32 = 2048;
+const CD_FRAME_SIZE: u32 = 2448;
+const CD_DATA_SIZE: u32 = 2352;
+const CD_SUBCHANNEL_SIZE: u32 = 96;
+const CD_TRACK_PADDING: u64 = 4;
 
 #[derive(Debug, Default)]
 pub struct ChdDiscDecoder;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct ChdDiscInfo {
     has_parent: bool,
     has_dvd_metadata: bool,
     unit_bytes: u32,
     logical_bytes: u64,
+    cd_tracks: Vec<ChdTrackInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChdTrackInfo {
+    number: u8,
+    track_type: String,
+    subtype: String,
+    frames: u64,
+    pregap: u64,
+    pregap_in_data: bool,
+    postgap: u64,
 }
 
 impl ChdDiscDecoder {
@@ -37,15 +56,29 @@ impl ChdDiscDecoder {
         let has_parent = header.has_parent();
         let unit_bytes = header.unit_bytes();
         let logical_bytes = header.logical_bytes();
-        let has_dvd_metadata = chd
-            .metadata_refs()
+        let metadata = Vec::<Metadata>::try_from(chd.metadata_refs())
+            .map_err(|error| map_chd_metadata_error(error, "failed to read CHD metadata"))?;
+        let has_dvd_metadata = metadata
+            .iter()
             .any(|metadata| metadata.metatag() == DVD_METADATA_TAG);
+        let cd_tracks = metadata
+            .iter()
+            .filter(|metadata| {
+                matches!(
+                    metadata.metatag(),
+                    tag if tag == KnownMetadata::CdRomTrack.metatag()
+                        || tag == KnownMetadata::CdRomTrack2.metatag()
+                )
+            })
+            .map(parse_cd_track_metadata)
+            .collect::<io::Result<Vec<_>>>()?;
 
         Ok(ChdDiscInfo {
             has_parent,
             has_dvd_metadata,
             unit_bytes,
             logical_bytes,
+            cd_tracks,
         })
     }
 
@@ -89,6 +122,285 @@ impl ChdDiscDecoder {
             ),
         })
     }
+
+    fn cd_disc(
+        content: &InputContent,
+        source: &crate::core::source::SourceRef,
+        info: &ChdDiscInfo,
+    ) -> io::Result<CdDisc> {
+        if info.has_parent {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "parent/delta CHDs are not supported",
+            ));
+        }
+        if info.cd_tracks.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "CHD does not describe CD media",
+            ));
+        }
+        if info.unit_bytes != CD_FRAME_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "CD CHD unit size must be {CD_FRAME_SIZE} bytes, found {}",
+                    info.unit_bytes
+                ),
+            ));
+        }
+
+        let mut chd_frame_offset = 0_u64;
+        let mut tracks = Vec::with_capacity(info.cd_tracks.len());
+        let mut previous_track_number = None;
+        for track in &info.cd_tracks {
+            if previous_track_number.is_some_and(|number| track.number <= number) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "CHD CD track numbers must be strictly increasing",
+                ));
+            }
+            previous_track_number = Some(track.number);
+            if track.postgap != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!(
+                        "CHD track {:02} has a postgap that the canonical CD model cannot preserve",
+                        track.number
+                    ),
+                ));
+            }
+            let (kind, sector_format, data_size) = chd_track_format(&track.track_type)?;
+            let subchannel_format = chd_subchannel_format(&track.subtype)?;
+            let (extent_offset, sector_count, file_backed_pregap, declared_pregap) =
+                if track.pregap_in_data {
+                    (chd_frame_offset, track.frames, track.pregap, 0)
+                } else {
+                    (
+                        chd_frame_offset,
+                        track.frames.checked_sub(track.pregap).ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "CHD track {:02} pregap exceeds its frame count",
+                                    track.number
+                                ),
+                            )
+                        })?,
+                        0,
+                        track.pregap,
+                    )
+                };
+            if sector_count == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("CHD track {:02} has no encoded sectors", track.number),
+                ));
+            }
+
+            let encoded_content = chd_sector_handle(
+                content,
+                extent_offset,
+                sector_count,
+                0,
+                data_size,
+                format!("track-{:02}", track.number),
+            );
+            let subchannel_content = subchannel_format.map(|_| {
+                chd_sector_handle(
+                    content,
+                    extent_offset,
+                    sector_count,
+                    CD_DATA_SIZE,
+                    CD_SUBCHANNEL_SIZE,
+                    format!("track-{:02}-subchannel", track.number),
+                )
+            });
+            let indexes = if file_backed_pregap > 0 {
+                vec![
+                    CdIndex {
+                        number: 0,
+                        sector: 0,
+                    },
+                    CdIndex {
+                        number: 1,
+                        sector: file_backed_pregap,
+                    },
+                ]
+            } else {
+                vec![CdIndex {
+                    number: 1,
+                    sector: 0,
+                }]
+            };
+            tracks.push(CdTrack {
+                number: track.number,
+                kind,
+                sector_format,
+                sector_count,
+                source: source.clone(),
+                source_offset: 0,
+                encoded_content,
+                logical_content: None,
+                subchannel_content,
+                subchannel_format,
+                indexes,
+                file_backed_pregap_sectors: file_backed_pregap,
+                declared_pregap_sectors: declared_pregap,
+            });
+
+            chd_frame_offset = chd_frame_offset
+                .checked_add(round_up(track.frames, CD_TRACK_PADDING)?)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "CHD track offset overflow")
+                })?;
+        }
+
+        let required_bytes = chd_frame_offset
+            .checked_mul(u64::from(CD_FRAME_SIZE))
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CHD CD size overflow"))?;
+        if required_bytes > info.logical_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "CHD CD track metadata exceeds its logical content",
+            ));
+        }
+
+        Ok(CdDisc { tracks })
+    }
+}
+
+fn map_chd_metadata_error(error: ChdError, context: &str) -> io::Error {
+    let mapped = map_chd_open_error(error);
+    io::Error::new(mapped.kind(), format!("{context}: {mapped}"))
+}
+
+fn parse_cd_track_metadata(metadata: &Metadata) -> io::Result<ChdTrackInfo> {
+    let text = std::str::from_utf8(&metadata.value)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "CHD CD metadata is not UTF-8"))?
+        .trim_end_matches('\0');
+    let mut values = std::collections::HashMap::new();
+    for field in text.split_whitespace() {
+        let Some((key, value)) = field.split_once(':') else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("malformed CHD CD metadata field '{field}'"),
+            ));
+        };
+        values.insert(key, value);
+    }
+    let parse_number = |key: &str| -> io::Result<u64> {
+        values
+            .get(key)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("CHD CD metadata is missing {key}"),
+                )
+            })?
+            .parse()
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("CHD CD metadata has invalid {key}"),
+                )
+            })
+    };
+    let number = u8::try_from(parse_number("TRACK")?).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "CHD CD track number is out of range",
+        )
+    })?;
+    let frames = parse_number("FRAMES")?;
+    if number == 0 || frames == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "CHD CD track number and frame count must be non-zero",
+        ));
+    }
+    let pregap = values
+        .get("PREGAP")
+        .map(|_| parse_number("PREGAP"))
+        .transpose()?
+        .unwrap_or(0);
+    let postgap = values
+        .get("POSTGAP")
+        .map(|_| parse_number("POSTGAP"))
+        .transpose()?
+        .unwrap_or(0);
+    let pregap_type = values.get("PGTYPE").copied().unwrap_or("NONE");
+
+    Ok(ChdTrackInfo {
+        number,
+        track_type: values
+            .get("TYPE")
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "CHD CD metadata is missing TYPE",
+                )
+            })?
+            .to_string(),
+        subtype: values.get("SUBTYPE").copied().unwrap_or("NONE").to_string(),
+        frames,
+        pregap,
+        pregap_in_data: pregap > 0 && pregap_type.starts_with('V'),
+        postgap,
+    })
+}
+
+fn chd_track_format(track_type: &str) -> io::Result<(CdTrackKind, CdSectorFormat, u32)> {
+    match track_type {
+        "MODE1" => Ok((CdTrackKind::Data, CdSectorFormat::Mode1_2048, 2048)),
+        "MODE1_RAW" => Ok((CdTrackKind::Data, CdSectorFormat::Mode1_2352, 2352)),
+        "MODE2_RAW" => Ok((CdTrackKind::Data, CdSectorFormat::Mode2_2352, 2352)),
+        "AUDIO" => Ok((CdTrackKind::Audio, CdSectorFormat::Audio2352, 2352)),
+        _ => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("unsupported CHD CD track type '{track_type}'"),
+        )),
+    }
+}
+
+fn chd_subchannel_format(subtype: &str) -> io::Result<Option<CdSubchannelFormat>> {
+    match subtype {
+        "NONE" => Ok(None),
+        "RW" => Ok(Some(CdSubchannelFormat::Normal)),
+        "RW_RAW" => Ok(Some(CdSubchannelFormat::Raw)),
+        _ => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("unsupported CHD CD subchannel type '{subtype}'"),
+        )),
+    }
+}
+
+fn chd_sector_handle(
+    content: &InputContent,
+    frame_offset: u64,
+    sector_count: u64,
+    output_offset: u32,
+    output_size: u32,
+    suffix: String,
+) -> ReaderHandle {
+    let source = content.handle.clone();
+    ReaderHandle::new(format!("chd:{}:{suffix}", content.handle.id()), move || {
+        Ok(Box::new(InterleavedSectorReader::new(
+            Box::new(ChdReader::open(&source)?),
+            frame_offset * u64::from(CD_FRAME_SIZE),
+            sector_count,
+            u64::from(CD_FRAME_SIZE),
+            u64::from(output_offset),
+            u64::from(output_size),
+        )?))
+    })
+}
+
+fn round_up(value: u64, multiple: u64) -> io::Result<u64> {
+    value
+        .checked_add(multiple - 1)
+        .map(|value| value / multiple * multiple)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CHD track padding overflow"))
 }
 
 fn map_chd_open_error(error: ChdError) -> io::Error {
@@ -122,7 +434,17 @@ impl InputDecoder for ChdDiscDecoder {
             return Ok(Vec::new());
         }
 
-        let logical_disc = Self::logical_disc(&object.content, Self::inspect(&object.content)?)?;
+        let info = Self::inspect(&object.content)?;
+        let (cd_disc, logical_disc) = if info.has_dvd_metadata {
+            (None, Some(Self::logical_disc(&object.content, info)?))
+        } else if !info.cd_tracks.is_empty() {
+            (
+                Some(Self::cd_disc(&object.content, &object.source, &info)?),
+                None,
+            )
+        } else {
+            (None, Some(Self::logical_disc(&object.content, info)?))
+        };
         let title = std::path::Path::new(&object.name)
             .file_stem()
             .and_then(|stem| stem.to_str())
@@ -135,8 +457,8 @@ impl InputDecoder for ChdDiscDecoder {
             title,
             disc_number: 1,
             consumed_sources: Vec::new(),
-            cd_disc: None,
-            logical_disc: Some(logical_disc),
+            cd_disc,
+            logical_disc,
         })])
     }
 }
@@ -146,6 +468,7 @@ mod tests {
     use super::*;
     use crate::core::input_content::{InputAccess, InputContent};
     use crate::core::reader_handle::ReaderHandle;
+    use crate::core::source::SourceRef;
     use crate::readers::inline_reader::InlineReader;
 
     fn test_content() -> InputContent {
@@ -162,6 +485,7 @@ mod tests {
             has_dvd_metadata: true,
             unit_bytes: DVD_SECTOR_SIZE,
             logical_bytes: u64::from(DVD_SECTOR_SIZE) * 3,
+            cd_tracks: Vec::new(),
         }
     }
 
@@ -240,5 +564,71 @@ mod tests {
             map_chd_open_error(ChdError::RequiresParent).kind(),
             io::ErrorKind::Unsupported
         );
+    }
+
+    #[test]
+    fn parses_modern_cd_track_metadata_and_valid_pregaps() {
+        let metadata = Metadata {
+            metatag: KnownMetadata::CdRomTrack2.metatag(),
+            value: b"TRACK:2 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:452 PREGAP:150 PGTYPE:VAUDIO PGSUB:NONE POSTGAP:0\0".to_vec(),
+            flags: 0,
+            index: 1,
+            length: 0,
+        };
+
+        let track = parse_cd_track_metadata(&metadata).unwrap();
+
+        assert_eq!(track.number, 2);
+        assert_eq!(track.track_type, "AUDIO");
+        assert_eq!(track.subtype, "RW_RAW");
+        assert_eq!(track.frames, 452);
+        assert_eq!(track.pregap, 150);
+        assert!(track.pregap_in_data);
+    }
+
+    #[test]
+    fn maps_cd_tracks_and_skips_internal_track_padding() {
+        let info = ChdDiscInfo {
+            has_parent: false,
+            has_dvd_metadata: false,
+            unit_bytes: CD_FRAME_SIZE,
+            logical_bytes: u64::from(CD_FRAME_SIZE) * 12,
+            cd_tracks: vec![
+                ChdTrackInfo {
+                    number: 1,
+                    track_type: "MODE2_RAW".to_string(),
+                    subtype: "NONE".to_string(),
+                    frames: 5,
+                    pregap: 0,
+                    pregap_in_data: false,
+                    postgap: 0,
+                },
+                ChdTrackInfo {
+                    number: 2,
+                    track_type: "AUDIO".to_string(),
+                    subtype: "RW_RAW".to_string(),
+                    frames: 4,
+                    pregap: 1,
+                    pregap_in_data: true,
+                    postgap: 0,
+                },
+            ],
+        };
+
+        let disc =
+            ChdDiscDecoder::cd_disc(&test_content(), &SourceRef::new("file:game.chd"), &info)
+                .unwrap();
+
+        assert_eq!(disc.tracks.len(), 2);
+        assert_eq!(disc.tracks[0].sector_count, 5);
+        assert_eq!(disc.tracks[1].sector_count, 4);
+        assert_eq!(disc.tracks[1].file_backed_pregap_sectors, 1);
+        assert_eq!(disc.tracks[1].index_one_sector(), Some(1));
+        assert_eq!(
+            disc.tracks[1].subchannel_format,
+            Some(CdSubchannelFormat::Raw)
+        );
+        assert!(disc.tracks[1].subchannel_content.is_some());
+        assert!(disc.tracks[1].encoded_content.id().contains("track-02"));
     }
 }

--- a/src/input/cue_disc_decoder.rs
+++ b/src/input/cue_disc_decoder.rs
@@ -233,6 +233,8 @@ fn build_track(
         source_offset,
         encoded_content: content.handle,
         logical_content,
+        subchannel_content: None,
+        subchannel_format: None,
         indexes: entry
             .indexes
             .iter()

--- a/src/output/cue_bin_encoder.rs
+++ b/src/output/cue_bin_encoder.rs
@@ -136,6 +136,15 @@ impl OutputEncoder for CueBinEncoder {
 }
 
 fn validate_track(track: &CdTrack) -> io::Result<()> {
+    if track.subchannel_content.is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "CD track {:02} contains subchannel data that CUE/BIN output cannot preserve",
+                track.number
+            ),
+        ));
+    }
     let index_one = track.index_one_sector().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidData,

--- a/src/readers/interleaved_sector_reader.rs
+++ b/src/readers/interleaved_sector_reader.rs
@@ -1,0 +1,103 @@
+use std::io;
+
+use crate::core::reader::Reader;
+
+pub struct InterleavedSectorReader {
+    source: Box<dyn Reader>,
+    source_offset: u64,
+    sector_count: u64,
+    input_sector_size: u64,
+    output_offset: u64,
+    output_sector_size: u64,
+}
+
+impl InterleavedSectorReader {
+    pub fn new(
+        source: Box<dyn Reader>,
+        source_offset: u64,
+        sector_count: u64,
+        input_sector_size: u64,
+        output_offset: u64,
+        output_sector_size: u64,
+    ) -> io::Result<Self> {
+        let output_end = output_offset
+            .checked_add(output_sector_size)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "sector range overflow"))?;
+        if input_sector_size == 0 || output_sector_size == 0 || output_end > input_sector_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid interleaved sector geometry",
+            ));
+        }
+        let source_len = sector_count
+            .checked_mul(input_sector_size)
+            .and_then(|length| source_offset.checked_add(length))
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "sector range overflow"))?;
+        if source_len > source.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "interleaved sector range extends past its source",
+            ));
+        }
+        Ok(Self {
+            source,
+            source_offset,
+            sector_count,
+            input_sector_size,
+            output_offset,
+            output_sector_size,
+        })
+    }
+}
+
+impl Reader for InterleavedSectorReader {
+    fn read_at(&mut self, offset: u64, buffer: &mut [u8]) -> io::Result<usize> {
+        let length = self.len();
+        if buffer.is_empty() || offset >= length {
+            return Ok(0);
+        }
+
+        let requested = buffer
+            .len()
+            .min(usize::try_from(length - offset).unwrap_or(usize::MAX));
+        let mut written = 0;
+        while written < requested {
+            let logical_offset = offset + written as u64;
+            let sector = logical_offset / self.output_sector_size;
+            let within = logical_offset % self.output_sector_size;
+            let count = (requested - written)
+                .min(usize::try_from(self.output_sector_size - within).unwrap_or(usize::MAX));
+            let source_offset =
+                self.source_offset + sector * self.input_sector_size + self.output_offset + within;
+            let read = self
+                .source
+                .read_at(source_offset, &mut buffer[written..written + count])?;
+            written += read;
+            if read < count {
+                break;
+            }
+        }
+        Ok(written)
+    }
+
+    fn len(&self) -> u64 {
+        self.sector_count * self.output_sector_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::readers::inline_reader::InlineReader;
+
+    #[test]
+    fn projects_unaligned_reads_across_interleaved_sectors() {
+        let source = InlineReader::new(b"abcdXYefghZZ".to_vec());
+        let mut reader = InterleavedSectorReader::new(Box::new(source), 0, 2, 6, 0, 4).unwrap();
+        let mut output = [0; 6];
+
+        assert_eq!(reader.read_at(2, &mut output).unwrap(), 6);
+        assert_eq!(&output, b"cdefgh");
+        assert_eq!(reader.len(), 8);
+    }
+}

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -1,6 +1,7 @@
 pub mod chd_reader;
 pub mod dir_reader;
 pub mod inline_reader;
+pub mod interleaved_sector_reader;
 pub mod range_reader;
 pub mod raw_cd_sector_reader;
 pub mod zip_reader;

--- a/tests/ps1_duckstation_integration.rs
+++ b/tests/ps1_duckstation_integration.rs
@@ -128,3 +128,124 @@ fn presents_stored_zip_cue_bin_through_the_same_duckstation_path() {
 
     assert_eq!(read_file(&session, track.inode), sector);
 }
+
+#[test]
+fn presents_a_mixed_mode_ps1_chd_through_the_duckstation_cue_bin_view() {
+    let directory = tempfile::tempdir().unwrap();
+    let chd_path = directory.path().join("CHD Game.chd");
+    fs::write(&chd_path, cd_chd_fixture(false)).unwrap();
+
+    let session = prepare_mount_session(&chd_path, "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "CHD Game")
+        .expect("CHD game directory");
+    let track1 = session
+        .lookup_child(game.inode, "CHD Game (Disc 1) (Track 01).bin")
+        .expect("CHD data track");
+    let track2 = session
+        .lookup_child(game.inode, "CHD Game (Disc 1) (Track 02).bin")
+        .expect("CHD audio track");
+
+    assert_eq!(
+        read_file(&session, track1.inode),
+        expected_chd_track_bytes(0, 4)
+    );
+    assert_eq!(
+        read_file(&session, track2.inode),
+        expected_chd_track_bytes(4, 4)
+    );
+}
+
+#[test]
+fn rejects_chd_subchannel_data_that_cue_bin_cannot_preserve() {
+    let directory = tempfile::tempdir().unwrap();
+    let chd_path = directory.path().join("Protected.chd");
+    fs::write(&chd_path, cd_chd_fixture(true)).unwrap();
+
+    let error = prepare_mount_session(&chd_path, "duckstation").unwrap_err();
+
+    assert!(error.to_string().contains("subchannel data"));
+}
+
+fn cd_chd_fixture(with_subchannel: bool) -> Vec<u8> {
+    const HEADER_SIZE: usize = 124;
+    const FRAME_SIZE: usize = 2448;
+    const FRAMES_PER_HUNK: usize = 4;
+    const HUNK_SIZE: usize = FRAME_SIZE * FRAMES_PER_HUNK;
+    const HUNK_COUNT: usize = 2;
+    const MAP_OFFSET: usize = HEADER_SIZE;
+    const METADATA_OFFSET: usize = MAP_OFFSET + HUNK_COUNT * 4;
+    const DATA_OFFSET: usize = HUNK_SIZE;
+
+    let subtype = if with_subchannel { "RW_RAW" } else { "NONE" };
+    let metadata = [
+        format!(
+            "TRACK:1 TYPE:MODE2_RAW SUBTYPE:{subtype} FRAMES:4 PREGAP:0 PGTYPE:MODE1 PGSUB:NONE POSTGAP:0\0"
+        )
+        .into_bytes(),
+        b"TRACK:2 TYPE:AUDIO SUBTYPE:NONE FRAMES:4 PREGAP:1 PGTYPE:VAUDIO PGSUB:NONE POSTGAP:0\0"
+            .to_vec(),
+    ];
+    let first_next = METADATA_OFFSET + 16 + metadata[0].len();
+
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"MComprHD");
+    push_u32(&mut bytes, HEADER_SIZE as u32);
+    push_u32(&mut bytes, 5);
+    for _ in 0..4 {
+        push_u32(&mut bytes, 0);
+    }
+    push_u64(&mut bytes, (HUNK_SIZE * HUNK_COUNT) as u64);
+    push_u64(&mut bytes, MAP_OFFSET as u64);
+    push_u64(&mut bytes, METADATA_OFFSET as u64);
+    push_u32(&mut bytes, HUNK_SIZE as u32);
+    push_u32(&mut bytes, FRAME_SIZE as u32);
+    bytes.resize(HEADER_SIZE, 0);
+
+    for hunk in 0..HUNK_COUNT {
+        push_u32(&mut bytes, (DATA_OFFSET / HUNK_SIZE + hunk) as u32);
+    }
+    push_metadata(&mut bytes, *b"CHT2", &metadata[0], first_next as u64);
+    push_metadata(&mut bytes, *b"CHT2", &metadata[1], 0);
+    bytes.resize(DATA_OFFSET, 0);
+
+    for frame in 0..HUNK_COUNT * FRAMES_PER_HUNK {
+        bytes.extend((0..2352).map(|offset| chd_sector_byte(frame, offset)));
+        bytes.extend((0..96).map(|offset| {
+            if with_subchannel && frame < 4 {
+                (offset as u8).wrapping_add(1)
+            } else {
+                0
+            }
+        }));
+    }
+    bytes
+}
+
+fn expected_chd_track_bytes(start_frame: usize, frames: usize) -> Vec<u8> {
+    (start_frame..start_frame + frames)
+        .flat_map(|frame| (0..2352).map(move |offset| chd_sector_byte(frame, offset)))
+        .collect()
+}
+
+fn chd_sector_byte(frame: usize, offset: usize) -> u8 {
+    ((frame * 13 + offset * 7 + 5) % 251) as u8
+}
+
+fn push_metadata(bytes: &mut Vec<u8>, tag: [u8; 4], value: &[u8], next: u64) {
+    bytes.extend_from_slice(&tag);
+    push_u32(bytes, value.len() as u32);
+    push_u64(bytes, next);
+    bytes.extend_from_slice(value);
+}
+
+fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend_from_slice(&value.to_be_bytes());
+}
+
+fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+    bytes.extend_from_slice(&value.to_be_bytes());
+}


### PR DESCRIPTION
## What changed

- decode CHD CD metadata into the canonical track-aware `CdDisc`
- expose live main-sector and optional subchannel views while skipping CHD track padding
- preserve mixed-mode data/audio tracks and declared versus file-backed pregaps
- present lossless CHDs through the existing DuckStation CUE/BIN view
- fail closed when embedded subchannel data cannot be represented by CUE/BIN
- mark PS1-2 implemented and document the remaining SBI boundary

## Why

PS1 CHDs must retain track, audio, timing, and subchannel semantics rather than being flattened into a 2048-byte logical disc. This reuses the live-content and bounded CHD hunk-reading architecture established by earlier slices.

## Validation

- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `markdownlint-cli2 'README.md' 'docs/**/*.md'`