### PR TITLE
Add native PS1 CHD passthrough

### DIFF
--- a/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
+++ b/docs/architecture/adr-013-ps1-duckstation-presentation-contract.md
@@ -4,7 +4,7 @@
 
 Accepted
 
-PS1-1 through PS1-5 implemented
+PS1-1 through PS1-5 and PS1-6a implemented
 
 ## Context
 
@@ -217,7 +217,8 @@ milestones, not an open-ended backlog:
 | PS1-3 | SBI sidecars | Preserve source-backed SBI files and couple their basename to the presented disc |
 | PS1-4 | Multi-disc M3U | Present all discs and generate a relative M3U playlist with stable names |
 | PS1-5 | Cooked ISO input | Accept only the explicitly safe data-only subset without implying missing track or subchannel data |
-| PS1-6 | CHD output | Provide native lossless CHD only after its bounded materialization and random-access behavior is specified and measured |
+| PS1-6a | Native CHD passthrough | Preserve an existing CHD and optional SBI byte-for-byte without re-encoding |
+| PS1-6b | Materialized CHD encoding | Encode other inputs only after bounded materialization, caching, and random-access behavior are specified and measured |
 | PS1-7 | Extend OPL with POPS | Add PS1 VCD content below `POPS/` to the existing OPL library presentation |
 
 CHD input must not be represented only as a 2048-byte `LogicalDisc`; doing so
@@ -347,6 +348,25 @@ The decoder rejects empty and partial-sector images. Filesystem and stored-ZIP
 sources use the same live reader contract. OPL continues to compose the ISO
 decoder with its own explicit or default CD/DVD media selection, so adding the
 PS1 path does not change PS2 presentation semantics.
+
+## PS1-6a implementation note
+
+Native CHD presentation is source passthrough, not CHD encoding. Serialized
+presentation rules can include or exclude source formats, allowing DuckStation
+to request a CHD artifact set only when every selected disc already originates
+from CHD. Other inputs continue to request CUE/BIN.
+
+The passthrough encoder validates that every canonical track points to one CHD
+source, exposes that source byte-for-byte, and retains an optional SBI under the
+same generated basename. Multi-disc CHD games use one atomic game directory,
+per-disc CHD artifact sets, and a relative M3U referencing the native CHDs.
+Embedded subchannel data remains intact because the CHD is never projected
+through the more limited CUE/BIN representation.
+
+Encoding CUE/BIN or ISO input to CHD is PS1-6b. It is not a live transform: it
+requires a completed materialized file with known length and usable random
+access. Its temporary-storage, cancellation, concurrency, invalidation, and
+reuse contract belongs to the performance and caching milestone.
 
 ## Consequences
 

--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -181,19 +181,20 @@ safe 2048-byte logical projection are rejected by the OPL composition.
 The `duckstation` contract is defined by
 [ADR-013](architecture/adr-013-ps1-duckstation-presentation-contract.md).
 Unlike OPL, it consumes the complete track-aware PS1 CD and produces one
-coherent artifact set containing a generated CUE and live per-track BIN files.
-It supports single-disc CUE/BIN, CHD, and cooked data-only ISO input. Cooked ISO
-is represented honestly as one `MODE1/2048` track; Retromount does not
-synthesize absent raw-sector headers, audio, pregaps, or subchannel data. CHD
-tracks are projected live from their interleaved sectors; CHDs containing
-subchannel data fail closed because CUE/BIN cannot preserve it. A valid
-same-stem SBI sibling is preserved live beside the generated CUE under the
-generated basename. The roadmap tracks native CHD output separately.
+coherent artifact set containing either a native CHD or a generated CUE with
+live per-track BIN files.
+It supports single-disc CUE/BIN, CHD, and cooked data-only ISO input. Existing
+CHDs are presented byte-for-byte with an optional same-stem SBI, preserving
+embedded subchannel data without re-encoding. Cooked ISO is represented
+honestly as one `MODE1/2048` track; Retromount does not synthesize absent
+raw-sector headers, audio, pregaps, or subchannel data. CUE/BIN and ISO inputs
+continue to produce generated CUE and live track BIN files.
 
 Multi-disc PS1 games are allocated as one game directory containing an ordered
