### PR TITLE
Support cooked PS1 ISO input

### DIFF
--- a/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
+++ b/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
@@ -4,7 +4,7 @@
 
 Accepted
 
-PS1-1 through PS1-4 implemented
+PS1-1 through PS1-5 implemented
 
 ## Context
 
@@ -332,6 +332,21 @@ The generated M3U is a sibling of those disc directories and references the
 planned CUE member of each set with a forward-slash relative path. The outer
 game name is conflict-resolved once before any children are planned, keeping
 the complete set coherent if another game requests the same presentation name.
+
+## PS1-5 implementation note
+
+Cooked ISO input is accepted only in a composition that supplies explicit CD
+media and PS1 platform context. The ISO decoder represents its complete
+2048-byte-sector extent as one `MODE1/2048` data track with `INDEX 01` at zero.
+The original random-access reader is retained for both encoded and logical
+content, allowing the existing DuckStation CUE/BIN encoder to expose the bytes
+without manufacturing raw-sector headers or claiming absent audio, pregap, or
+subchannel information.
+
+The decoder rejects empty and partial-sector images. Filesystem and stored-ZIP
+sources use the same live reader contract. OPL continues to compose the ISO
+decoder with its own explicit or default CD/DVD media selection, so adding the
+PS1 path does not change PS2 presentation semantics.
 
 ## Consequences
 

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -182,11 +182,13 @@ The `duckstation` contract is defined by
 [ADR-013](architecture/adr-013-ps1-duckstation-presentation-contract.md).
 Unlike OPL, it consumes the complete track-aware PS1 CD and produces one
 coherent artifact set containing a generated CUE and live per-track BIN files.
-It supports single-disc CUE/BIN and CHD input. CHD tracks are projected live
-from their interleaved sectors; CHDs containing subchannel data fail closed
-because CUE/BIN cannot preserve it. A valid same-stem SBI sibling is preserved
-live beside the generated CUE under the generated basename. The roadmap tracks
-cooked ISO and native CHD output separately.
+It supports single-disc CUE/BIN, CHD, and cooked data-only ISO input. Cooked ISO
+is represented honestly as one `MODE1/2048` track; Retromount does not
+synthesize absent raw-sector headers, audio, pregaps, or subchannel data. CHD
+tracks are projected live from their interleaved sectors; CHDs containing
+subchannel data fail closed because CUE/BIN cannot preserve it. A valid
+same-stem SBI sibling is preserved live beside the generated CUE under the
+generated basename. The roadmap tracks native CHD output separately.
 
 Multi-disc PS1 games are allocated as one game directory containing an ordered
 CUE/BIN subdirectory for each disc and a sibling M3U playlist. Playlist entries

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -266,7 +266,7 @@ so normalization can group and order both input formats consistently.
 
 #### PS1-5: Cooked ISO input
 
-**Status:** Planned
+**Status:** Implemented
 
 Accept cooked ISO only for the explicit data-only PS1 subset that it can
 represent. Require PS1 platform and CD media context; do not infer completeness
@@ -275,6 +275,15 @@ from the extension or synthesize absent audio, raw-sector, or subchannel data.
 Acceptance requires byte-exact live reads, explicit rejection of incompatible
 claims, and presentation through a consumer representation that honestly
 describes the available sectors.
+
+The DuckStation composition supplies the otherwise unknowable PS1 CD context
+and decodes a cooked ISO as exactly one `MODE1/2048` data track. The source
+reader backs both the canonical logical-disc view and the encoded track view,
+so generated CUE/BIN output is byte-exact and does not synthesize raw-sector
+headers, audio, pregaps, or subchannel data. Empty images and sizes that do not
+contain whole 2048-byte sectors fail closed. Filesystem and stored-ZIP inputs
+use the same live path, while OPL retains its independently selected CD/DVD
+media behavior.
 
 #### PS1-6: Native CHD output
 
@@ -333,7 +342,7 @@ presentation.
   or naming cannot be represented.
 * PS2 and unknown CDs do not match the DuckStation rule.
 * Multi-disc support remains deferred from this first implementation.
-* PS1-5 through PS1-7 remain visible as planned work after PS1-4 merges.
+* PS1-6 and PS1-7 remain visible as planned work after PS1-5 merges.
 
 ## Milestone 5: Performance, caching, and optimization
 

--- a/src/engine/components.rs
+++ b/src/engine/components.rs
@@ -47,10 +47,13 @@ pub fn pipeline_components_with_media(
     } else {
         CueDiscDecoder::new()
     });
