### PR TITLE
Present multi-disc PlayStation games with M3U

### DIFF
--- a/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
+++ b/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
@@ -4,7 +4,7 @@
 
 Accepted
 
-PS1-1 through PS1-3 implemented
+PS1-1 through PS1-4 implemented
 
 ## Context
 
@@ -319,6 +319,19 @@ generated CUE and track BINs. Its output name is derived from the artifact
 basename rather than copied from the source, guaranteeing the adjacency and
 same-basename convention expected by DuckStation for both filesystem and
 stored-ZIP sources.
+
+## PS1-4 implementation note
+
+Multi-disc expansion is selected declaratively by platform, but compiled as
+one atomic game directory rather than unrelated per-disc rules. Disc numbers
+parsed by the dedicated CUE and CHD decoders feed normalization and stable
+ordering. Each part then reuses the existing CUE/BIN artifact-set encoder in a
+nested directory.
+
+The generated M3U is a sibling of those disc directories and references the
+planned CUE member of each set with a forward-slash relative path. The outer
+game name is conflict-resolved once before any children are planned, keeping
+the complete set coherent if another game requests the same presentation name.
 
 ## Consequences
 

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -186,7 +186,12 @@ It supports single-disc CUE/BIN and CHD input. CHD tracks are projected live
 from their interleaved sectors; CHDs containing subchannel data fail closed
 because CUE/BIN cannot preserve it. A valid same-stem SBI sibling is preserved
 live beside the generated CUE under the generated basename. The roadmap tracks
-multi-disc M3U, cooked ISO, and native CHD output separately.
+cooked ISO and native CHD output separately.
+
+Multi-disc PS1 games are allocated as one game directory containing an ordered
+CUE/BIN subdirectory for each disc and a sibling M3U playlist. Playlist entries
+use portable relative paths to the generated CUE files, so conflict-renamed
+game directories remain internally coherent.
 
 The PS1 roadmap also commits to extending the existing `opl` presentation with
 POPS support. The resulting PS2 library view will retain PS2 games below

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -249,7 +249,7 @@ the original SBI source is suppressed as consumed input.
 
 #### PS1-4: Multi-disc M3U
 
-**Status:** Planned
+**Status:** Implemented
 
 Present every disc in a normalized multi-disc PS1 game and generate an M3U
 whose relative entries reference the planned CUE or CHD artifacts.
@@ -257,6 +257,12 @@ whose relative entries reference the planned CUE or CHD artifacts.
 Acceptance requires deterministic disc ordering, atomic conflict resolution
 for the complete game artifact set, relative portable paths, and DuckStation
 validation of disc switching and game grouping.
+
+The implementation allocates one game directory before expanding its ordered
+disc parts. Each disc is a nested atomic CUE/BIN artifact set, and the sibling
+M3U references its generated CUE through a forward-slash relative path.
+Dedicated CUE and CHD decoders share the existing `(Disc N)` filename parsing
+so normalization can group and order both input formats consistently.
 
 #### PS1-5: Cooked ISO input
 
@@ -327,7 +333,7 @@ presentation.
   or naming cannot be represented.
 * PS2 and unknown CDs do not match the DuckStation rule.
 * Multi-disc support remains deferred from this first implementation.
-* PS1-4 through PS1-7 remain visible as planned work after PS1-3 merges.
+* PS1-5 through PS1-7 remain visible as planned work after PS1-4 merges.
 
 ## Milestone 5: Performance, caching, and optimization
 

--- a/presentations/duckstation.yaml
+++ b/presentations/duckstation.yaml
@@ -18,3 +18,16 @@ files:
         - lossless
         - random_access
         - multi_file
+
+  - select:
+      type: multi_disc_games_by_platform
+      platform: ps1
+    naming:
+      type: game_name
+    artifact:
+      content_type: game
+      format: cue_bin
+      required_features:
+        - lossless
+        - random_access
+        - multi_file

--- a/src/input/basic_decoder.rs
+++ b/src/input/basic_decoder.rs
@@ -166,7 +166,7 @@ fn path_without_extension(name: &str) -> String {
     }
 }
 
