### PR TITLE
Preserve PlayStation SBI sidecars

### DIFF
--- a/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
+++ b/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
@@ -4,7 +4,7 @@
 
 Accepted
 
-PS1-1 and PS1-2 implemented
+PS1-1 through PS1-3 implemented
 
 ## Context
 
@@ -304,6 +304,21 @@ The CUE/BIN output encoder deliberately rejects any track carrying subchannel
 content. This keeps PS1-2 lossless at the canonical boundary without pretending
 that CUE/BIN can represent LibCrypt or other subchannel information. SBI
 sidecar presentation remains PS1-3.
+
+## PS1-3 implementation note
+
+SBI is modeled as optional disc-level auxiliary content. CUE and CHD decoders
+look only for a sibling whose stem matches the disc input case-insensitively;
+unrelated SBI files are not claimed, and multiple matching names are rejected
+as ambiguous. The selected sidecar is validated as an `SBI\0` header followed
+by complete 14-byte type-1 SubQ records, then retained through a live reader
+handle and marked as consumed input.
+
+The CUE/BIN encoder includes that reader in the same atomic artifact set as the
+generated CUE and track BINs. Its output name is derived from the artifact
+basename rather than copied from the source, guaranteeing the adjacency and
+same-basename convention expected by DuckStation for both filesystem and
+stored-ZIP sources.
 
 ## Consequences
 

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -184,8 +184,9 @@ Unlike OPL, it consumes the complete track-aware PS1 CD and produces one
 coherent artifact set containing a generated CUE and live per-track BIN files.
 It supports single-disc CUE/BIN and CHD input. CHD tracks are projected live
 from their interleaved sectors; CHDs containing subchannel data fail closed
-because CUE/BIN cannot preserve it. The roadmap tracks SBI, multi-disc M3U,
-cooked ISO, and native CHD output separately.
+because CUE/BIN cannot preserve it. A valid same-stem SBI sibling is preserved
+live beside the generated CUE under the generated basename. The roadmap tracks
+multi-disc M3U, cooked ISO, and native CHD output separately.
 
 The PS1 roadmap also commits to extending the existing `opl` presentation with
 POPS support. The resulting PS2 library view will retain PS2 games below

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -230,7 +230,7 @@ subchannel-capable output must be specified before this case can be presented.
 
 #### PS1-3: SBI sidecars
 
-**Status:** Planned
+**Status:** Implemented
 
 Resolve and preserve optional source-backed SBI sidecars. Couple the output
 basename to the presented disc basename and reject ambiguous or mismatched
@@ -239,6 +239,13 @@ sidecars.
 Acceptance requires filesystem and supported ZIP-backed sidecars, byte-exact
 live reads, and a DuckStation layout in which the SBI is adjacent to its disc
 entry with the same basename.
+
+The implementation discovers one case-insensitive, same-stem `.sbi` sibling
+for CUE or CHD input, validates its `SBI\0` header and complete type-1 SubQ
+records, and attaches its live content to the canonical CD. Multiple matching
+siblings fail as ambiguous. The DuckStation CUE/BIN artifact set emits the
+sidecar adjacent to the generated CUE using the generated disc basename, and
+the original SBI source is suppressed as consumed input.
 
 #### PS1-4: Multi-disc M3U
 
@@ -320,7 +327,7 @@ presentation.
   or naming cannot be represented.
 * PS2 and unknown CDs do not match the DuckStation rule.
 * Multi-disc support remains deferred from this first implementation.
-* PS1-3 through PS1-7 remain visible as planned work after PS1-2 merges.
+* PS1-4 through PS1-7 remain visible as planned work after PS1-3 merges.
 
 ## Milestone 5: Performance, caching, and optimization
 