-CUE/BIN subdirectory for each disc and a sibling M3U playlist. Playlist entries
-use portable relative paths to the generated CUE files, so conflict-renamed
-game directories remain internally coherent.
+artifact set for each disc and a sibling M3U playlist. Existing CHDs remain
+native; other supported inputs produce CUE/BIN. Playlist entries use portable
+relative paths to the selected disc artifacts, so conflict-renamed game
+directories remain internally coherent.
 
 The PS1 roadmap also commits to extending the existing `opl` presentation with
 POPS support. The resulting PS2 library view will retain PS2 games below
@@ -209,3 +210,8 @@ Schema version 1 intentionally exposes only concepts supported by the current
 generic compiler. New fields and rule types should be added in response to a
 real presentation requirement, then covered by validation and compilation
 tests.
+
+Rules may constrain `source_formats` or `excluded_source_formats`. These
+filters select representations from the normalized source identity; they do
+not reinterpret or convert the source. A format cannot appear in both sets on
+one rule, and every part of a multi-part game must satisfy the selected rule.

--- a/docs/roadmap/optical-media-capabilities.md
+++ b/docs/roadmap/optical-media-capabilities.md
@@ -285,13 +285,26 @@ contain whole 2048-byte sectors fail closed. Filesystem and stored-ZIP inputs
 use the same live path, while OPL retains its independently selected CD/DVD
 media behavior.
 
-#### PS1-6: Native CHD output
+#### PS1-6a: Native CHD passthrough
 
-**Status:** Planned
+**Status:** Implemented
 
-Add lossless CHD output for DuckStation after specifying how a compression
-encoder fits a lazy, random-access VFS. The design must set bounded temporary
-storage, cancellation, cache lifetime, concurrency, and repeat-mount behavior.
+Present existing CHD input byte-for-byte rather than decoding and re-encoding
+it. Preserve an optional same-stem SBI sidecar, embedded subchannel data, and
+multi-disc M3U behavior. Serialized source-format filters select native CHD
+artifact sets while CUE/BIN and ISO inputs retain their existing representation.
+
+Acceptance requires filesystem and stored-ZIP parity, byte-exact CHD and SBI
+reads, relative native-CHD M3U entries, and no CHD encoder invocation.
+
+#### PS1-6b: Materialized CHD encoding
+
+**Status:** Deferred to Milestone 5
+
+Encode CUE/BIN or ISO input only after specifying how a compression encoder
+fits a lazy, random-access VFS. This is bounded materialization rather than a
+live transform. The design must set temporary-storage limits, cancellation,
+cache lifetime and invalidation, concurrency, and repeat-mount behavior.
 
 Acceptance requires round-trip track/layout verification, measured resource
 bounds, no untracked permanent intermediate, and useful random-read behavior
@@ -342,7 +355,7 @@ presentation.
   or naming cannot be represented.
 * PS2 and unknown CDs do not match the DuckStation rule.
 * Multi-disc support remains deferred from this first implementation.
-* PS1-6 and PS1-7 remain visible as planned work after PS1-5 merges.
+* PS1-6b and PS1-7 remain visible after PS1-6a merges.
 
 ## Milestone 5: Performance, caching, and optimization
 

--- a/presentations/duckstation.yaml
+++ b/presentations/duckstation.yaml
@@ -6,9 +6,25 @@ layout:
   path: PS1
 
 files:
+  - source_formats:
+      - chd
+    select:
+      type: single_disc_games_by_platform
+      platform: ps1
+    naming:
+      type: part_name
+    artifact:
+      content_type: disc
+      format: chd
+      required_features:
+        - lossless
+        - random_access
+
   - select:
       type: single_disc_games_by_platform
       platform: ps1
+    excluded_source_formats:
+      - chd
     naming:
       type: part_name
     artifact:
@@ -19,9 +35,25 @@ files:
         - random_access
         - multi_file
 