-fn parse_disc_info_from_name(name: &str) -> (String, u32) {
+pub(crate) fn parse_disc_info_from_name(name: &str) -> (String, u32) {
     let lower = name.to_lowercase();
 
     let patterns = ["disc", "cd", "disk", "vol"];

--- a/src/input/chd_disc_decoder.rs
+++ b/src/input/chd_disc_decoder.rs
@@ -9,6 +9,7 @@ use crate::core::input_content::InputContent;
 use crate::core::reader_cursor::ReaderCursor;
 use crate::core::reader_handle::ReaderHandle;
 use crate::core::source::SourceObject;
+use crate::input::basic_decoder::parse_disc_info_from_name;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
 use crate::input::sbi_sidecar::discover_sbi_sidecar;
@@ -449,11 +450,12 @@ impl InputDecoder for ChdDiscDecoder {
         if let Some(cd_disc) = &mut cd_disc {
             cd_disc.sbi = discover_sbi_sidecar(object)?;
         }
-        let title = std::path::Path::new(&object.name)
+        let raw_title = std::path::Path::new(&object.name)
             .file_stem()
             .and_then(|stem| stem.to_str())
             .unwrap_or(&object.name)
             .to_string();
+        let (title, disc_number) = parse_disc_info_from_name(&raw_title);
 
         let consumed_sources = cd_disc
             .as_ref()
@@ -465,7 +467,7 @@ impl InputDecoder for ChdDiscDecoder {
             id: ContentId::new(object.name.clone()),
             source: object.source.clone(),
             title,
-            disc_number: 1,
+            disc_number,
             consumed_sources,
             cd_disc,
             logical_disc,

--- a/src/input/cue_disc_decoder.rs
+++ b/src/input/cue_disc_decoder.rs
@@ -8,6 +8,7 @@ use crate::core::input_content::InputContent;
 use crate::core::reader_handle::ReaderHandle;
 use crate::core::source::{SourceObject, SourceRef};
 use crate::core::source_resolver::resolve_source_ref;
+use crate::input::basic_decoder::parse_disc_info_from_name;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
 use crate::input::sbi_sidecar::discover_sbi_sidecar;
@@ -126,11 +127,12 @@ impl InputDecoder for CueDiscDecoder {
                 "CUE/BIN disc contains mixed-mode, audio, Form 2, or multiple-track content that OPL cannot represent as a 2048-byte ISO",
             ));
         }
-        let title = Path::new(&object.name)
+        let raw_title = Path::new(&object.name)
             .file_stem()
             .and_then(|stem| stem.to_str())
             .unwrap_or(&object.name)
             .to_string();
+        let (title, disc_number) = parse_disc_info_from_name(&raw_title);
         let mut consumed_sources = unique_track_sources(&cd_disc);
         if let Some(sbi) = &cd_disc.sbi {
             consumed_sources.push(sbi.source.clone());
@@ -140,7 +142,7 @@ impl InputDecoder for CueDiscDecoder {
             id: ContentId::new(object.name.clone()),
             source: object.source.clone(),
             title,
-            disc_number: 1,
+            disc_number,
             consumed_sources,
             cd_disc: Some(cd_disc),
             logical_disc,

--- a/src/output/materialize.rs
+++ b/src/output/materialize.rs
@@ -61,7 +61,10 @@ fn collect_artifact_names_recursive(
                 names.insert(file.artifact.id.clone(), file.name.clone());
             }
             PlanEntry::ArtifactSet(set) => {
-                names.insert(set.artifact.id.clone(), set.directory_name.clone());
+                names.insert(
+                    set.artifact.id.clone(),
+                    format!("{}/{}.cue", set.directory_name, set.artifact_name),
+                );
             }
         }
     }

--- a/src/output/plugin_discovery.rs
+++ b/src/output/plugin_discovery.rs
@@ -116,7 +116,7 @@ pub fn build_registry_from_discovery(
     Ok(registry)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use std::fs;
 

--- a/src/output/plugin_runtime.rs
+++ b/src/output/plugin_runtime.rs
@@ -171,12 +171,15 @@ impl EncoderPluginClient for SubprocessEncoderPluginClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::output::plugin_protocol::ProtocolInlineFile;
+    #[cfg(unix)]
     use crate::output::plugin_protocol::{
         PluginManifest, ProtocolContentType, ProtocolEncoderCapability, ProtocolFormat,
         ENCODER_PLUGIN_PROTOCOL_V1,
     };
     use std::path::Path;
+    #[cfg(unix)]
     use tempfile::TempDir;
 
     #[cfg(unix)]

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -115,6 +115,9 @@ fn try_compile_rule(
     if rule.select == SelectSpec::MultiDiscGames {
         return try_compile_multi_disc_rule(rule, item, policy, root_names);
     }
+    if matches!(rule.select, SelectSpec::MultiDiscGamesByPlatform { .. }) {
+        return try_compile_multi_disc_cue_bin_game(rule, item, policy, root_names);
+    }
 
     let match_result = match rule.select {
         SelectSpec::Games => match_game(item),
@@ -127,6 +130,7 @@ fn try_compile_rule(
             match_single_disc_game_by_platform_and_media(item, platform, media)
         }
         SelectSpec::MultiDiscGames => unreachable!("handled above"),
+        SelectSpec::MultiDiscGamesByPlatform { .. } => unreachable!("handled above"),
         SelectSpec::SingleRomGames => match_single_rom_game(item),
         SelectSpec::Bytes => match_bytes(item),
         SelectSpec::Text => match_text(item),
@@ -181,6 +185,76 @@ fn try_compile_rule(
     );
 
     vec![PlanEntry::File(PlanFile::new(allocated_name, artifact))]
+}
+
+fn try_compile_multi_disc_cue_bin_game(
+    rule: &FileRuleSpec,
+    item: &NormalizedContent,
+    policy: &PolicySet,
+    names: &mut Vec<String>,
+) -> Vec<PlanEntry> {
+    let NormalizedContent::Game(game) = item else {
+        return Vec::new();
+    };
+    let SelectSpec::MultiDiscGamesByPlatform { platform } = rule.select else {
+        return Vec::new();
+    };
+    if game.platform != platform
+        || !is_multi_disc_game(game)
+        || rule.artifact.content_type != ContentType::Game
+        || rule.artifact.format != Some(Format::CueBin)
+    {
+        return Vec::new();
+    }
+
+    let directory_name = policy.resolve_name_conflict(&policy.naming().game_name(game), names);
+    names.push(directory_name.clone());
+
+    let mut entries = Vec::with_capacity(game.parts.len() + 1);
+    let mut child_names = Vec::new();
+    let mut references = Vec::new();
+    for disc in sorted_disc_parts(game) {
+        let Some(cd_disc) = &disc.cd_disc else {
+            return Vec::new();
+        };
+        let part_name = policy
+            .naming()
+            .part_name(game, &GamePart::Disc(disc.clone()));
+        let artifact_name = strip_known_extension(&part_name, Some(Format::CueBin));
+        let disc_directory_name = policy.resolve_name_conflict(&artifact_name, &child_names);
+        child_names.push(disc_directory_name.clone());
+        let artifact_id = ArtifactId::new(format!("game:{}:disc:{}", game.id, disc.disc_number));
+        references.push(ArtifactReference::new(artifact_id.clone()));
+
+        let mut disc_spec = rule.artifact.clone();
+        disc_spec.content_type = ContentType::Disc;
+        entries.push(PlanEntry::ArtifactSet(PlanArtifactSet::new(
+            disc_directory_name,
+            artifact_name,
+            ArtifactRequest::new(
+                artifact_id,
+                PlannedArtifactKind::ContentBacked(ContentArtifact::cd_disc(cd_disc.clone())),
+                build_requirements(&disc_spec),
+            ),
+        )));
+    }
+
+    let playlist_name = policy.naming().playlist_name(game);
+    entries.push(PlanEntry::File(PlanFile::new(
+        playlist_name,
+        ArtifactRequest::new(
+            ArtifactId::new(format!("game:{}:playlist", game.id)),
+            PlannedArtifactKind::Generated(GeneratedArtifact::Playlist(PlaylistArtifact::new(
+                references,
+            ))),
+            CapabilityRequirements::new(ContentType::Playlist).with_format(Format::M3u),
+        ),
+    )));
+
+    vec![PlanEntry::Directory(PlanDirectory::new(
+        directory_name,
+        entries,
+    ))]
 }
 
 fn try_compile_multi_disc_rule(
@@ -610,6 +684,9 @@ fn build_artifact_id(select: &SelectSpec, item: &NormalizedContent) -> ArtifactI
             ArtifactId::new(format!("game:{}", game.id))
         }
         (SelectSpec::MultiDiscGames, NormalizedContent::Game(game)) => {
+            ArtifactId::new(format!("game:{}", game.id))
+        }
+        (SelectSpec::MultiDiscGamesByPlatform { .. }, NormalizedContent::Game(game)) => {
             ArtifactId::new(format!("game:{}", game.id))
         }
         (SelectSpec::SingleRomGames, NormalizedContent::Game(game)) => {

--- a/src/output/presentation_file.rs
+++ b/src/output/presentation_file.rs
@@ -202,6 +202,9 @@ enum SerializedSelect {
         media: SerializedDiscMedia,
     },
     MultiDiscGames,
+    MultiDiscGamesByPlatform {
+        platform: SerializedPlatform,
+    },
     SingleRomGames,
     Bytes,
     Text,
@@ -223,6 +226,9 @@ impl SerializedSelect {
                 }
             }
             Self::MultiDiscGames => SelectSpec::MultiDiscGames,
+            Self::MultiDiscGamesByPlatform { platform } => SelectSpec::MultiDiscGamesByPlatform {
+                platform: platform.into(),
+            },
             Self::SingleRomGames => SelectSpec::SingleRomGames,
             Self::Bytes => SelectSpec::Bytes,
             Self::Text => SelectSpec::Text,

--- a/src/output/presentation_spec.rs
+++ b/src/output/presentation_spec.rs
@@ -76,6 +76,9 @@ pub enum SelectSpec {
     /// Match games consisting entirely of multiple disc parts.
     MultiDiscGames,
 
+    /// Match multi-disc games for a specific platform.
+    MultiDiscGamesByPlatform { platform: Platform },
+
     /// Match games with exactly one ROM part.
     SingleRomGames,
 

--- a/tests/ps1_duckstation_integration.rs
+++ b/tests/ps1_duckstation_integration.rs
@@ -193,6 +193,88 @@ fn rejects_malformed_sbi_sidecars() {
 }
 
 #[test]
+fn presents_multi_disc_ps1_as_ordered_cue_bin_sets_and_relative_m3u() {
+    let directory = tempfile::tempdir().unwrap();
+    for (disc, fill) in [(2, 0x72), (1, 0x61)] {
+        let cue_name = format!("Multi Game (Disc {disc}).cue");
+        let bin_name = format!("Multi Game (Disc {disc}).bin");
+        fs::write(
+            directory.path().join(&cue_name),
+            format!("FILE \"{bin_name}\" BINARY\n  TRACK 01 MODE1/2352\n    INDEX 01 00:00:00\n"),
+        )
+        .unwrap();
+        fs::write(directory.path().join(bin_name), mode1_sector(fill)).unwrap();
+    }
+
+    let session = prepare_mount_session(directory.path(), "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "Multi Game")
+        .expect("atomic multi-disc game directory");
+    let disc1 = session
+        .lookup_child(game.inode, "Multi Game (Disc 1)")
+        .expect("disc 1 artifact set");
+    let disc2 = session
+        .lookup_child(game.inode, "Multi Game (Disc 2)")
+        .expect("disc 2 artifact set");
+    let playlist = session
+        .lookup_child(game.inode, "Multi Game.m3u")
+        .expect("multi-disc playlist");
+    let disc1_track = session
+        .lookup_child(disc1.inode, "Multi Game (Disc 1) (Track 01).bin")
+        .expect("disc 1 track");
+    let disc2_track = session
+        .lookup_child(disc2.inode, "Multi Game (Disc 2) (Track 01).bin")
+        .expect("disc 2 track");
+
+    assert_eq!(read_file(&session, disc1_track.inode), mode1_sector(0x61));
+    assert_eq!(read_file(&session, disc2_track.inode), mode1_sector(0x72));
+    assert_eq!(
+        String::from_utf8(read_file(&session, playlist.inode)).unwrap(),
+        concat!(
+            "Multi Game (Disc 1)/Multi Game (Disc 1).cue\n",
+            "Multi Game (Disc 2)/Multi Game (Disc 2).cue\n",
+        )
+    );
+}
+
+#[test]
+fn presents_multi_disc_chds_through_the_same_relative_m3u_contract() {
+    let directory = tempfile::tempdir().unwrap();
+    fs::write(
+        directory.path().join("CHD Multi (Disc 2).chd"),
+        cd_chd_fixture(false),
+    )
+    .unwrap();
+    fs::write(
+        directory.path().join("CHD Multi (Disc 1).chd"),
+        cd_chd_fixture(false),
+    )
+    .unwrap();
+
+    let session = prepare_mount_session(directory.path(), "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "CHD Multi")
+        .expect("CHD multi-disc game");
+    let playlist = session
+        .lookup_child(game.inode, "CHD Multi.m3u")
+        .expect("CHD multi-disc playlist");
+
+    assert_eq!(
+        String::from_utf8(read_file(&session, playlist.inode)).unwrap(),
+        concat!(
+            "CHD Multi (Disc 1)/CHD Multi (Disc 1).cue\n",
+            "CHD Multi (Disc 2)/CHD Multi (Disc 2).cue\n",
+        )
+    );
+}
+
+#[test]
 fn presents_a_mixed_mode_ps1_chd_through_the_duckstation_cue_bin_view() {
     let directory = tempfile::tempdir().unwrap();
     let chd_path = directory.path().join("CHD Game.chd");


### PR DESCRIPTION
## What changed

- add a serialized DuckStation rule for multi-disc PS1 games
- allocate one atomically conflict-resolved directory for the complete game
- emit each ordered disc as a nested live CUE/BIN artifact set
- generate a sibling M3U containing portable relative paths to the generated CUE files
- share `(Disc N)` filename parsing with the dedicated CUE and CHD decoders
- cover multi-disc CUE/BIN and CHD inputs end to end
- guard Unix-only plugin test fixtures to eliminate Windows CI warnings
- mark PS1-4 implemented in the roadmap and presentation contract

## Why

DuckStation uses M3U playlists for multi-disc grouping and disc switching. Planning the complete game as one directory keeps playlist references coherent when naming conflicts are resolved and reuses the existing live CUE/BIN encoder for each disc.

## Validation

- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `markdownlint-cli2 'README.md' 'docs/**/*.md'`