--- a/src/core/cd.rs
+++ b/src/core/cd.rs
@@ -23,6 +23,13 @@ pub enum CdSubchannelFormat {
     Raw,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CdSbi {
+    pub source: SourceRef,
+    pub size: u64,
+    pub content: ReaderHandle,
+}
+
 impl CdSectorFormat {
     pub fn encoded_sector_size(self) -> u32 {
         match self {
@@ -86,6 +93,7 @@ impl CdTrack {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CdDisc {
     pub tracks: Vec<CdTrack>,
+    pub sbi: Option<CdSbi>,
 }
 
 impl CdDisc {
@@ -140,16 +148,23 @@ mod tests {
         };
 
         assert!(CdDisc {
-            tracks: vec![data.clone()]
+            tracks: vec![data.clone()],
+            sbi: None,
         }
         .opl_logical_track()
         .is_some());
         assert!(CdDisc {
-            tracks: vec![data.clone(), audio]
+            tracks: vec![data.clone(), audio],
+            sbi: None,
         }
         .opl_logical_track()
         .is_none());
-        assert!(CdDisc { tracks: vec![] }.opl_logical_track().is_none());
+        assert!(CdDisc {
+            tracks: vec![],
+            sbi: None,
+        }
+        .opl_logical_track()
+        .is_none());
     }
 
     #[test]

--- a/src/input/chd_disc_decoder.rs
+++ b/src/input/chd_disc_decoder.rs
@@ -11,6 +11,7 @@ use crate::core::reader_handle::ReaderHandle;
 use crate::core::source::SourceObject;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
+use crate::input::sbi_sidecar::discover_sbi_sidecar;
 use crate::readers::chd_reader::ChdReader;
 use crate::readers::interleaved_sector_reader::InterleavedSectorReader;
 
@@ -266,7 +267,7 @@ impl ChdDiscDecoder {
             ));
         }
 
-        Ok(CdDisc { tracks })
+        Ok(CdDisc { tracks, sbi: None })
     }
 }
 
@@ -435,7 +436,7 @@ impl InputDecoder for ChdDiscDecoder {
         }
 
         let info = Self::inspect(&object.content)?;
-        let (cd_disc, logical_disc) = if info.has_dvd_metadata {
+        let (mut cd_disc, logical_disc) = if info.has_dvd_metadata {
             (None, Some(Self::logical_disc(&object.content, info)?))
         } else if !info.cd_tracks.is_empty() {
             (
@@ -445,18 +446,27 @@ impl InputDecoder for ChdDiscDecoder {
         } else {
             (None, Some(Self::logical_disc(&object.content, info)?))
         };
+        if let Some(cd_disc) = &mut cd_disc {
+            cd_disc.sbi = discover_sbi_sidecar(object)?;
+        }
         let title = std::path::Path::new(&object.name)
             .file_stem()
             .and_then(|stem| stem.to_str())
             .unwrap_or(&object.name)
             .to_string();
 
+        let consumed_sources = cd_disc
+            .as_ref()
+            .and_then(|disc| disc.sbi.as_ref())
+            .map(|sbi| vec![sbi.source.clone()])
+            .unwrap_or_default();
+
         Ok(vec![DecodedContent::Disc(DecodedDiscContent {
             id: ContentId::new(object.name.clone()),
             source: object.source.clone(),
             title,
             disc_number: 1,
-            consumed_sources: Vec::new(),
+            consumed_sources,
             cd_disc,
             logical_disc,
         })])

--- a/src/input/cue_disc_decoder.rs
+++ b/src/input/cue_disc_decoder.rs
@@ -10,6 +10,7 @@ use crate::core::source::{SourceObject, SourceRef};
 use crate::core::source_resolver::resolve_source_ref;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
+use crate::input::sbi_sidecar::discover_sbi_sidecar;
 use crate::readers::range_reader::RangeReader;
 use crate::readers::raw_cd_sector_reader::{
     validate_raw_cd_track, RawCdDataMode, RawCdSectorReader,
@@ -88,7 +89,7 @@ impl CueDiscDecoder {
             }
         }
 
-        Ok(CdDisc { tracks })
+        Ok(CdDisc { tracks, sbi: None })
     }
 }
 
@@ -106,7 +107,8 @@ impl InputDecoder for CueDiscDecoder {
             return Ok(Vec::new());
         }
 
-        let cd_disc = Self::decode_cd(object)?;
+        let mut cd_disc = Self::decode_cd(object)?;
+        cd_disc.sbi = discover_sbi_sidecar(object)?;
         let logical_disc = cd_disc.opl_logical_track().map(|track| LogicalDisc {
             media: DiscMedia::Cd,
             sector_size: 2048,
@@ -129,7 +131,10 @@ impl InputDecoder for CueDiscDecoder {
             .and_then(|stem| stem.to_str())
             .unwrap_or(&object.name)
             .to_string();
-        let consumed_sources = unique_track_sources(&cd_disc);
+        let mut consumed_sources = unique_track_sources(&cd_disc);
+        if let Some(sbi) = &cd_disc.sbi {
+            consumed_sources.push(sbi.source.clone());
+        }
 
         Ok(vec![DecodedContent::Disc(DecodedDiscContent {
             id: ContentId::new(object.name.clone()),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -8,5 +8,6 @@ pub mod directory_source;
 pub mod file_source;
 pub mod identify;
 pub mod iso_disc_decoder;
+pub mod sbi_sidecar;
 pub mod source;
 pub mod zip_source;

--- a/src/input/sbi_sidecar.rs
+++ b/src/input/sbi_sidecar.rs
@@ -1,0 +1,162 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::core::cd::CdSbi;
+use crate::core::source::{SourceObject, SourceOrigin, SourceRef};
+use crate::core::source_resolver::resolve_source_ref;
+
+const SBI_HEADER: &[u8; 4] = b"SBI\0";
+const SBI_RECORD_SIZE: u64 = 14;
+
+pub fn discover_sbi_sidecar(object: &SourceObject) -> io::Result<Option<CdSbi>> {
+    let candidates = match &object.origin {
+        SourceOrigin::Filesystem(path) => filesystem_candidates(path)?,
+        SourceOrigin::ZipEntry {
+            archive_path,
+            entry_name,
+        } => zip_candidates(archive_path, entry_name)?,
+    };
+
+    let source = match candidates.as_slice() {
+        [] => return Ok(None),
+        [source] => source.clone(),
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("disc '{}' has multiple matching SBI sidecars", object.name),
+            ));
+        }
+    };
+    let content = resolve_source_ref(&source)?;
+    validate_sbi(&source, &content)?;
+
+    Ok(Some(CdSbi {
+        source,
+        size: content.size,
+        content: content.handle,
+    }))
+}
+
+fn filesystem_candidates(path: &Path) -> io::Result<Vec<SourceRef>> {
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return Ok(Vec::new());
+    };
+    let directory = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut candidates = Vec::new();
+    for entry in std::fs::read_dir(directory)? {
+        let candidate = entry?.path();
+        if candidate.is_file() && matches_sbi_stem(&candidate, stem) {
+            candidates.push(SourceRef::new(candidate.to_string_lossy().into_owned()));
+        }
+    }
+    candidates.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(candidates)
+}
+
+fn zip_candidates(archive_path: &Path, entry_name: &str) -> io::Result<Vec<SourceRef>> {
+    let disc_path = Path::new(entry_name);
+    let Some(stem) = disc_path.file_stem().and_then(|stem| stem.to_str()) else {
+        return Ok(Vec::new());
+    };
+    let directory = disc_path.parent().unwrap_or_else(|| Path::new(""));
+    let file = std::fs::File::open(archive_path)?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let mut candidates = Vec::new();
+    for index in 0..archive.len() {
+        let entry = archive
+            .by_index(index)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        if entry.is_dir() {
+            continue;
+        }
+        let candidate = PathBuf::from(entry.name());
+        if candidate.parent().unwrap_or_else(|| Path::new("")) == directory
+            && matches_sbi_stem(&candidate, stem)
+        {
+            candidates.push(SourceRef::new(format!(
+                "zip:{}#{}",
+                archive_path.to_string_lossy(),
+                entry.name()
+            )));
+        }
+    }
+    candidates.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(candidates)
+}
+
+fn matches_sbi_stem(path: &Path, expected_stem: &str) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("sbi"))
+        && path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| stem.eq_ignore_ascii_case(expected_stem))
+}
+
+fn validate_sbi(
+    source: &SourceRef,
+    content: &crate::core::input_content::InputContent,
+) -> io::Result<()> {
+    if content.size < SBI_HEADER.len() as u64
+        || !(content.size - SBI_HEADER.len() as u64).is_multiple_of(SBI_RECORD_SIZE)
+    {
+        return Err(invalid_sbi(
+            source,
+            "size does not contain complete 14-byte records",
+        ));
+    }
+
+    let mut reader = content.handle.open()?;
+    let mut header = [0; SBI_HEADER.len()];
+    read_exact_at(reader.as_mut(), 0, &mut header)
+        .map_err(|_| invalid_sbi(source, "ended before its declared size"))?;
+    if &header != SBI_HEADER {
+        return Err(invalid_sbi(source, "has an invalid header"));
+    }
+    let mut offset = SBI_HEADER.len() as u64;
+    let mut record = [0; SBI_RECORD_SIZE as usize];
+    while offset < content.size {
+        read_exact_at(reader.as_mut(), offset, &mut record)
+            .map_err(|_| invalid_sbi(source, "ended before its declared size"))?;
+        if !record[..3].iter().copied().all(valid_packed_bcd) {
+            return Err(invalid_sbi(source, "contains an invalid BCD position"));
+        }
+        if record[3] != 1 {
+            return Err(invalid_sbi(source, "contains a non-Q subchannel record"));
+        }
+        offset += SBI_RECORD_SIZE;
+    }
+    Ok(())
+}
+
+fn read_exact_at(
+    reader: &mut dyn crate::core::reader::Reader,
+    offset: u64,
+    buffer: &mut [u8],
+) -> io::Result<()> {
+    let mut read = 0;
+    while read < buffer.len() {
+        let count = reader.read_at(offset + read as u64, &mut buffer[read..])?;
+        if count == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "reader ended before requested bytes",
+            ));
+        }
+        read += count;
+    }
+    Ok(())
+}
+
+fn valid_packed_bcd(value: u8) -> bool {
+    value >> 4 <= 9 && value & 0x0f <= 9
+}
+
+fn invalid_sbi(source: &SourceRef, message: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("SBI sidecar '{source}' {message}"),
+    )
+}