+  - source_formats:
+      - chd
+    select:
+      type: multi_disc_games_by_platform
+      platform: ps1
+    naming:
+      type: game_name
+    artifact:
+      content_type: game
+      format: chd
+      required_features:
+        - lossless
+        - random_access
+
   - select:
       type: multi_disc_games_by_platform
       platform: ps1
+    excluded_source_formats:
+      - chd
     naming:
       type: game_name
     artifact:

--- a/src/output/chd_passthrough_encoder.rs
+++ b/src/output/chd_passthrough_encoder.rs
@@ -1,0 +1,101 @@
+use std::io;
+
+use crate::core::source_resolver::open_source_ref;
+use crate::output::capabilities::{CapabilityFeature, ContentType, EncoderCapability, Format};
+use crate::output::encode::{
+    MaterializationContext, MaterializedArtifact, MaterializedNamedArtifact, OutputEncoder,
+};
+use crate::output::plan::{ArtifactRequest, ContentArtifact, PlannedArtifactKind};
+
+pub struct ChdPassthroughEncoder;
+
+impl ChdPassthroughEncoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ChdPassthroughEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OutputEncoder for ChdPassthroughEncoder {
+    fn plugin_id(&self) -> &str {
+        "chd-passthrough"
+    }
+
+    fn capabilities(&self) -> Vec<EncoderCapability> {
+        vec![
+            EncoderCapability::new(self.plugin_id(), "disc.chd-passthrough", ContentType::Disc)
+                .supports_format(Format::Chd)
+                .with_feature(CapabilityFeature::Lossless)
+                .with_feature(CapabilityFeature::RandomAccess)
+                .with_feature(CapabilityFeature::MultiFile),
+        ]
+    }
+
+    fn materialize(
+        &self,
+        _file_name: &str,
+        _artifact: &ArtifactRequest,
+        selected_capability_id: &str,
+        _context: &MaterializationContext,
+    ) -> Result<MaterializedArtifact, io::Error> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("capability '{selected_capability_id}' produces an artifact set"),
+        ))
+    }
+
+    fn materialize_set(
+        &self,
+        artifact_name: &str,
+        artifact: &ArtifactRequest,
+        selected_capability_id: &str,
+        _context: &MaterializationContext,
+    ) -> Result<Vec<MaterializedNamedArtifact>, io::Error> {
+        if selected_capability_id != "disc.chd-passthrough" {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unsupported capability '{selected_capability_id}'"),
+            ));
+        }
+        let PlannedArtifactKind::ContentBacked(ContentArtifact::CdDisc(disc)) = &artifact.kind
+        else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CHD passthrough requires track-aware CD content",
+            ));
+        };
+        let source = disc
+            .tracks
+            .first()
+            .map(|track| track.source.clone())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "CHD has no tracks"))?;
+        if !source.file_name().to_ascii_lowercase().ends_with(".chd")
+            || disc.tracks.iter().any(|track| track.source != source)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CHD passthrough requires every track to originate from one CHD source",
+            ));
+        }
+        let size = open_source_ref(&source)?.len();
+        let mut members = vec![MaterializedNamedArtifact::new(
+            format!("{artifact_name}.chd"),
+            MaterializedArtifact::SourceBacked { source, size },
+        )];
+        if let Some(sbi) = &disc.sbi {
+            members.push(MaterializedNamedArtifact::new(
+                format!("{artifact_name}.sbi"),
+                MaterializedArtifact::ReaderBacked {
+                    handle: sbi.content.clone(),
+                    size: sbi.size,
+                },
+            ));
+        }
+        Ok(members)
+    }
+}

--- a/src/output/encoder_registry.rs
+++ b/src/output/encoder_registry.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::output::basic_encoder::BasicEncoder;
+use crate::output::chd_passthrough_encoder::ChdPassthroughEncoder;
 use crate::output::cue_bin_encoder::CueBinEncoder;
 use crate::output::encode::OutputEncoder;
 use crate::output::logical_disc_iso_encoder::LogicalDiscIsoEncoder;