-    if presentation_name == "opl" {
-        decoder.register(IsoDiscDecoder::new(
-            media_hint.unwrap_or(crate::core::content::DiscMedia::Dvd),
-        ));
+    if matches!(presentation_name, "opl" | "duckstation") {
+        let default_media = if presentation_name == "duckstation" {
+            crate::core::content::DiscMedia::Cd
+        } else {
+            crate::core::content::DiscMedia::Dvd
+        };
+        decoder.register(IsoDiscDecoder::new(media_hint.unwrap_or(default_media)));
     }
     decoder.register(BasicInputDecoder::new());
 

--- a/src/input/iso_disc_decoder.rs
+++ b/src/input/iso_disc_decoder.rs
@@ -1,9 +1,11 @@
 use std::io;
 use std::path::Path;
 
+use crate::core::cd::{CdDisc, CdIndex, CdSectorFormat, CdTrack, CdTrackKind};
 use crate::core::content::{ContentId, DecodedContent, DecodedDiscContent, DiscMedia, LogicalDisc};
 use crate::core::input_content::InputContent;
 use crate::core::source::SourceObject;
+use crate::input::basic_decoder::parse_disc_info_from_name;
 use crate::input::decode::InputDecoder;
 use crate::input::identify::InputIdentity;
 
@@ -49,6 +51,40 @@ impl IsoDiscDecoder {
             content: content.handle.clone(),
         })
     }
+
+    fn cd_disc(object: &SourceObject, logical_disc: &LogicalDisc) -> io::Result<Option<CdDisc>> {
+        if logical_disc.media != DiscMedia::Cd {
+            return Ok(None);
+        }
+        if logical_disc.sector_size != ISO_SECTOR_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cooked CD ISO input requires 2048-byte sectors",
+            ));
+        }
+
+        Ok(Some(CdDisc {
+            tracks: vec![CdTrack {
+                number: 1,
+                kind: CdTrackKind::Data,
+                sector_format: CdSectorFormat::Mode1_2048,
+                sector_count: logical_disc.sector_count,
+                source: object.source.clone(),
+                source_offset: 0,
+                encoded_content: logical_disc.content.clone(),
+                logical_content: Some(logical_disc.content.clone()),
+                subchannel_content: None,
+                subchannel_format: None,
+                indexes: vec![CdIndex {
+                    number: 1,
+                    sector: 0,
+                }],
+                file_backed_pregap_sectors: 0,
+                declared_pregap_sectors: 0,
+            }],
+            sbi: None,
+        }))
+    }
 }
 
 impl InputDecoder for IsoDiscDecoder {
@@ -66,19 +102,21 @@ impl InputDecoder for IsoDiscDecoder {
         }
 
         let logical_disc = Self::logical_disc(&object.content, self.media)?;
-        let title = Path::new(&object.name)
+        let cd_disc = Self::cd_disc(object, &logical_disc)?;
+        let raw_title = Path::new(&object.name)
             .file_stem()
             .and_then(|stem| stem.to_str())
             .unwrap_or(&object.name)
             .to_string();
+        let (title, disc_number) = parse_disc_info_from_name(&raw_title);
 
         Ok(vec![DecodedContent::Disc(DecodedDiscContent {
             id: ContentId::new(object.name.clone()),
             source: object.source.clone(),
             title,
-            disc_number: 1,
+            disc_number,
             consumed_sources: Vec::new(),
-            cd_disc: None,
+            cd_disc,
             logical_disc: Some(logical_disc),
         })])
     }