--- a/src/output/cue_bin_encoder.rs
+++ b/src/output/cue_bin_encoder.rs
@@ -85,7 +85,7 @@ impl OutputEncoder for CueBinEncoder {
         }
 
         let mut cue = String::new();
-        let mut members = Vec::with_capacity(disc.tracks.len() + 1);
+        let mut members = Vec::with_capacity(disc.tracks.len() + 2);
         for track in &disc.tracks {
             validate_track(track)?;
             let bin_name = format!("{artifact_name} (Track {:02}).bin", track.number);
@@ -131,6 +131,15 @@ impl OutputEncoder for CueBinEncoder {
                 MaterializedArtifact::Inline(cue.into_bytes()),
             ),
         );
+        if let Some(sbi) = &disc.sbi {
+            members.push(MaterializedNamedArtifact::new(
+                format!("{artifact_name}.sbi"),
+                MaterializedArtifact::ReaderBacked {
+                    handle: sbi.content.clone(),
+                    size: sbi.size,
+                },
+            ));
+        }
         Ok(members)
     }
 }

--- a/tests/ps1_duckstation_integration.rs
+++ b/tests/ps1_duckstation_integration.rs
@@ -151,18 +151,26 @@ fn presents_stored_zip_cue_bin_through_the_same_duckstation_path() {
 
 #[test]
 fn rejects_ambiguous_case_insensitive_sbi_sidecars() {
-    let directory = tempfile::tempdir().unwrap();
-    let cue_path = directory.path().join("Game.cue");
-    fs::write(
-        &cue_path,
-        "FILE \"Game.bin\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n",
-    )
-    .unwrap();
-    fs::write(directory.path().join("Game.bin"), mode1_sector(0x32)).unwrap();
-    fs::write(directory.path().join("Game.sbi"), sbi_fixture(0x41)).unwrap();
-    fs::write(directory.path().join("game.SBI"), sbi_fixture(0x42)).unwrap();
+    let archive = tempfile::NamedTempFile::new().unwrap();
+    {
+        let mut zip = zip::ZipWriter::new(archive.reopen().unwrap());
+        let stored =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("Game.cue", stored).unwrap();
+        zip.write_all(b"FILE \"Game.bin\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n")
+            .unwrap();
+        zip.start_file("Game.bin", stored).unwrap();
+        zip.write_all(&mode1_sector(0x32)).unwrap();
+        zip.start_file("Game.sbi", stored).unwrap();
+        zip.write_all(&sbi_fixture(0x41)).unwrap();
+        zip.start_file("game.SBI", stored).unwrap();
+        zip.write_all(&sbi_fixture(0x42)).unwrap();
+        zip.finish().unwrap();
+    }
+    let zip_path = archive.path().with_extension("zip");
+    fs::copy(archive.path(), &zip_path).unwrap();
 
-    let error = prepare_mount_session(&cue_path, "duckstation").unwrap_err();
+    let error = prepare_mount_session(&zip_path, "duckstation").unwrap_err();
 
     assert!(error.to_string().contains("multiple matching SBI"));
 }

--- a/tests/ps1_duckstation_integration.rs
+++ b/tests/ps1_duckstation_integration.rs
@@ -17,6 +17,13 @@ fn mode1_sector(fill: u8) -> Vec<u8> {
     sector
 }
 
+fn sbi_fixture(fill: u8) -> Vec<u8> {
+    let mut sbi = b"SBI\0".to_vec();
+    sbi.extend_from_slice(&[0x00, 0x02, 0x00, 0x01]);
+    sbi.extend_from_slice(&[fill; 10]);
+    sbi
+}
+
 fn read_file(session: &retromount::mount::session::MountSession, inode: u64) -> Vec<u8> {
     let file = session.file(inode).expect("mounted file");
     let mut reader = open_vfs_file(file).unwrap();
@@ -58,6 +65,8 @@ fn presents_mixed_mode_ps1_as_generated_cue_and_live_track_bins() {
     source.extend_from_slice(&file_backed_pregap);
     source.extend_from_slice(&audio);
     fs::write(directory.path().join("Game.bin"), source).unwrap();
+    let sbi_bytes = sbi_fixture(0x64);
+    fs::write(directory.path().join("Game.sbi"), &sbi_bytes).unwrap();
 
     let session = prepare_mount_session(&cue_path, "duckstation").unwrap();
     let ps1 = session
@@ -75,11 +84,15 @@ fn presents_mixed_mode_ps1_as_generated_cue_and_live_track_bins() {
     let track2 = session
         .lookup_child(game.inode, "Game (Disc 1) (Track 02).bin")
         .expect("audio track BIN");
+    let sbi = session
+        .lookup_child(game.inode, "Game (Disc 1).sbi")
+        .expect("renamed SBI sidecar");
 
     assert_eq!(read_file(&session, track1.inode), data);
     let mut expected_track2 = file_backed_pregap;
     expected_track2.extend_from_slice(&audio);
     assert_eq!(read_file(&session, track2.inode), expected_track2);
+    assert_eq!(read_file(&session, sbi.inode), sbi_bytes);
     assert_eq!(
         String::from_utf8(read_file(&session, cue.inode)).unwrap(),
         concat!(
@@ -99,6 +112,7 @@ fn presents_mixed_mode_ps1_as_generated_cue_and_live_track_bins() {
 fn presents_stored_zip_cue_bin_through_the_same_duckstation_path() {
     let archive = tempfile::NamedTempFile::new().unwrap();
     let sector = mode1_sector(0x67);
+    let sbi_bytes = sbi_fixture(0x76);
     {
         let mut zip = zip::ZipWriter::new(archive.reopen().unwrap());
         let stored =
@@ -110,6 +124,8 @@ fn presents_stored_zip_cue_bin_through_the_same_duckstation_path() {
         .unwrap();
         zip.start_file("Zip Game.bin", stored).unwrap();
         zip.write_all(&sector).unwrap();
+        zip.start_file("Zip Game.sbi", stored).unwrap();
+        zip.write_all(&sbi_bytes).unwrap();
         zip.finish().unwrap();
     }
     let zip_path = archive.path().with_extension("zip");
@@ -125,8 +141,47 @@ fn presents_stored_zip_cue_bin_through_the_same_duckstation_path() {
     let track = session
         .lookup_child(game.inode, "Zip Game (Disc 1) (Track 01).bin")
         .expect("stored ZIP track BIN");
+    let sbi = session
+        .lookup_child(game.inode, "Zip Game (Disc 1).sbi")
+        .expect("stored ZIP SBI");
 
     assert_eq!(read_file(&session, track.inode), sector);
+    assert_eq!(read_file(&session, sbi.inode), sbi_bytes);
+}
+
+#[test]
+fn rejects_ambiguous_case_insensitive_sbi_sidecars() {
+    let directory = tempfile::tempdir().unwrap();
+    let cue_path = directory.path().join("Game.cue");
+    fs::write(
+        &cue_path,
+        "FILE \"Game.bin\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n",
+    )
+    .unwrap();
+    fs::write(directory.path().join("Game.bin"), mode1_sector(0x32)).unwrap();
+    fs::write(directory.path().join("Game.sbi"), sbi_fixture(0x41)).unwrap();
+    fs::write(directory.path().join("game.SBI"), sbi_fixture(0x42)).unwrap();
+
+    let error = prepare_mount_session(&cue_path, "duckstation").unwrap_err();
+
+    assert!(error.to_string().contains("multiple matching SBI"));
+}
+
+#[test]
+fn rejects_malformed_sbi_sidecars() {
+    let directory = tempfile::tempdir().unwrap();
+    let cue_path = directory.path().join("Game.cue");
+    fs::write(
+        &cue_path,
+        "FILE \"Game.bin\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n",
+    )
+    .unwrap();
+    fs::write(directory.path().join("Game.bin"), mode1_sector(0x32)).unwrap();
+    fs::write(directory.path().join("Game.sbi"), b"NOT-SBI").unwrap();
+
+    let error = prepare_mount_session(&cue_path, "duckstation").unwrap_err();
+
+    assert!(error.to_string().contains("SBI sidecar"));
 }
 
 #[test]
@@ -134,6 +189,8 @@ fn presents_a_mixed_mode_ps1_chd_through_the_duckstation_cue_bin_view() {
     let directory = tempfile::tempdir().unwrap();
     let chd_path = directory.path().join("CHD Game.chd");
     fs::write(&chd_path, cd_chd_fixture(false)).unwrap();
+    let sbi_bytes = sbi_fixture(0x58);
+    fs::write(directory.path().join("CHD Game.sbi"), &sbi_bytes).unwrap();
 
     let session = prepare_mount_session(&chd_path, "duckstation").unwrap();
     let ps1 = session
@@ -148,6 +205,9 @@ fn presents_a_mixed_mode_ps1_chd_through_the_duckstation_cue_bin_view() {
     let track2 = session
         .lookup_child(game.inode, "CHD Game (Disc 1) (Track 02).bin")
         .expect("CHD audio track");
+    let sbi = session
+        .lookup_child(game.inode, "CHD Game (Disc 1).sbi")
+        .expect("CHD-adjacent SBI");
 
     assert_eq!(
         read_file(&session, track1.inode),
@@ -157,6 +217,7 @@ fn presents_a_mixed_mode_ps1_chd_through_the_duckstation_cue_bin_view() {
         read_file(&session, track2.inode),
         expected_chd_track_bytes(4, 4)
     );
+    assert_eq!(read_file(&session, sbi.inode), sbi_bytes);
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- discover same-stem SBI sidecars for CUE and CHD disc inputs
- validate the `SBI\0` header, complete 14-byte records, BCD positions, and type-1 SubQ records
- retain SBI as live disc-level auxiliary content and suppress the consumed source
- emit the SBI beside the generated DuckStation CUE with the generated disc basename
- support filesystem and stored-ZIP inputs
- reject malformed and ambiguous case-insensitive matches
- update the PS1 roadmap and presentation contract to mark PS1-3 implemented

## Why

PAL PlayStation titles using LibCrypt need replacement SubQ information. DuckStation discovers SBI files only when they are adjacent to the disc image and share its basename, so Retromount must preserve the sidecar as part of the same atomic artifact set.

## Validation

- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `markdownlint-cli2 'README.md' 'docs/**/*.md'`
- Windows CI portability fix validated with ZIP-based case-distinct ambiguity fixture