### PR TITLE
Update sccache to 0.17.0

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -58,7 +58,7 @@ jobs:
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
         with:
           crate: sccache
-          version: "0.14.0"
+          version: "0.17.0"
           locked: false
 
       - name: Configure sccache

--- a/.github/workflows/package-linux.yml
+++ b/.github/workflows/package-linux.yml
@@ -49,7 +49,7 @@ jobs:
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
         with:
           crate: sccache
-          version: "0.14.0"
+          version: "0.17.0"
           locked: false
 
       - name: Configure sccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,12 @@ jobs:
         with:
           shared-key: "retromount-release"
 
-      - name: Ensure sccache is installed
-        run: |
-          if ! command -v sccache >/dev/null 2>&1; then
-            cargo install sccache
-          fi
+      - name: Install sccache
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: sccache
+          version: "0.17.0"
+          locked: false
 
       - name: Configure sccache
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -73,4 +74,3 @@ jobs:
       - name: sccache stats
         if: always()
         run: sccache --show-stats
-        

--- a/.github/workflows/validate-rust.yml
+++ b/.github/workflows/validate-rust.yml
@@ -63,7 +63,7 @@ jobs:
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
         with:
           crate: sccache
-          version: "0.14.0"
+          version: "0.17.0"
           locked: false
 
       - name: Configure sccache
@@ -113,7 +113,7 @@ jobs:
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
         with:
           crate: sccache
-          version: "0.14.0"
+          version: "0.17.0"
           locked: false
 
       - name: Configure sccache


### PR DESCRIPTION
## What changed

- update every CI sccache installation from 0.14.0 to 0.17.0
- replace the release workflow's unpinned conditional `cargo install sccache` with the same pinned cargo-install action

## Why

Pinning all workflows to one current version keeps lint, validation, packaging, and release builds consistent and prevents release runners from silently using an older preinstalled binary.

## Validation

- verified all five workflow installation sites pin `0.17.0`
- confirmed no unpinned `cargo install sccache` remains
- `git diff --check`