@@ -53,6 +54,7 @@ impl Default for EncoderRegistry {
 pub fn default_encoder_registry() -> EncoderRegistry {
     let mut registry = EncoderRegistry::new();
     registry.register("basic", || Box::new(BasicEncoder::new()));
+    registry.register("chd-passthrough", || Box::new(ChdPassthroughEncoder::new()));
     registry.register("cue-bin", || Box::new(CueBinEncoder::new()));
     registry.register(
         "logical-disc-iso",

--- a/src/output/materialize.rs
+++ b/src/output/materialize.rs
@@ -63,7 +63,7 @@ fn collect_artifact_names_recursive(
             PlanEntry::ArtifactSet(set) => {
                 names.insert(
                     set.artifact.id.clone(),
-                    format!("{}/{}.cue", set.directory_name, set.artifact_name),
+                    format!("{}/{}", set.directory_name, set.primary_file_name()),
                 );
             }
         }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,6 @@
 pub mod basic_encoder;
 pub mod capabilities;
+pub mod chd_passthrough_encoder;
 pub mod cue_bin_encoder;
 pub mod encode;
 pub mod encoder_registry;

--- a/src/output/plan.rs
+++ b/src/output/plan.rs
@@ -31,6 +31,7 @@ pub enum PlanEntry {
 pub struct PlanArtifactSet {
     pub directory_name: String,
     pub artifact_name: String,
+    pub primary_extension: String,
     pub artifact: ArtifactRequest,
 }
 
@@ -38,13 +39,19 @@ impl PlanArtifactSet {
     pub fn new(
         directory_name: impl Into<String>,
         artifact_name: impl Into<String>,
+        primary_extension: impl Into<String>,
         artifact: ArtifactRequest,
     ) -> Self {
         Self {
             directory_name: directory_name.into(),
             artifact_name: artifact_name.into(),
+            primary_extension: primary_extension.into(),
             artifact,
         }
+    }
+
+    pub fn primary_file_name(&self) -> String {
+        format!("{}.{}", self.artifact_name, self.primary_extension)
     }
 }
 

--- a/src/output/presentation_compile.rs
+++ b/src/output/presentation_compile.rs
@@ -112,10 +112,16 @@ fn try_compile_rule(
     policy: &PolicySet,
     root_names: &mut Vec<String>,
 ) -> Vec<PlanEntry> {
+    if !matches_source_format_filters(rule, item) {
+        return Vec::new();
+    }
     if rule.select == SelectSpec::MultiDiscGames {
         return try_compile_multi_disc_rule(rule, item, policy, root_names);
     }
     if matches!(rule.select, SelectSpec::MultiDiscGamesByPlatform { .. }) {
+        if rule.artifact.format == Some(Format::Chd) && rule.source_formats.contains(&Format::Chd) {
+            return try_compile_multi_disc_chd_game(rule, item, policy, root_names);
+        }
         return try_compile_multi_disc_cue_bin_game(rule, item, policy, root_names);
     }
 
@@ -143,7 +149,9 @@ fn try_compile_rule(
     let Some(proposed_name) = build_name(&rule.naming, item, &rule.artifact, policy) else {
         return Vec::new();
     };
-    if rule.artifact.format == Some(Format::CueBin) {
+    let is_native_chd_set =
+        rule.artifact.format == Some(Format::Chd) && rule.source_formats.contains(&Format::Chd);
+    if rule.artifact.format == Some(Format::CueBin) || is_native_chd_set {
         let NormalizedContent::Game(game) = item else {
             return Vec::new();
         };
@@ -153,7 +161,11 @@ fn try_compile_rule(
         let directory_name =
             policy.resolve_name_conflict(&policy.naming().game_name(game), root_names);
         root_names.push(directory_name.clone());
-        let artifact_name = strip_known_extension(&proposed_name, Some(Format::CueBin));
+        let artifact_name = if rule.artifact.format == Some(Format::Chd) {
+            strip_known_extension(&proposed_name, Some(Format::CueBin))
+        } else {
+            strip_known_extension(&proposed_name, rule.artifact.format)
+        };
         let artifact = ArtifactRequest::new(
             build_artifact_id(&rule.select, item),
             PlannedArtifactKind::ContentBacked(ContentArtifact::cd_disc(cd_disc)),
@@ -162,6 +174,7 @@ fn try_compile_rule(
         return vec![PlanEntry::ArtifactSet(PlanArtifactSet::new(
             directory_name,
             artifact_name,
+            if is_native_chd_set { "chd" } else { "cue" },
             artifact,
         ))];
     }
@@ -185,6 +198,126 @@ fn try_compile_rule(
     );
 
     vec![PlanEntry::File(PlanFile::new(allocated_name, artifact))]
+}
+
+fn matches_source_format_filters(rule: &FileRuleSpec, item: &NormalizedContent) -> bool {
+    if rule.source_formats.is_empty() && rule.excluded_source_formats.is_empty() {
+        return true;
+    }
+
+    let NormalizedContent::Game(game) = item else {
+        return false;
+    };
+    let formats = game
+        .parts
+        .iter()
+        .map(|part| match part {
+            GamePart::Disc(disc) => source_format(&disc.source),
+            GamePart::Rom(rom) => source_format(&rom.source),
+        })
+        .collect::<Option<Vec<_>>>();
+    let Some(formats) = formats else {
+        return false;
+    };
+
+    (rule.source_formats.is_empty()
+        || formats
+            .iter()
+            .all(|format| rule.source_formats.contains(format)))
+        && formats
+            .iter()
+            .all(|format| !rule.excluded_source_formats.contains(format))
+}
+
+fn source_format(source: &SourceRef) -> Option<Format> {
+    let file_name = source.file_name();
+    let extension = std::path::Path::new(&file_name)
+        .extension()
+        .and_then(|extension| extension.to_str())?;
+
+    if extension.eq_ignore_ascii_case("chd") {
+        Some(Format::Chd)
+    } else if extension.eq_ignore_ascii_case("iso") {
+        Some(Format::Iso)
+    } else if extension.eq_ignore_ascii_case("cue") {
+        Some(Format::CueBin)
+    } else if extension.eq_ignore_ascii_case("bin") {
+        Some(Format::Bin)
+    } else if extension.eq_ignore_ascii_case("zip") {
+        Some(Format::Zip)
+    } else {
+        None
+    }
+}
+
+fn try_compile_multi_disc_chd_game(
+    rule: &FileRuleSpec,
+    item: &NormalizedContent,
+    policy: &PolicySet,
+    names: &mut Vec<String>,
+) -> Vec<PlanEntry> {
+    let NormalizedContent::Game(game) = item else {
+        return Vec::new();
+    };
+    let SelectSpec::MultiDiscGamesByPlatform { platform } = rule.select else {
+        return Vec::new();
+    };
+    if game.platform != platform
+        || !is_multi_disc_game(game)
+        || rule.artifact.content_type != ContentType::Game
+        || rule.artifact.format != Some(Format::Chd)
+    {
+        return Vec::new();
+    }
+
+    let directory_name = policy.resolve_name_conflict(&policy.naming().game_name(game), names);
+    names.push(directory_name.clone());
+    let mut entries = Vec::with_capacity(game.parts.len() + 1);
+    let mut child_names = Vec::new();
+    let mut references = Vec::new();
+
+    for disc in sorted_disc_parts(game) {
+        let part_name = policy
+            .naming()
+            .part_name(game, &GamePart::Disc(disc.clone()));
+        let artifact_name = strip_known_extension(&part_name, Some(Format::CueBin));
+        let disc_directory_name = policy.resolve_name_conflict(&artifact_name, &child_names);
+        child_names.push(disc_directory_name.clone());
+        let artifact_id = ArtifactId::new(format!("game:{}:disc:{}", game.id, disc.disc_number));
+        references.push(ArtifactReference::new(artifact_id.clone()));
+        let Some(cd_disc) = &disc.cd_disc else {
+            return Vec::new();
+        };
+
+        let mut disc_spec = rule.artifact.clone();
+        disc_spec.content_type = ContentType::Disc;
+        entries.push(PlanEntry::ArtifactSet(PlanArtifactSet::new(
+            disc_directory_name,
+            artifact_name,
+            "chd",
+            ArtifactRequest::new(
+                artifact_id,
+                PlannedArtifactKind::ContentBacked(ContentArtifact::cd_disc(cd_disc.clone())),
+                build_requirements(&disc_spec),
+            ),
+        )));
+    }
+
+    entries.push(PlanEntry::File(PlanFile::new(
+        policy.naming().playlist_name(game),
+        ArtifactRequest::new(
+            ArtifactId::new(format!("game:{}:playlist", game.id)),
+            PlannedArtifactKind::Generated(GeneratedArtifact::Playlist(PlaylistArtifact::new(
+                references,
+            ))),
+            CapabilityRequirements::new(ContentType::Playlist).with_format(Format::M3u),
+        ),
+    )));
+
+    vec![PlanEntry::Directory(PlanDirectory::new(
+        directory_name,
+        entries,
+    ))]
 }
 
 fn try_compile_multi_disc_cue_bin_game(
@@ -231,6 +364,7 @@ fn try_compile_multi_disc_cue_bin_game(
         entries.push(PlanEntry::ArtifactSet(PlanArtifactSet::new(
             disc_directory_name,
             artifact_name,
+            "cue",
             ArtifactRequest::new(
                 artifact_id,
                 PlannedArtifactKind::ContentBacked(ContentArtifact::cd_disc(cd_disc.clone())),

--- a/src/output/presentation_file.rs
+++ b/src/output/presentation_file.rs
@@ -133,6 +133,10 @@ impl TryFrom<SerializedLayout> for LayoutSpec {
 struct SerializedFileRule {
     #[serde(default)]
     directory: Option<String>,
+    #[serde(default)]
+    source_formats: BTreeSet<SerializedFormat>,
+    #[serde(default)]
+    excluded_source_formats: BTreeSet<SerializedFormat>,
     select: SerializedSelect,
     naming: SerializedNaming,
     artifact: SerializedArtifact,
@@ -146,12 +150,34 @@ impl SerializedFileRule {
             .transpose()?
             .unwrap_or_default();
 
+        if let Some(format) = self
+            .source_formats
+            .intersection(&self.excluded_source_formats)
+            .next()
+        {
+            return Err(format!(
+                "source format {format:?} cannot be both included and excluded"
+            ));
+        }
+        let source_formats = self
+            .source_formats
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<_>>();
+        let excluded_source_formats = self
+            .excluded_source_formats
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<_>>();
+
         Ok(FileRuleSpec::new(
             self.select.into_select(),
             self.naming.into_naming()?,
             self.artifact.into_artifact()?,
         )
-        .in_directory(directory))
+        .in_directory(directory)
+        .with_source_formats(source_formats)
+        .excluding_source_formats(excluded_source_formats))
     }
 }
 
@@ -362,7 +388,7 @@ impl From<SerializedContentType> for ContentType {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 enum SerializedFormat {
     Iso,
@@ -512,6 +538,32 @@ files: []
             .unwrap_err()
             .to_string()
             .contains("both required and forbidden"));
+    }
+
+    #[test]
+    fn parses_and_validates_source_format_filters() {
+        let filtered = VALID.replace(
+            "    select:",
+            "    source_formats: [chd]\n    excluded_source_formats: [iso]\n    select:",
+        );
+        let document = parse_presentation_yaml(&filtered).unwrap();
+        assert_eq!(
+            document.spec.files[0].source_formats,
+            BTreeSet::from([Format::Chd])
+        );
+        assert_eq!(
+            document.spec.files[0].excluded_source_formats,
+            BTreeSet::from([Format::Iso])
+        );
+
+        let conflicting = filtered.replace(
+            "excluded_source_formats: [iso]",
+            "excluded_source_formats: [chd]",
+        );
+        assert!(parse_presentation_yaml(&conflicting)
+            .unwrap_err()
+            .to_string()
+            .contains("both included and excluded"));
     }
 
     #[test]

--- a/src/output/presentation_spec.rs
+++ b/src/output/presentation_spec.rs
@@ -32,6 +32,8 @@ pub enum LayoutSpec {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileRuleSpec {
     pub directory: Vec<String>,
+    pub source_formats: BTreeSet<Format>,
+    pub excluded_source_formats: BTreeSet<Format>,
     pub select: SelectSpec,
     pub naming: NamingSpec,
     pub artifact: ArtifactSpec,
@@ -41,10 +43,22 @@ impl FileRuleSpec {
     pub fn new(select: SelectSpec, naming: NamingSpec, artifact: ArtifactSpec) -> Self {
         Self {
             directory: Vec::new(),
+            source_formats: BTreeSet::new(),
+            excluded_source_formats: BTreeSet::new(),
             select,
             naming,
             artifact,
         }
+    }
+
+    pub fn with_source_formats(mut self, formats: impl IntoIterator<Item = Format>) -> Self {
+        self.source_formats = formats.into_iter().collect();
+        self
+    }
+
+    pub fn excluding_source_formats(mut self, formats: impl IntoIterator<Item = Format>) -> Self {
+        self.excluded_source_formats = formats.into_iter().collect();
+        self
     }
 
     pub fn in_directory(mut self, directory: impl IntoIterator<Item = impl Into<String>>) -> Self {

--- a/tests/ps1_duckstation_integration.rs
+++ b/tests/ps1_duckstation_integration.rs
@@ -342,17 +342,18 @@ fn presents_multi_disc_chds_through_the_same_relative_m3u_contract() {
     assert_eq!(
         String::from_utf8(read_file(&session, playlist.inode)).unwrap(),
         concat!(
-            "CHD Multi (Disc 1)/CHD Multi (Disc 1).cue\n",
-            "CHD Multi (Disc 2)/CHD Multi (Disc 2).cue\n",
+            "CHD Multi (Disc 1)/CHD Multi (Disc 1).chd\n",
+            "CHD Multi (Disc 2)/CHD Multi (Disc 2).chd\n",
         )
     );
 }
 
 #[test]
-fn presents_a_mixed_mode_ps1_chd_through_the_duckstation_cue_bin_view() {
+fn presents_a_ps1_chd_and_sbi_byte_exactly_without_reencoding() {
     let directory = tempfile::tempdir().unwrap();
     let chd_path = directory.path().join("CHD Game.chd");
-    fs::write(&chd_path, cd_chd_fixture(false)).unwrap();
+    let chd_bytes = cd_chd_fixture(false);
+    fs::write(&chd_path, &chd_bytes).unwrap();
     let sbi_bytes = sbi_fixture(0x58);
     fs::write(directory.path().join("CHD Game.sbi"), &sbi_bytes).unwrap();
 
@@ -363,36 +364,72 @@ fn presents_a_mixed_mode_ps1_chd_through_the_duckstation_cue_bin_view() {
     let game = session
         .lookup_child(ps1.inode, "CHD Game")
         .expect("CHD game directory");
-    let track1 = session
-        .lookup_child(game.inode, "CHD Game (Disc 1) (Track 01).bin")
-        .expect("CHD data track");
-    let track2 = session
-        .lookup_child(game.inode, "CHD Game (Disc 1) (Track 02).bin")
-        .expect("CHD audio track");
+    let chd = session
+        .lookup_child(game.inode, "CHD Game (Disc 1).chd")
+        .expect("native CHD");
     let sbi = session
         .lookup_child(game.inode, "CHD Game (Disc 1).sbi")
         .expect("CHD-adjacent SBI");
 
-    assert_eq!(
-        read_file(&session, track1.inode),
-        expected_chd_track_bytes(0, 4)
-    );
-    assert_eq!(
-        read_file(&session, track2.inode),
-        expected_chd_track_bytes(4, 4)
-    );
+    assert_eq!(read_file(&session, chd.inode), chd_bytes);
     assert_eq!(read_file(&session, sbi.inode), sbi_bytes);
 }
 
 #[test]
-fn rejects_chd_subchannel_data_that_cue_bin_cannot_preserve() {
+fn presents_a_stored_zip_chd_and_sbi_byte_exactly_without_reencoding() {
+    let archive = tempfile::NamedTempFile::new().unwrap();
+    let chd_bytes = cd_chd_fixture(false);
+    let sbi_bytes = sbi_fixture(0x68);
+    {
+        let mut zip = zip::ZipWriter::new(archive.reopen().unwrap());
+        let stored =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("Zip CHD.chd", stored).unwrap();
+        zip.write_all(&chd_bytes).unwrap();
+        zip.start_file("Zip CHD.sbi", stored).unwrap();
+        zip.write_all(&sbi_bytes).unwrap();
+        zip.finish().unwrap();
+    }
+    let zip_path = archive.path().with_extension("zip");
+    fs::copy(archive.path(), &zip_path).unwrap();
+
+    let session = prepare_mount_session(&zip_path, "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "Zip CHD")
+        .expect("stored ZIP CHD game");
+    let chd = session
+        .lookup_child(game.inode, "Zip CHD (Disc 1).chd")
+        .expect("stored ZIP native CHD");
+    let sbi = session
+        .lookup_child(game.inode, "Zip CHD (Disc 1).sbi")
+        .expect("stored ZIP SBI");
+
+    assert_eq!(read_file(&session, chd.inode), chd_bytes);
+    assert_eq!(read_file(&session, sbi.inode), sbi_bytes);
+}
+
+#[test]
+fn preserves_chd_subchannel_data_via_native_passthrough() {
     let directory = tempfile::tempdir().unwrap();
     let chd_path = directory.path().join("Protected.chd");
-    fs::write(&chd_path, cd_chd_fixture(true)).unwrap();
+    let chd_bytes = cd_chd_fixture(true);
+    fs::write(&chd_path, &chd_bytes).unwrap();
 
-    let error = prepare_mount_session(&chd_path, "duckstation").unwrap_err();
+    let session = prepare_mount_session(&chd_path, "duckstation").unwrap();
+    let ps1 = session
+        .lookup_child(session.root_inode(), "PS1")
+        .expect("PS1 presentation root");
+    let game = session
+        .lookup_child(ps1.inode, "Protected")
+        .expect("protected CHD game");
+    let chd = session
+        .lookup_child(game.inode, "Protected (Disc 1).chd")
+        .expect("native protected CHD");
 
-    assert!(error.to_string().contains("subchannel data"));
+    assert_eq!(read_file(&session, chd.inode), chd_bytes);
 }
 
 fn cd_chd_fixture(with_subchannel: bool) -> Vec<u8> {
@@ -448,12 +485,6 @@ fn cd_chd_fixture(with_subchannel: bool) -> Vec<u8> {
         }));
     }
     bytes
-}
-
-fn expected_chd_track_bytes(start_frame: usize, frames: usize) -> Vec<u8> {
-    (start_frame..start_frame + frames)
-        .flat_map(|frame| (0..2352).map(move |offset| chd_sector_byte(frame, offset)))
-        .collect()
 }
 
 fn chd_sector_byte(frame: usize, offset: usize) -> u8 {


### PR DESCRIPTION
## Summary

- present existing PS1 CHD sources byte-for-byte in the DuckStation view
- preserve SBI sidecars and embedded subchannel data without re-encoding
- add declarative source-format filters for presentation rules
- support native CHD artifact sets and relative multi-disc M3U references
- keep CUE/BIN and cooked ISO inputs on their existing presentation paths
- split native CHD passthrough from deferred materialized CHD encoding in the roadmap

## Test coverage

- filesystem CHD and SBI passthrough
- stored-ZIP CHD and SBI passthrough
- byte-exact reads
- embedded subchannel preservation
- multi-disc CHD M3U paths
- source-format filter parsing and validation

## Notes

This implements PS1-6a only. Encoding CUE/BIN or ISO inputs to CHD remains deferred until bounded materialization, caching, cancellation, concurrency, and random-access behaviour are specified.