@@ -155,6 +193,43 @@ mod tests {
         assert_eq!(
             disc.logical_disc.as_ref().map(|disc| disc.media),
             Some(DiscMedia::Dvd)
+        );
+        assert!(disc.cd_disc.is_none());
+    }
+
+    #[test]
+    fn decodes_cooked_cd_iso_as_one_mode1_2048_track() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        fs::write(file.path(), vec![0x5a; ISO_SECTOR_SIZE as usize * 2]).unwrap();
+        let object = object_for(file.path(), "Game (Disc 2).iso");
+
+        let decoded = IsoDiscDecoder::new(DiscMedia::Cd)
+            .decode(&object, &InputIdentity::IsoDisc)
+            .unwrap();
+        let DecodedContent::Disc(disc) = &decoded[0] else {
+            panic!("ISO should decode as a disc");
+        };
+        let cd = disc
+            .cd_disc
+            .as_ref()
+            .expect("CD hint should retain CD semantics");
+
+        assert_eq!(disc.title, "Game");
+        assert_eq!(disc.disc_number, 2);
+        assert_eq!(cd.tracks.len(), 1);
+        assert_eq!(cd.tracks[0].kind, CdTrackKind::Data);
+        assert_eq!(cd.tracks[0].sector_format, CdSectorFormat::Mode1_2048);
+        assert_eq!(cd.tracks[0].sector_count, 2);
+        assert_eq!(
+            cd.tracks[0].indexes,
+            vec![CdIndex {
+                number: 1,
+                sector: 0
+            }]
+        );
+        assert_eq!(
+            cd.tracks[0].encoded_content,
+            disc.logical_disc.as_ref().unwrap().content
         );
     }
 }

--- a/tests/ps1_duckstation_integration.rs
+++ b/tests/ps1_duckstation_integration.rs
@@ -150,6 +150,80 @@ fn presents_stored_zip_cue_bin_through_the_same_duckstation_path() {
 }
 
 #[test]
+fn presents_a_cooked_ps1_iso_as_an_honest_mode1_2048_cue_bin_set() {
+    let directory = tempfile::tempdir().unwrap();
+    let iso_path = directory.path().join("Cooked Game.iso");
+    let iso = (0..4096)
+        .map(|offset| (offset % 251) as u8)
+        .collect::<Vec<_>>();
+    fs::write(&iso_path, &iso).unwrap();
+
+    let session = prepare_mount_session(&iso_path, "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "Cooked Game")
+        .expect("cooked ISO game directory");
+    let cue = session
+        .lookup_child(game.inode, "Cooked Game (Disc 1).cue")
+        .expect("generated CUE");
+    let track = session
+        .lookup_child(game.inode, "Cooked Game (Disc 1) (Track 01).bin")
+        .expect("generated MODE1/2048 BIN");
+
+    assert_eq!(read_file(&session, track.inode), iso);
+    assert_eq!(
+        String::from_utf8(read_file(&session, cue.inode)).unwrap(),
+        concat!(
+            "FILE \"Cooked Game (Disc 1) (Track 01).bin\" BINARY\n",
+            "  TRACK 01 MODE1/2048\n",
+            "    INDEX 01 00:00:00\n",
+        )
+    );
+}
+
+#[test]
+fn presents_a_stored_zip_cooked_iso_through_the_same_live_path() {
+    let archive = tempfile::NamedTempFile::new().unwrap();
+    let iso = vec![0x5c; 4096];
+    {
+        let mut zip = zip::ZipWriter::new(archive.reopen().unwrap());
+        let stored =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("Zip ISO.iso", stored).unwrap();
+        zip.write_all(&iso).unwrap();
+        zip.finish().unwrap();
+    }
+    let zip_path = archive.path().with_extension("zip");
+    fs::copy(archive.path(), &zip_path).unwrap();
+
+    let session = prepare_mount_session(&zip_path, "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "Zip ISO")
+        .expect("stored ZIP ISO game directory");
+    let track = session
+        .lookup_child(game.inode, "Zip ISO (Disc 1) (Track 01).bin")
+        .expect("stored ZIP ISO track");
+
+    assert_eq!(read_file(&session, track.inode), iso);
+}
+
+#[test]
+fn rejects_cooked_ps1_iso_with_partial_sector_geometry() {
+    let directory = tempfile::tempdir().unwrap();
+    let iso_path = directory.path().join("Partial.iso");
+    fs::write(&iso_path, vec![0; 2049]).unwrap();
+
+    let error = prepare_mount_session(&iso_path, "duckstation").unwrap_err();
+
+    assert!(error.to_string().contains("whole 2048-byte sectors"));
+}
+
+#[test]
 fn rejects_ambiguous_case_insensitive_sbi_sidecars() {
     let archive = tempfile::NamedTempFile::new().unwrap();
     {


### PR DESCRIPTION
## Summary

- decode cooked PS1 ISO input as one canonical MODE1/2048 data track
- expose filesystem and stored-ZIP ISO bytes live through the DuckStation CUE/BIN presentation
- reject empty and partial-sector images without synthesizing absent CD information
- preserve existing OPL CD and DVD ISO behavior
- mark PS1-5 implemented in the ADR, presentation guide, and optical-media roadmap

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `git diff --check`