### PR TITLE
chore: standardize GPL-3.0 licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🎮 RetroMount
 
 ![Rust](https://img.shields.io/badge/Rust-1.70%2B-orange)
-![License](https://img.shields.io/badge/license-GPL--3.0-blue)
+[![License](https://img.shields.io/github/license/lloydsmart/retromount)](LICENSE)
 
 > A virtual filesystem for retro game collections that can be mounted and transformed on-the-fly without duplicating files.
 
@@ -313,4 +313,4 @@ Output-specific filtering will be implemented in the **view/output layer** in a 
 
 ## License
 
-[GPL-3.0](LICENSE)
+This project is licensed under the [GNU General Public License v3.0 only](LICENSE).


### PR DESCRIPTION
## What changed

- Keep the canonical GNU GPL v3.0 license text in `LICENSE`.
- Align the README badge and license section with the shared repository format.

## Why

The three related projects used inconsistent license types, filenames, presentation, and metadata. The extensionless canonical file is both detected correctly by GitHub and outside Markdown linting scope.

## Validation

- `markdownlint-cli2 v0.23.2`: 0 issues
- `cargo metadata --no-deps --format-version 1`
- GitHub license API: `GPL-3.0`
- Commit verified with GPG key `1534542E61DC82D3`